### PR TITLE
fix: guard K-tail loads in Blackwell gather GEMM

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
@@ -1915,7 +1915,12 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                         a_predicate_slice = cute.make_rmem_tensor(
                             cute.make_layout((1,)), cutlass.Boolean
                         )
-                        a_predicate_slice[0] = a_predicate_tensor[i]
+                        # Row validity does not guard a partial final K tile.
+                        a_predicate_slice[0] = a_predicate_tensor[i] & (
+                            a_producer_state.count * self.cta_tile_shape_mnk[2]
+                            + A_gmem_thread_offset
+                            < cute.size(mA_mkl, mode=[1])
+                        )
 
                         cute.copy_atom_call(
                             a_atom_copy, tAgA_slice, tAsA_slice, pred=a_predicate_slice
@@ -1946,11 +1951,19 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                             tAsSFA_slice_ptr, cute.make_layout((4,))
                         )
 
+                        sfa_tail_predicate = cute.make_rmem_tensor(
+                            cute.make_layout((1,)), cutlass.Boolean
+                        )
+                        sfa_tail_predicate[0] = sfa_predicate_tensor[0] & (
+                            a_producer_state.count * self.cta_tile_shape_mnk_sfa[2]
+                            + 4 * swizzled_iterator
+                            < cute.size(mSFA_mkl, mode=[1])
+                        )
                         cute.copy_atom_call(
                             sfa_atom_copy,
                             tAgSFA_slice,
                             tAsSFA_slice,
-                            pred=sfa_predicate_tensor,
+                            pred=sfa_tail_predicate,
                         )
 
                     a_pipeline.producer_commit(a_producer_state)

--- a/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
@@ -1760,9 +1760,6 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                 cute.make_layout((1,)),
                 cutlass.Boolean,
             )
-            sfa_tail_predicate = cute.make_rmem_tensor(
-                cute.make_layout((1,)), cutlass.Boolean
-            )
             #
             # Persistent tile scheduling loop
             #
@@ -1954,6 +1951,9 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                             tAsSFA_slice_ptr, cute.make_layout((4,))
                         )
 
+                        sfa_tail_predicate = cute.make_rmem_tensor(
+                            cute.make_layout((1,)), cutlass.Boolean
+                        )
                         sfa_tail_predicate[0] = sfa_predicate_tensor[0] & (
                             a_producer_state.count * self.cta_tile_shape_mnk_sfa[2]
                             + 4 * swizzled_iterator

--- a/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
@@ -1760,6 +1760,9 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                 cute.make_layout((1,)),
                 cutlass.Boolean,
             )
+            sfa_tail_predicate = cute.make_rmem_tensor(
+                cute.make_layout((1,)), cutlass.Boolean
+            )
             #
             # Persistent tile scheduling loop
             #
@@ -1951,9 +1954,6 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                             tAsSFA_slice_ptr, cute.make_layout((4,))
                         )
 
-                        sfa_tail_predicate = cute.make_rmem_tensor(
-                            cute.make_layout((1,)), cutlass.Boolean
-                        )
                         sfa_tail_predicate[0] = sfa_predicate_tensor[0] & (
                             a_producer_state.count * self.cta_tile_shape_mnk_sfa[2]
                             + 4 * swizzled_iterator

--- a/tests/moe/test_cute_dsl_gather_k_tail.py
+++ b/tests/moe/test_cute_dsl_gather_k_tail.py
@@ -1,0 +1,87 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Regression coverage for partial K tiles in Blackwell gather GEMM1."""
+
+import pytest
+import torch
+
+from flashinfer.cute_dsl import is_cute_dsl_available
+from flashinfer.utils import get_compute_capability
+
+
+@pytest.mark.skipif(not is_cute_dsl_available(), reason="CuTe DSL is not available")
+@pytest.mark.parametrize("k", [128, 256, 384, 512])
+@pytest.mark.parametrize("num_tokens", [1, 17])
+@pytest.mark.parametrize("tile_m", [128, 256])
+def test_gather_gemm_k_tail(k, num_tokens, tile_m):
+    if not torch.cuda.is_available() or get_compute_capability(
+        torch.device("cuda")
+    ) not in (
+        (10, 0),
+        (10, 3),
+    ):
+        pytest.skip("Requires Blackwell SM100 or SM103")
+
+    from flashinfer.fused_moe.cute_dsl.blockscaled_contiguous_gather_grouped_gemm_act_fusion import (
+        blockscaled_contiguous_gather_grouped_gemm_act_fusion,
+    )
+
+    device = "cuda"
+    n = 256
+    # Two FP4 ones per byte. An extra row keeps the old kernel's tail reads
+    # inside allocated storage, so a failure cannot poison the CUDA context.
+    a_storage = torch.full(
+        (num_tokens + 1, k // 2), 0x22, dtype=torch.uint8, device=device
+    )
+    a = a_storage[:num_tokens]
+    # E4M3 1.0 = 0x38; 0x7f is NaN. Reading the extra scale row must not
+    # contaminate the last real row, even though the weight K tail is zero.
+    scale_storage = torch.full(
+        (num_tokens + 1, k // 16), 0x7F, dtype=torch.uint8, device=device
+    )
+    a_scale = scale_storage[:num_tokens]
+    a_scale.fill_(0x38)
+    b = torch.full((1, n, k // 2), 0x22, dtype=torch.uint8, device=device)
+    b_scale = torch.full(
+        (32, 4, n // 128, 4, k // 64, 1), 0x38, dtype=torch.uint8, device=device
+    )
+    mapping = torch.full((tile_m,), -1, dtype=torch.int32, device=device)
+    mapping[:num_tokens] = torch.arange(num_tokens - 1, -1, -1, device=device)
+
+    output, _ = blockscaled_contiguous_gather_grouped_gemm_act_fusion(
+        a=a,
+        b=b,
+        a_scale=a_scale,
+        b_scale=b_scale,
+        alpha=torch.full((1,), 1.0 / k, device=device),
+        tile_idx_to_expert_idx=torch.zeros(1, dtype=torch.int32, device=device),
+        tile_idx_to_mn_limit=torch.tensor(
+            [num_tokens], dtype=torch.int32, device=device
+        ),
+        token_id_mapping=mapping,
+        num_non_exiting_tiles=torch.ones(1, dtype=torch.int32, device=device),
+        topk=1,
+        c_dtype="bfloat16",
+        mma_tiler_mn=(tile_m, 128),
+        cluster_shape_mn=(tile_m // 128, 1),
+        enable_pdl=False,
+    )
+    # Both projections are dot(ones, ones) / K = 1, hence SwiGLU = sigmoid(1).
+    expected = torch.full_like(
+        output[:num_tokens], torch.sigmoid(torch.tensor(1.0)).item()
+    )
+    torch.testing.assert_close(output[:num_tokens], expected, rtol=0, atol=0)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Fix partial K-tile handling in the Blackwell block-scaled gather GEMM used by FP4 MoE workloads. The activation and scale-factor copies currently guard rows but can read past the logical K extent on the final tile.

Add K bounds to both copy predicates. Include a synthetic regression in `tests/moe/test_cute_dsl_fused_moe.py` that poisons scale-factor storage beyond the logical input to detect tail reads without depending on allocator placement.

## 🔍 Related Issues

No linked issue.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

Installed the hooks with `pre-commit install` and ran `pre-commit run --all-files` successfully. All applicable hooks passed, including clang-format, mypy, Ruff, and the experimental test-scope selftest; no files were changed.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

Targeted validation on B300:
- Original kernel: eight partial-K cases fail; eight aligned-K controls pass.
- Corrected kernel: all 16 cases pass.
- Compute Sanitizer memcheck with allocation caching disabled: all 16 cases pass with zero errors.

The synthetic matrix covers K=128/256/384/512, 1/17 input rows, and one-/two-CTA tactics. The candidate wrapper and kernel were loaded into an existing CUDA test environment for local validation; the full upstream test suite was not run.

The regression test now lives in the existing fused MoE test module, with all 16 parameter combinations preserved. Pre-commit hooks, syntax, and diff checks passed after the move; the GPU test was not rerun because the active Python environment has no `pytest`.

Reproduce in a source-enabled environment:
```bash
pytest tests/moe/test_cute_dsl_fused_moe.py::test_gather_gemm_k_tail -q
PYTORCH_NO_CUDA_MEMORY_CACHING=1 compute-sanitizer --tool memcheck \
  --padding 32 --error-exitcode 86 python -m pytest \
  tests/moe/test_cute_dsl_fused_moe.py::test_gather_gemm_k_tail -q
```

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

Please review the activation/scale K-coordinate bounds and the synthetic tail-poisoning coverage. This is a correctness fix; no performance improvement is claimed.

Keep this PR in draft pending author approval.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed fused MoE gather GEMM operations for inputs whose K dimension does not evenly fill the final tile, preventing invalid reads during processing.

- **Tests**
  - Added coverage for K-tail handling across multiple K sizes, token counts, and tile configurations on supported Blackwell GPUs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->