### PR TITLE
fix(attention): enable DCP on SM107 and skip unsupported VSA tests

### DIFF
--- a/flashinfer/cake_dcp.py
+++ b/flashinfer/cake_dcp.py
@@ -211,12 +211,14 @@ def _is_cuda_version_at_least(version: str) -> bool:
 
 def _select_target(device: torch.device) -> str:
     capability = get_compute_capability(device)
-    if capability not in ((10, 0), (10, 3)):
+    if capability not in ((10, 0), (10, 3), (10, 7)):
         raise RuntimeError(
             "DCP speculative FMHA requires compute capability 10.0 "
-            f"(B200/GB200) or 10.3 (B300/GB300), got {capability[0]}.{capability[1]}"
+            "(B200/GB200), 10.3 (B300/GB300), or 10.7 (Rubin), "
+            f"got {capability[0]}.{capability[1]}"
         )
-    # Base and add-on sources use the same exact product architecture names.
+    # Preserve the exact SM100/SM103 targets; SM107 uses the forward-compatible
+    # family target for the shared DCP sources.
     if capability == (10, 0):
         if _is_cuda_version_at_least("12.8"):
             return "sm100a"
@@ -224,14 +226,13 @@ def _select_target(device: torch.device) -> str:
             "DCP speculative FMHA on compute capability 10.0 requires CUDA "
             "12.8 or newer"
         )
+    target = "sm103a" if capability == (10, 3) else "sm100f"
     if _is_cuda_version_at_least("12.9"):
-        return "sm103a"
-    if capability == (10, 3):
-        raise RuntimeError(
-            "DCP speculative FMHA on compute capability 10.3 requires CUDA 12.9 "
-            "or newer for the sm_103a exact target"
-        )
-    raise AssertionError(f"unreachable DCP target capability: {capability}")
+        return target
+    raise RuntimeError(
+        f"DCP speculative FMHA on compute capability {capability[0]}.{capability[1]} "
+        f"requires CUDA 12.9 or newer for the {target} target"
+    )
 
 
 def _validate_core_inputs(

--- a/flashinfer/jit/cake_dcp.py
+++ b/flashinfer/jit/cake_dcp.py
@@ -33,17 +33,25 @@ from .core import (
     gen_jit_spec,
     logger,
     sm100a_nvcc_flags,
+    sm100f_nvcc_flags,
     sm103a_nvcc_flags,
 )
 
 DcpSpecVariant = Literal["v1", "v4"]
-DcpSpecTarget = Literal["sm100a", "sm103a"]
+DcpSpecTarget = Literal["sm100a", "sm103a", "sm100f"]
 
 _DCP_SPEC_NVCC_FLAGS = {
     "sm100a": sm100a_nvcc_flags,
     "sm103a": sm103a_nvcc_flags,
+    "sm100f": sm100f_nvcc_flags,
 }
-_TARGET_MANIFEST_ARCH = {"sm100a": "sm_100a", "sm103a": "sm_103a"}
+# The DCP manifest shares source bodies between SM100 and SM103. Compile those
+# authenticated bodies with the family target for SM107.
+_TARGET_MANIFEST_ARCH = {
+    "sm100a": "sm_100a",
+    "sm103a": "sm_103a",
+    "sm100f": "sm_100a",
+}
 _DCP_JIT_BINDINGS = {
     "dcp_spec_bf16_v1": "jit/cake_fmha_dcp_spec_bf16_v1_jit_binding.cu",
     "dcp_spec_bf16_v4": "jit/cake_fmha_dcp_spec_bf16_v4_jit_binding.cu",

--- a/tests/attention/test_block_sparse.py
+++ b/tests/attention/test_block_sparse.py
@@ -137,6 +137,8 @@ def _run_block_sparse_attention_case(
             pytest.skip("vsa_blackwell supports SM100 and SM103, not SM107")
         if not is_sm100a_supported(torch.device(0)):
             pytest.skip("vsa_blackwell requires sm100a (Blackwell GPU)")
+        if torch.cuda.get_device_capability(0) == (10, 7):
+            pytest.skip("vsa_blackwell supports SM100/SM103, not SM107")
         if R != 128 or C != 128:
             pytest.skip("vsa_blackwell requires R == C == 128")
         if M % 128 != 0 or N % 128 != 0:

--- a/tests/attention/test_dcp_spec_jit.py
+++ b/tests/attention/test_dcp_spec_jit.py
@@ -52,7 +52,10 @@ def test_dcp_spec_uri_covers_full_parameterized_domain() -> None:
     )
 
 
-def test_dcp_jit_selects_the_route_specialized_source_family(monkeypatch) -> None:
+@pytest.mark.parametrize("target", ["sm100a", "sm103a", "sm100f"])
+def test_dcp_jit_selects_the_route_specialized_source_family(
+    monkeypatch, target
+) -> None:
     jit_dcp = importlib.import_module("flashinfer.jit.cake_dcp")
     source_dir = Path(__file__).resolve().parents[2] / "csrc" / "cake_fmha"
     monkeypatch.setattr(jit_dcp, "get_cake_fmha_csrc_dir", lambda: source_dir)
@@ -65,9 +68,16 @@ def test_dcp_jit_selects_the_route_specialized_source_family(monkeypatch) -> Non
     jit_dcp.gen_dcp_spec_fp8_module.cache_clear()
 
     try:
-        v1 = jit_dcp.gen_dcp_spec_module("v1", "sm100a", 1, 1, 64, 8, 1, 1)
-        v4 = jit_dcp.gen_dcp_spec_module("v4", "sm100a", 1, 1, 64, 8, 1, 16)
-        fp8 = jit_dcp.gen_dcp_spec_fp8_module("sm103a", 64, 3, 64, 8, 4, 3, 1)
+        v1 = jit_dcp.gen_dcp_spec_module("v1", target, 1, 1, 64, 8, 1, 1)
+        v4 = jit_dcp.gen_dcp_spec_module("v4", target, 1, 1, 64, 8, 1, 16)
+        fp8 = jit_dcp.gen_dcp_spec_fp8_module(target, 64, 3, 64, 8, 4, 3, 1)
+
+        arch = target.replace("sm", "", 1)
+        for spec in (v1, v4, fp8):
+            assert (
+                f"-gencode=arch=compute_{arch},code=sm_{arch}" in spec.extra_cuda_cflags
+            )
+            assert f"_{target}_" in spec.name
 
         assert Path(v1.sources[0]).name == "retain_kv_l21.cu"
         assert Path(v4.sources[0]).name == "num_split16.cu"
@@ -199,6 +209,7 @@ def test_dcp_split_selector_matches_promoted_policy() -> None:
     [
         ((10, 0), "sm100a"),
         ((10, 3), "sm103a"),
+        ((10, 7), "sm100f"),
     ],
 )
 def test_dcp_target_keeps_independent_architecture_baselines(


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

DCP speculative FP8 attention rejects SM107 before launch, although its existing `sm100f` target passes correctness checks on SM107. Admit compute capability 10.7 through that target, preserving SM100's `sm100a` selection, upstream's SM103 `sm103a` selection, and the CUDA 12.9 requirement for family targets. Register `sm100f` in the updated manifest-backed DCP JIT loader using its shared source bodies. Extend architecture-selection and JIT-source/compile-flag coverage for SM107.

The `vsa_blackwell` tests also reach a production guard that only admits SM100/SM103. Skip those cases on SM107 before wrapper construction, matching the backend's current support contract.

## 🔍 Related Issues

No linked public issue.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

Changed-file pre-commit checks and commit hooks passed, including mypy, Ruff, and formatting. The repository-wide `--all-files` command was not run.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

Historical validation before the rebase (commit `49f2dd1`, base `62362bb1`):

- SM107, x86_64 CUDA 13.4: `tests/attention/test_dcp_spec_fp8.py` — **12 passed, 1 skipped**; `vsa_blackwell` matrix — **5,184 skipped** with the architecture-specific reason.
- SM107, x86_64 CUDA 13.5: combined `test_block_sparse.py`, `test_cudnn_prefill_deepseek.py`, `test_cute_dsl_fmha_backend.py`, and `test_dcp_spec_fp8.py` — **3,482 passed, 7,777 skipped, zero failures**.
- Physical SM100, CUDA 13.4: focused DCP and VSA correctness controls passed.
- After rebasing onto `2b750b2e`, changed-file pre-commit checks (including mypy and Ruff) and diff-integrity checks passed. Upstream replaced the DCP JIT loader and source families, so the earlier GPU results do not validate the rebased runtime. The expanded JIT tests and GPU tests have not been rerun for this head.

Full-repository tests and ARM64 Rubin CI have not been validated for this PR.

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

The VSA skip reflects existing implementation guards; it does not establish that the kernel is intrinsically incompatible with SM107. Enabling that backend would require separate compilation, launch, and correctness evidence.

The investigation also observed cuDNN and CuTe accuracy failures in an earlier ARM64 environment. This PR makes no changes to those paths or tolerances and does not claim to resolve those failures. Available x86 tests passed, but the original causes remain unconfirmed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for NVIDIA SM107 (compute capability 10.7) devices.
  - SM107 devices can use the `sm100f` target with CUDA 12.9 or newer.
  - Added target-specific compilation support for `sm100a`, `sm103a`, and `sm100f`.
  - Improved DCP speculative attention target selection across supported SM100-family architectures.

- **Bug Fixes**
  - Updated compatibility handling so unsupported attention backends are skipped on SM107 devices instead of running incompatible tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->