### PR TITLE
fix: preserve both generated-source pre-commit exclusions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,10 +13,8 @@
 # See https://github.com/pre-commit/pre-commit
 # Note the pre-commit hooks shoule only be used for formatting, but not for linting.
 # For linting consider using CI.
-files: ^(?!flashinfer/moe_ep/kernel_src/blackwell_bf16_rank_major/src/)
-
-# cake_fmha is a manifest-authenticated export and must remain byte-exact.
-files: ^(?!csrc/cake_fmha/)
+# These manifest-authenticated generated sources must remain byte-exact.
+files: ^(?!(?:flashinfer/moe_ep/kernel_src/blackwell_bf16_rank_major/src/|csrc/cake_fmha/))
 
 # The kernel_src */src trees and blackwell_msa CUDA snapshots are generated or
 # upstream kernel drops that are re-synced periodically


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Combine the two top-level `files` filters into one negative lookahead. The second YAML key overrode the first, causing clang-format to rewrite the immutable Blackwell BF16 rank-major MoE source during `pre-commit run --all-files`.

Preserve exclusions for both `flashinfer/moe_ep/kernel_src/blackwell_bf16_rank_major/src/` and `csrc/cake_fmha/`. All other exclusions and hook settings remain unchanged; maintained adapter files stay checked. No generated sources or checksum manifests are modified.

## 🔍 Related Issues

Regression introduced when #4980 added a second `files` key after #4810. Observed in [the pre-commit run for #5111](https://github.com/flashinfer-ai/flashinfer/actions/runs/34545687841/job/103097668524?pr=5111), whose changes did not touch these files.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Validation (local configuration checks, Python 3.12):
- Reproduced the original filter failure with pre-commit’s config loader and file-selection function: both immutable MoE files were selected before the fix.
- Verified the corrected selection across all 4,555 tracked paths: both generated directories are excluded, maintained controls stay selected, no duplicate top-level keys remain, and the selection delta is exactly the restored MoE exclusion.
- `pre-commit run --all-files`: all applicable hooks passed without additional tracked-file changes. The broken-symlink hook had no files to check.
- `git diff --check`: passed.

The regression probe was run as validation evidence; no repository test file was added. GPU tests are not applicable to this configuration-only change. Public CI uses Python 3.10 and remains the cross-environment check.

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

The existing `VENDOR.md` requires the MoE generated source/manifest pair to remain immutable. Keeping both exclusions in one key restores that contract without widening the exclusion to maintained sibling files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated code-quality check configuration by consolidating existing exclusion rules.
  - Existing exclusions remain unchanged, so affected files continue to be skipped by the relevant checks.
  - No changes were made to application functionality, public APIs, or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->