### PR TITLE
fix(gemm): honor output strides in fixed-shape cuDNN BF16 GEMM

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -4529,6 +4529,7 @@ def build_cudnn_gemm_bf16_graph(
     bias_shape,
     bias_stride,
     tactic=-1,
+    c_stride=None,
 ):
     _check_cudnn_availability()
 
@@ -4565,6 +4566,8 @@ def build_cudnn_gemm_bf16_graph(
             c_final_cudnn_tensor = c_cudnn_tensor
 
         c_final_cudnn_tensor.set_name("c_final").set_output(True).set_data_type(o_type)
+        if c_stride is not None:
+            c_final_cudnn_tensor.set_stride(c_stride)
 
         a_cudnn_tensor.set_uid(UIDs.A_UID.value)
         b_cudnn_tensor.set_uid(UIDs.B_UID.value)
@@ -4809,6 +4812,7 @@ def _cudnn_gemm_bf16(
     # This allows the same graph to work for both mm (2D) and bmm (3D)
     a_shape, a_stride = _get_bf16_3d_shape_stride(a)
     b_shape, b_stride = _get_bf16_3d_shape_stride(b)
+    _, c_stride = _get_bf16_3d_shape_stride(out)
 
     if bias is not None:
         bias_shape, bias_stride = _get_3d_shape_stride_from_vector(bias, 2)
@@ -4827,6 +4831,7 @@ def _cudnn_gemm_bf16(
         bias_shape,
         bias_stride,
         tactic=tactic,
+        c_stride=c_stride,
     )
 
     execute_cudnn_gemm_bf16_graph(graph, a, b, bias, out, workspace, tactic=tactic)
@@ -4924,6 +4929,9 @@ def _cudnn_gemm_bf16_runner(
                 bias is not None,
                 self._is_a_k_major,
                 self._is_b_k_major,
+                # Fixed-shape plans bind output strides. Do not reuse a
+                # tuned tactic ordinal across different output layouts.
+                tuple(out.stride()),
             )
 
         def get_valid_tactics(
@@ -4956,6 +4964,7 @@ def _cudnn_gemm_bf16_runner(
                     bias_shape,
                     bias_stride,
                     tactic=0,
+                    c_stride=_get_bf16_3d_shape_stride(out)[1],
                 )
 
             return _cudnn_graph_engine_knob_tactics(graph)

--- a/tests/gemm/test_cudnn_bf16_output_strides.py
+++ b/tests/gemm/test_cudnn_bf16_output_strides.py
@@ -1,0 +1,73 @@
+"""Regression for fixed-shape cuDNN BF16 graphs with caller-owned strided output."""
+
+import pytest
+import torch
+
+import flashinfer
+from flashinfer.gemm import gemm_base
+
+
+@pytest.mark.parametrize("rank", [2, 3])
+def test_fixed_shape_cudnn_bf16_output_layouts_and_changed_graph(monkeypatch, rank):
+    if not torch.cuda.is_available() or not gemm_base.CUDNN_AVAILABLE:
+        pytest.skip("cuDNN CUDA execution required")
+    cc = torch.cuda.get_device_capability()
+    api = flashinfer.bmm_bf16 if rank == 3 else flashinfer.mm_bf16
+    if not api.is_backend_supported("cudnn", cc[0] * 10 + cc[1]):
+        pytest.skip("cuDNN BF16 GEMM not supported on this device")
+    # This is also the route used after an override-shape tactic falls back.
+    monkeypatch.setattr(gemm_base, "_is_cudnn_override_shape_available", lambda: False)
+    torch.manual_seed(42241 + rank)
+    groups, m, n, k = (8 if rank == 3 else 1), 2, 128, 256
+    base_a = torch.randn(m, groups, k, device="cuda", dtype=torch.bfloat16)
+    a3 = base_a.transpose(0, 1)
+    weight = torch.randn(groups, n, k, device="cuda", dtype=torch.bfloat16)
+    a, b = (a3, weight.transpose(1, 2)) if rank == 3 else (a3[0], weight[0].T)
+    # Alternate declarations at identical shape to exercise graph cache identity.
+    for layout in ("contiguous", "interleaved", "padded", "contiguous"):
+        if layout == "contiguous":
+            storage = torch.full(
+                (groups, m, n), 17, device="cuda", dtype=torch.bfloat16
+            )
+            out3 = storage
+        elif layout == "interleaved":
+            storage = torch.full(
+                (m, groups, n), 17, device="cuda", dtype=torch.bfloat16
+            )
+            out3 = storage.transpose(0, 1)
+        else:
+            storage = torch.full(
+                (groups, m, n * 2), 17, device="cuda", dtype=torch.bfloat16
+            )
+            out3 = storage[..., :n]
+        out = out3 if rank == 3 else out3[0]
+
+        def run():
+            return api(a, b, out=out, backend="cudnn")
+
+        def verify():
+            expected = torch.matmul(a.double(), b.double()).bfloat16()
+            torch.testing.assert_close(out, expected, rtol=0.01, atol=0.005)
+            if layout == "padded":
+                torch.testing.assert_close(
+                    storage[..., n:],
+                    torch.full_like(storage[..., n:], 17),
+                    rtol=0,
+                    atol=0,
+                )
+
+        run()
+        verify()
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            run()
+        torch.cuda.current_stream().wait_stream(stream)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=stream):
+            run()
+        for _ in range(2):
+            base_a.copy_(torch.randn_like(base_a))
+            weight.copy_(torch.randn_like(weight))
+            graph.replay()
+            verify()


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

BF16 MM/BMM with a caller-provided non-contiguous output could write to the wrong locations because the fixed-shape cuDNN graph assumed a contiguous output. Pass the actual output strides to graph construction and include output strides in the tactic-cache key so layouts cannot reuse an incompatible cached tactic.

This is a correctness fix discovered while connecting grouped output projections. No new kernel backend or automatic dispatch is introduced.

## 🔍 Related Issues

No existing issue. Independent of the experimental DeepSeek V4.1 kernel series.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

Validated the exact PR commit `93007f66` on NVIDIA B200 (SM100), PyTorch 2.13.0+cu130, cuDNN backend 9.26.0, with **2 passed**:

```bash
pytest tests/gemm/test_cudnn_bf16_output_strides.py -q
```

Coverage includes MM/BMM, interleaved/padded/contiguous outputs, alternating output-layout cache entries, and changing inputs/weights under CUDA graph replay. Full CI has not been requested; this PR is draft. Review the cache-key boundary alongside the graph descriptor change.

## Takeover review notes (open items, not yet addressed)

This fix is correct in direction (cudnn-frontend defaults an unset output stride to packed row-major, so a transposed or padded `out` was written to the wrong addresses). Three items remain before it is ready for review:

1. `get_cache_key_extras` now includes the raw `tuple(out.stride())`. The autotuner contract requires extras to be synthesis-invariant, but `out` is a `ConstraintSpec` tensor that profiling synthesizes as contiguous at the bucketed M. For `bmm_bf16` a contiguous 3-D `out` has `stride(0) = M*N`, so the profile-time key and the runtime key differ whenever M != bucket and the tuned tactic is never reused (silent fallback to tactic -1). Needs verification and a normalized layout descriptor instead of raw strides.
2. The override-shape path (`build_cudnn_gemm_bf16_graph_override_shape`, the default on recent cuDNN) still assumes a contiguous output; the new test disables override-shape via monkeypatch, so CI cannot see it.
3. Overlaps with #4674 in `_cudnn_gemm_bf16` and the runner cache key; rebase once one of them lands.

<!-- note to self: claude::b05c9b4c-3682-4094-9513-413b613fa1ff — "DS4.1 frost PR batch takeover review" · cwd /home/scratch.yanxu_libs/flashinfer · workspace /home/scratch.yanxu_libs/cudnn_frontend/.ds41-work -->
