### PR TITLE
feat(cake_comm): support SM100 and SM103 TP8 packed-QKV all-gather matmul

### DIFF
--- a/csrc/cake_all_gather_matmul/sm100a/cake_all_gather_matmul_kernels.cu
+++ b/csrc/cake_all_gather_matmul/sm100a/cake_all_gather_matmul_kernels.cu
@@ -20,11 +20,13 @@
 #include <stdint.h>
 
 // Pointer-ABI TMA descriptors are encoded by the CUDA driver and stored in
-// device memory. Keep the generated kernel pointee self-contained and
+// device memory.  Keep the generated kernel pointee self-contained and
 // layout-identical to the compiler's opaque 128-byte descriptor type.
 struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+#include <stdint.h>
 #include <cuda.h>
 #include <cuda_bf16.h>
+#include <cuda_fp8.h>
 
 #include <math_constants.h>
 
@@ -44,6 +46,11 @@ __device__ __forceinline__ uint32_t elect_sync() {
 __device__ __forceinline__ void mbarrier_init(int mbar_addr, int count) {
     asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;"
         :: "r"(mbar_addr), "r"(count) : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_init_generic(void* mbar_addr, int count) {
+    asm volatile("mbarrier.init.b64 [%0], %1;"
+        :: "l"(mbar_addr), "r"(count));
 }
 
 __device__ __forceinline__ uint32_t mbarrier_try_wait(int mbar_addr, int phase) {
@@ -74,37 +81,105 @@ __device__ __forceinline__ uint32_t mbarrier_try_wait_cluster(int mbar_addr, int
     return token;
 }
 
-// CTA-local pipelines have short, resident producer/consumer edges.  Omitting
-// suspendTimeHint keeps a miss on the lightweight TRYWAIT retry path; the
-// explicit loop still makes this helper blocking until acquire succeeds.
+// Match CUTLASS ClusterBarrier::wait: a large suspendTimeHint lets the hardware
+// take the blocking phase-check slowpath instead of spinning on TRYWAIT misses.
 
 __device__ __forceinline__ void mbarrier_wait(int mbar_addr, int phase) {
+    uint32_t ticks = 0x989680;
     asm volatile(
         "{\n\t"
         ".reg .pred P1;\n\t"
         "LAB_WAIT:\n\t"
         "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64"
-        " P1, [%0], %1;\n\t"
+        " P1, [%0], %1, %2;\n\t"
         "@P1 bra.uni DONE;\n\t"
         "bra.uni LAB_WAIT;\n\t"
         "DONE:\n\t"
         "}\n"
-        :: "r"(mbar_addr), "r"(phase) : "memory");
+        :: "r"(mbar_addr), "r"(phase), "r"(ticks) : "memory");
+}
+
+// Exact source ports may request the PTX suspendTimeHint operand explicitly.
+// The hint is expressed in nanoseconds and is kept separate from the canonical
+// no-hint CTA helper so unrelated schedules retain their existing retry path.
+
+__device__ __forceinline__ void mbarrier_wait_suspend(
+        int mbar_addr, int phase, uint32_t suspend_time_hint) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "LAB_WAIT_SUSPEND:\n\t"
+        "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64"
+        " P1, [%0], %1, %2;\n\t"
+        "@P1 bra.uni DONE_SUSPEND;\n\t"
+        "bra.uni LAB_WAIT_SUSPEND;\n\t"
+        "DONE_SUSPEND:\n\t"
+        "}\n"
+        :: "r"(mbar_addr), "r"(phase), "r"(suspend_time_hint) : "memory");
 }
 
 __device__ __forceinline__ void mbarrier_wait_cluster(int mbar_addr, int phase) {
-    uint32_t ticks = 0x989680;
     asm volatile(
         "{\n\t"
         ".reg .pred P1;\n\t"
         "LAB_WAIT_CLUSTER:\n\t"
         "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64"
-        " P1, [%0], %1, %2;\n\t"
+        " P1, [%0], %1;\n\t"
         "@P1 bra.uni DONE_CLUSTER;\n\t"
         "bra.uni LAB_WAIT_CLUSTER;\n\t"
         "DONE_CLUSTER:\n\t"
         "}\n"
-        :: "r"(mbar_addr), "r"(phase), "r"(ticks) : "memory");
+        :: "r"(mbar_addr), "r"(phase) : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_wait_hint(
+        int mbar_addr, int phase, uint32_t suspend_time_hint) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        ".reg .u32 WAIT_ADDR;\n\t"
+        "mov.u32 WAIT_ADDR, %0;\n\t"
+        "LAB_WAIT_HINT:\n\t"
+        "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64"
+        " P1, [WAIT_ADDR], %1, %2;\n\t"
+        "@P1 bra.uni DONE_HINT;\n\t"
+        "bra.uni LAB_WAIT_HINT;\n\t"
+        "DONE_HINT:\n\t"
+        "}\n"
+        :: "r"(mbar_addr), "r"(phase), "r"(suspend_time_hint) : "memory");
+}
+
+// Exact unqualified CTA wait used by source schedules whose PTX intentionally
+// omits the acquire qualifier while retaining a typed suspendTimeHint operand.
+
+__device__ __forceinline__ void mbarrier_wait_relaxed_hint(
+        int mbar_addr, int phase, uint32_t suspend_time_hint) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "LAB_WAIT_RELAXED_HINT:\n\t"
+        "mbarrier.try_wait.parity.shared::cta.b64"
+        " P1, [%0], %1, %2;\n\t"
+        "@P1 bra DONE_RELAXED_HINT;\n\t"
+        "bra LAB_WAIT_RELAXED_HINT;\n\t"
+        "DONE_RELAXED_HINT:\n\t"
+        "}\n"
+        :: "r"(mbar_addr), "r"(phase), "r"(suspend_time_hint));
+}
+
+__device__ __forceinline__ void mbarrier_wait_cluster_hint(
+        int mbar_addr, int phase, uint32_t suspend_time_hint) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "LAB_WAIT_CLUSTER_HINT:\n\t"
+        "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64"
+        " P1, [%0], %1, %2;\n\t"
+        "@P1 bra.uni DONE_CLUSTER_HINT;\n\t"
+        "bra.uni LAB_WAIT_CLUSTER_HINT;\n\t"
+        "DONE_CLUSTER_HINT:\n\t"
+        "}\n"
+        :: "r"(mbar_addr), "r"(phase), "r"(suspend_time_hint) : "memory");
 }
 
 __device__ __forceinline__ void mbarrier_wait_token(int mbar_addr, int phase, uint32_t token) {
@@ -113,9 +188,30 @@ __device__ __forceinline__ void mbarrier_wait_token(int mbar_addr, int phase, ui
     }
 }
 
+__device__ __forceinline__ void mbarrier_wait_token_suspend(
+        int mbar_addr, int phase, uint32_t token, uint32_t suspend_time_hint) {
+    if (token == 0) {
+        mbarrier_wait_suspend(mbar_addr, phase, suspend_time_hint);
+    }
+}
+
 __device__ __forceinline__ void mbarrier_wait_token_cluster(int mbar_addr, int phase, uint32_t token) {
     if (token == 0) {
         mbarrier_wait_cluster(mbar_addr, phase);
+    }
+}
+
+__device__ __forceinline__ void mbarrier_wait_token_hint(
+        int mbar_addr, int phase, uint32_t token, uint32_t suspend_time_hint) {
+    if (token == 0) {
+        mbarrier_wait_hint(mbar_addr, phase, suspend_time_hint);
+    }
+}
+
+__device__ __forceinline__ void mbarrier_wait_token_cluster_hint(
+        int mbar_addr, int phase, uint32_t token, uint32_t suspend_time_hint) {
+    if (token == 0) {
+        mbarrier_wait_cluster_hint(mbar_addr, phase, suspend_time_hint);
     }
 }
 
@@ -228,7 +324,7 @@ __device__ __forceinline__ uint32_t make_warp_uniform(uint32_t val) {
     return result;
 }
 
-#define LOOM_INF CUDART_INF_F
+#define CAKE_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
 #define THREADS 32
 
@@ -238,8 +334,9 @@ __global__ __launch_bounds__(32) void
 kernel_cake_blackwell_all_gather_matmul_barrier_ws2_p0(int32_t pg_world, int32_t pg_rank, unsigned* const* __restrict__ pg_flags)
 {
     const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+    const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    uint32_t lane;
+    asm("mov.u32 %0, %%laneid;" : "=r"(lane));
 
 
     const int bid = blockIdx.x;
@@ -276,11 +373,11 @@ kernel_cake_blackwell_all_gather_matmul_barrier_ws2_p0(int32_t pg_world, int32_t
 
 } // extern "C"
 
-#undef LOOM_INF
+#undef CAKE_INF
 #undef NUM_MAIN_STAGES
 #undef THREADS
 
-#define LOOM_INF CUDART_INF_F
+#define CAKE_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
 #define THREADS 32
 
@@ -290,8 +387,9 @@ __global__ __launch_bounds__(32) void
 kernel_cake_blackwell_all_gather_matmul_barrier_ws2_p1(int32_t pg_world, int32_t pg_rank, unsigned* const* __restrict__ pg_flags)
 {
     const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+    const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    uint32_t lane;
+    asm("mov.u32 %0, %%laneid;" : "=r"(lane));
 
 
     const int bid = blockIdx.x;
@@ -328,11 +426,11 @@ kernel_cake_blackwell_all_gather_matmul_barrier_ws2_p1(int32_t pg_world, int32_t
 
 } // extern "C"
 
-#undef LOOM_INF
+#undef CAKE_INF
 #undef NUM_MAIN_STAGES
 #undef THREADS
 
-#define LOOM_INF CUDART_INF_F
+#define CAKE_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
 #define THREADS 32
 
@@ -342,8 +440,9 @@ __global__ __launch_bounds__(32) void
 kernel_cake_blackwell_all_gather_matmul_barrier_ws4_p0(int32_t pg_world, int32_t pg_rank, unsigned* const* __restrict__ pg_flags)
 {
     const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+    const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    uint32_t lane;
+    asm("mov.u32 %0, %%laneid;" : "=r"(lane));
 
 
     const int bid = blockIdx.x;
@@ -380,11 +479,11 @@ kernel_cake_blackwell_all_gather_matmul_barrier_ws4_p0(int32_t pg_world, int32_t
 
 } // extern "C"
 
-#undef LOOM_INF
+#undef CAKE_INF
 #undef NUM_MAIN_STAGES
 #undef THREADS
 
-#define LOOM_INF CUDART_INF_F
+#define CAKE_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
 #define THREADS 32
 
@@ -394,8 +493,9 @@ __global__ __launch_bounds__(32) void
 kernel_cake_blackwell_all_gather_matmul_barrier_ws4_p1(int32_t pg_world, int32_t pg_rank, unsigned* const* __restrict__ pg_flags)
 {
     const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+    const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    uint32_t lane;
+    asm("mov.u32 %0, %%laneid;" : "=r"(lane));
 
 
     const int bid = blockIdx.x;
@@ -432,11 +532,11 @@ kernel_cake_blackwell_all_gather_matmul_barrier_ws4_p1(int32_t pg_world, int32_t
 
 } // extern "C"
 
-#undef LOOM_INF
+#undef CAKE_INF
 #undef NUM_MAIN_STAGES
 #undef THREADS
 
-#define LOOM_INF CUDART_INF_F
+#define CAKE_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
 #define THREADS 32
 
@@ -446,8 +546,9 @@ __global__ __launch_bounds__(32) void
 kernel_cake_blackwell_all_gather_matmul_barrier_ws8_p0(int32_t pg_world, int32_t pg_rank, unsigned* const* __restrict__ pg_flags)
 {
     const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+    const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    uint32_t lane;
+    asm("mov.u32 %0, %%laneid;" : "=r"(lane));
 
 
     const int bid = blockIdx.x;
@@ -484,11 +585,11 @@ kernel_cake_blackwell_all_gather_matmul_barrier_ws8_p0(int32_t pg_world, int32_t
 
 } // extern "C"
 
-#undef LOOM_INF
+#undef CAKE_INF
 #undef NUM_MAIN_STAGES
 #undef THREADS
 
-#define LOOM_INF CUDART_INF_F
+#define CAKE_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
 #define THREADS 32
 
@@ -498,8 +599,9 @@ __global__ __launch_bounds__(32) void
 kernel_cake_blackwell_all_gather_matmul_barrier_ws8_p1(int32_t pg_world, int32_t pg_rank, unsigned* const* __restrict__ pg_flags)
 {
     const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+    const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    uint32_t lane;
+    asm("mov.u32 %0, %%laneid;" : "=r"(lane));
 
 
     const int bid = blockIdx.x;
@@ -536,11 +638,11 @@ kernel_cake_blackwell_all_gather_matmul_barrier_ws8_p1(int32_t pg_world, int32_t
 
 } // extern "C"
 
-#undef LOOM_INF
+#undef CAKE_INF
 #undef NUM_MAIN_STAGES
 #undef THREADS
 
-#define LOOM_INF CUDART_INF_F
+#define CAKE_INF CUDART_INF_F
 #define TMEM_NCOLS 512
 #define TMEM_ACCUM_OFFSET 0
 #define NUM_TMA_PIPE_STAGES 4
@@ -560,12 +662,14 @@ __global__ __launch_bounds__(192) void
 kernel_cake_blackwell_all_gather_matmul_float16_ws2(CakeTensorMap const* A_local, CakeTensorMap const* A_scratch, CakeTensorMap const* B, __half* __restrict__ C, __half* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
 {
     const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+    const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    uint32_t lane;
+    asm("mov.u32 %0, %%laneid;" : "=r"(lane));
 
     extern __shared__ __align__(1024) char smem_raw[];
     int smem;
     smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
     const int mbar_base = smem;
     #define tma_full_addr (mbar_base + 0)
     #define mma_done_addr (mbar_base + 32)
@@ -574,6 +678,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws2(CakeTensorMap const* A_local
 
     const int bid = blockIdx.x;
     const int num_bids = gridDim.x;
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 96);
     if (tid == 0) {
         asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(A_local)) : "memory");
         asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(A_scratch)) : "memory");
@@ -588,7 +693,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws2(CakeTensorMap const* A_local
     __half* smem_b = reinterpret_cast<__half*>(smem_raw + 17408);
     const int smem_b_addr = smem + 17408;
 
-    // Mbarrier init (4 groups, 12 barriers)
+    // Mbarrier init (4 pipeline groups, 0 ordered-sequence groups, 12 barriers)
     // Mbarriers at smem_raw[0..96)
 
     if (warp == 0) {
@@ -619,7 +724,6 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws2(CakeTensorMap const* A_local
     __syncwarp();
 
     // TMEM alloc (512 columns, 512 used)
-    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 96);
     if (warp == 0) {
         int _tmem_hold = smem + 96;
         asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
@@ -771,7 +875,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws2(CakeTensorMap const* A_local
         { // epilogue_main
             unsigned int epi_stage = 0;
             const int epi_warp = warp % 4;
-            const int epi_tid = epi_warp * 32 + lane;
+            const int epi_tid = (unsigned int)(epi_warp * 32) + lane;
             unsigned int _phase_mainloop_done = 0;
             #pragma unroll 1
             for (int peer_pass_1 = 0; peer_pass_1 < 2; peer_pass_1++) {
@@ -827,7 +931,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws2(CakeTensorMap const* A_local
 
 } // extern "C"
 
-#undef LOOM_INF
+#undef CAKE_INF
 #undef NUM_MAINLOOP_PIPE_STAGES
 #undef NUM_TMA_PIPE_STAGES
 #undef SMEM_SMEM_A_OFF
@@ -846,7 +950,8 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws2(CakeTensorMap const* A_local
 #undef smem_a_addr
 #undef smem_b_addr
 #undef tma_full_addr
-#define LOOM_INF CUDART_INF_F
+
+#define CAKE_INF CUDART_INF_F
 #define TMEM_NCOLS 512
 #define TMEM_ACCUM_OFFSET 0
 #define NUM_TMA_PIPE_STAGES 4
@@ -866,12 +971,14 @@ __global__ __launch_bounds__(192) void
 kernel_cake_blackwell_all_gather_matmul_bfloat16_ws2(CakeTensorMap const* A_local, CakeTensorMap const* A_scratch, CakeTensorMap const* B, __nv_bfloat16* __restrict__ C, __nv_bfloat16* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
 {
     const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+    const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    uint32_t lane;
+    asm("mov.u32 %0, %%laneid;" : "=r"(lane));
 
     extern __shared__ __align__(1024) char smem_raw[];
     int smem;
     smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
     const int mbar_base = smem;
     #define tma_full_addr (mbar_base + 0)
     #define mma_done_addr (mbar_base + 32)
@@ -880,6 +987,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws2(CakeTensorMap const* A_loca
 
     const int bid = blockIdx.x;
     const int num_bids = gridDim.x;
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 96);
     if (tid == 0) {
         asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(A_local)) : "memory");
         asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(A_scratch)) : "memory");
@@ -894,7 +1002,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws2(CakeTensorMap const* A_loca
     __nv_bfloat16* smem_b = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
     const int smem_b_addr = smem + 17408;
 
-    // Mbarrier init (4 groups, 12 barriers)
+    // Mbarrier init (4 pipeline groups, 0 ordered-sequence groups, 12 barriers)
     // Mbarriers at smem_raw[0..96)
 
     if (warp == 0) {
@@ -925,7 +1033,6 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws2(CakeTensorMap const* A_loca
     __syncwarp();
 
     // TMEM alloc (512 columns, 512 used)
-    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 96);
     if (warp == 0) {
         int _tmem_hold = smem + 96;
         asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
@@ -1077,7 +1184,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws2(CakeTensorMap const* A_loca
         { // epilogue_main
             unsigned int epi_stage = 0;
             const int epi_warp = warp % 4;
-            const int epi_tid = epi_warp * 32 + lane;
+            const int epi_tid = (unsigned int)(epi_warp * 32) + lane;
             unsigned int _phase_mainloop_done = 0;
             #pragma unroll 1
             for (int peer_pass_1 = 0; peer_pass_1 < 2; peer_pass_1++) {
@@ -1133,7 +1240,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws2(CakeTensorMap const* A_loca
 
 } // extern "C"
 
-#undef LOOM_INF
+#undef CAKE_INF
 #undef NUM_MAINLOOP_PIPE_STAGES
 #undef NUM_TMA_PIPE_STAGES
 #undef SMEM_SMEM_A_OFF
@@ -1152,7 +1259,8 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws2(CakeTensorMap const* A_loca
 #undef smem_a_addr
 #undef smem_b_addr
 #undef tma_full_addr
-#define LOOM_INF CUDART_INF_F
+
+#define CAKE_INF CUDART_INF_F
 #define TMEM_NCOLS 512
 #define TMEM_ACCUM_OFFSET 0
 #define NUM_TMA_PIPE_STAGES 4
@@ -1172,12 +1280,14 @@ __global__ __launch_bounds__(192) void
 kernel_cake_blackwell_all_gather_matmul_float16_ws4(CakeTensorMap const* A_local, CakeTensorMap const* A_scratch, CakeTensorMap const* B, __half* __restrict__ C, __half* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
 {
     const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+    const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    uint32_t lane;
+    asm("mov.u32 %0, %%laneid;" : "=r"(lane));
 
     extern __shared__ __align__(1024) char smem_raw[];
     int smem;
     smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
     const int mbar_base = smem;
     #define tma_full_addr (mbar_base + 0)
     #define mma_done_addr (mbar_base + 32)
@@ -1186,6 +1296,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws4(CakeTensorMap const* A_local
 
     const int bid = blockIdx.x;
     const int num_bids = gridDim.x;
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 96);
     if (tid == 0) {
         asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(A_local)) : "memory");
         asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(A_scratch)) : "memory");
@@ -1200,7 +1311,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws4(CakeTensorMap const* A_local
     __half* smem_b = reinterpret_cast<__half*>(smem_raw + 17408);
     const int smem_b_addr = smem + 17408;
 
-    // Mbarrier init (4 groups, 12 barriers)
+    // Mbarrier init (4 pipeline groups, 0 ordered-sequence groups, 12 barriers)
     // Mbarriers at smem_raw[0..96)
 
     if (warp == 0) {
@@ -1231,7 +1342,6 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws4(CakeTensorMap const* A_local
     __syncwarp();
 
     // TMEM alloc (512 columns, 512 used)
-    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 96);
     if (warp == 0) {
         int _tmem_hold = smem + 96;
         asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
@@ -1383,7 +1493,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws4(CakeTensorMap const* A_local
         { // epilogue_main
             unsigned int epi_stage = 0;
             const int epi_warp = warp % 4;
-            const int epi_tid = epi_warp * 32 + lane;
+            const int epi_tid = (unsigned int)(epi_warp * 32) + lane;
             unsigned int _phase_mainloop_done = 0;
             #pragma unroll 1
             for (int peer_pass_1 = 0; peer_pass_1 < 4; peer_pass_1++) {
@@ -1439,7 +1549,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws4(CakeTensorMap const* A_local
 
 } // extern "C"
 
-#undef LOOM_INF
+#undef CAKE_INF
 #undef NUM_MAINLOOP_PIPE_STAGES
 #undef NUM_TMA_PIPE_STAGES
 #undef SMEM_SMEM_A_OFF
@@ -1459,7 +1569,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws4(CakeTensorMap const* A_local
 #undef smem_b_addr
 #undef tma_full_addr
 
-#define LOOM_INF CUDART_INF_F
+#define CAKE_INF CUDART_INF_F
 #define TMEM_NCOLS 512
 #define TMEM_ACCUM_OFFSET 0
 #define NUM_TMA_PIPE_STAGES 4
@@ -1479,12 +1589,14 @@ __global__ __launch_bounds__(192) void
 kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4(CakeTensorMap const* A_local, CakeTensorMap const* A_scratch, CakeTensorMap const* B, __nv_bfloat16* __restrict__ C, __nv_bfloat16* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
 {
     const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+    const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    uint32_t lane;
+    asm("mov.u32 %0, %%laneid;" : "=r"(lane));
 
     extern __shared__ __align__(1024) char smem_raw[];
     int smem;
     smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
     const int mbar_base = smem;
     #define tma_full_addr (mbar_base + 0)
     #define mma_done_addr (mbar_base + 32)
@@ -1493,6 +1605,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4(CakeTensorMap const* A_loca
 
     const int bid = blockIdx.x;
     const int num_bids = gridDim.x;
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 96);
     if (tid == 0) {
         asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(A_local)) : "memory");
         asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(A_scratch)) : "memory");
@@ -1507,7 +1620,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4(CakeTensorMap const* A_loca
     __nv_bfloat16* smem_b = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
     const int smem_b_addr = smem + 17408;
 
-    // Mbarrier init (4 groups, 12 barriers)
+    // Mbarrier init (4 pipeline groups, 0 ordered-sequence groups, 12 barriers)
     // Mbarriers at smem_raw[0..96)
 
     if (warp == 0) {
@@ -1538,7 +1651,6 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4(CakeTensorMap const* A_loca
     __syncwarp();
 
     // TMEM alloc (512 columns, 512 used)
-    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 96);
     if (warp == 0) {
         int _tmem_hold = smem + 96;
         asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
@@ -1690,7 +1802,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4(CakeTensorMap const* A_loca
         { // epilogue_main
             unsigned int epi_stage = 0;
             const int epi_warp = warp % 4;
-            const int epi_tid = epi_warp * 32 + lane;
+            const int epi_tid = (unsigned int)(epi_warp * 32) + lane;
             unsigned int _phase_mainloop_done = 0;
             #pragma unroll 1
             for (int peer_pass_1 = 0; peer_pass_1 < 4; peer_pass_1++) {
@@ -1746,7 +1858,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4(CakeTensorMap const* A_loca
 
 } // extern "C"
 
-#undef LOOM_INF
+#undef CAKE_INF
 #undef NUM_MAINLOOP_PIPE_STAGES
 #undef NUM_TMA_PIPE_STAGES
 #undef SMEM_SMEM_A_OFF
@@ -1766,7 +1878,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4(CakeTensorMap const* A_loca
 #undef smem_b_addr
 #undef tma_full_addr
 
-#define LOOM_INF CUDART_INF_F
+#define CAKE_INF CUDART_INF_F
 #define TMEM_NCOLS 512
 #define TMEM_ACCUM_OFFSET 0
 #define NUM_TMA_PIPE_STAGES 4
@@ -1786,12 +1898,14 @@ __global__ __launch_bounds__(192) void
 kernel_cake_blackwell_all_gather_matmul_float16_ws8(CakeTensorMap const* A_local, CakeTensorMap const* A_scratch, CakeTensorMap const* B, __half* __restrict__ C, __half* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
 {
     const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+    const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    uint32_t lane;
+    asm("mov.u32 %0, %%laneid;" : "=r"(lane));
 
     extern __shared__ __align__(1024) char smem_raw[];
     int smem;
     smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
     const int mbar_base = smem;
     #define tma_full_addr (mbar_base + 0)
     #define mma_done_addr (mbar_base + 32)
@@ -1800,6 +1914,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws8(CakeTensorMap const* A_local
 
     const int bid = blockIdx.x;
     const int num_bids = gridDim.x;
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 96);
     if (tid == 0) {
         asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(A_local)) : "memory");
         asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(A_scratch)) : "memory");
@@ -1814,7 +1929,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws8(CakeTensorMap const* A_local
     __half* smem_b = reinterpret_cast<__half*>(smem_raw + 17408);
     const int smem_b_addr = smem + 17408;
 
-    // Mbarrier init (4 groups, 12 barriers)
+    // Mbarrier init (4 pipeline groups, 0 ordered-sequence groups, 12 barriers)
     // Mbarriers at smem_raw[0..96)
 
     if (warp == 0) {
@@ -1845,7 +1960,6 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws8(CakeTensorMap const* A_local
     __syncwarp();
 
     // TMEM alloc (512 columns, 512 used)
-    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 96);
     if (warp == 0) {
         int _tmem_hold = smem + 96;
         asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
@@ -1997,7 +2111,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws8(CakeTensorMap const* A_local
         { // epilogue_main
             unsigned int epi_stage = 0;
             const int epi_warp = warp % 4;
-            const int epi_tid = epi_warp * 32 + lane;
+            const int epi_tid = (unsigned int)(epi_warp * 32) + lane;
             unsigned int _phase_mainloop_done = 0;
             #pragma unroll 1
             for (int peer_pass_1 = 0; peer_pass_1 < 8; peer_pass_1++) {
@@ -2053,7 +2167,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws8(CakeTensorMap const* A_local
 
 } // extern "C"
 
-#undef LOOM_INF
+#undef CAKE_INF
 #undef NUM_MAINLOOP_PIPE_STAGES
 #undef NUM_TMA_PIPE_STAGES
 #undef SMEM_SMEM_A_OFF
@@ -2073,7 +2187,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws8(CakeTensorMap const* A_local
 #undef smem_b_addr
 #undef tma_full_addr
 
-#define LOOM_INF CUDART_INF_F
+#define CAKE_INF CUDART_INF_F
 #define TMEM_NCOLS 512
 #define TMEM_ACCUM_OFFSET 0
 #define NUM_TMA_PIPE_STAGES 4
@@ -2093,12 +2207,14 @@ __global__ __launch_bounds__(192) void
 kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(CakeTensorMap const* A_local, CakeTensorMap const* A_scratch, CakeTensorMap const* B, __nv_bfloat16* __restrict__ C, __nv_bfloat16* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
 {
     const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+    const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    uint32_t lane;
+    asm("mov.u32 %0, %%laneid;" : "=r"(lane));
 
     extern __shared__ __align__(1024) char smem_raw[];
     int smem;
     smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
     const int mbar_base = smem;
     #define tma_full_addr (mbar_base + 0)
     #define mma_done_addr (mbar_base + 32)
@@ -2107,6 +2223,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(CakeTensorMap const* A_loca
 
     const int bid = blockIdx.x;
     const int num_bids = gridDim.x;
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 96);
     if (tid == 0) {
         asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(A_local)) : "memory");
         asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(A_scratch)) : "memory");
@@ -2121,7 +2238,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(CakeTensorMap const* A_loca
     __nv_bfloat16* smem_b = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
     const int smem_b_addr = smem + 17408;
 
-    // Mbarrier init (4 groups, 12 barriers)
+    // Mbarrier init (4 pipeline groups, 0 ordered-sequence groups, 12 barriers)
     // Mbarriers at smem_raw[0..96)
 
     if (warp == 0) {
@@ -2152,7 +2269,6 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(CakeTensorMap const* A_loca
     __syncwarp();
 
     // TMEM alloc (512 columns, 512 used)
-    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 96);
     if (warp == 0) {
         int _tmem_hold = smem + 96;
         asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
@@ -2176,7 +2292,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(CakeTensorMap const* A_loca
             unsigned int load_stage = 0;
             unsigned int load_phase = 1;
             #pragma unroll
-            for (int peer_pass = 0; peer_pass < 8; peer_pass++) {
+            for (int peer_pass = blockIdx.y; peer_pass < 8; peer_pass += gridDim.y) {
                 int peer = (rank - peer_pass + 8) % 8;
                 #pragma unroll 1
                 for (int chunk_idx = 0; chunk_idx < (M + ((M < 2432) ? M : 2432) - 1) / ((M < 2432) ? M : 2432); chunk_idx++) {
@@ -2237,7 +2353,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(CakeTensorMap const* A_loca
             unsigned int _phase_epilogue_done = 1;
             unsigned int _phase_tma_full = 0;
             #pragma unroll
-            for (int _peer_pass = 0; _peer_pass < 8; _peer_pass++) {
+            for (int _peer_pass = blockIdx.y; _peer_pass < 8; _peer_pass += gridDim.y) {
                 #pragma unroll 1
                 for (int chunk_idx_1 = 0; chunk_idx_1 < (M + ((M < 2432) ? M : 2432) - 1) / ((M < 2432) ? M : 2432); chunk_idx_1++) {
                     int rows_left_1 = M - chunk_idx_1 * ((M < 2432) ? M : 2432);
@@ -2304,10 +2420,10 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(CakeTensorMap const* A_loca
         { // epilogue_main
             unsigned int epi_stage = 0;
             const int epi_warp = warp % 4;
-            const int epi_tid = epi_warp * 32 + lane;
+            const int epi_tid = (unsigned int)(epi_warp * 32) + lane;
             unsigned int _phase_mainloop_done = 0;
             #pragma unroll 1
-            for (int peer_pass_1 = 0; peer_pass_1 < 8; peer_pass_1++) {
+            for (int peer_pass_1 = blockIdx.y; peer_pass_1 < 8; peer_pass_1 += gridDim.y) {
                 int peer_1 = (rank - peer_pass_1 + 8) % 8;
                 #pragma unroll 1
                 for (int chunk_idx_2 = 0; chunk_idx_2 < (M + ((M < 2432) ? M : 2432) - 1) / ((M < 2432) ? M : 2432); chunk_idx_2++) {
@@ -2360,7 +2476,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(CakeTensorMap const* A_loca
 
 } // extern "C"
 
-#undef LOOM_INF
+#undef CAKE_INF
 #undef NUM_MAINLOOP_PIPE_STAGES
 #undef NUM_TMA_PIPE_STAGES
 #undef SMEM_SMEM_A_OFF

--- a/csrc/cake_all_gather_matmul/sm100a/cake_all_gather_matmul_kernels.cu
+++ b/csrc/cake_all_gather_matmul/sm100a/cake_all_gather_matmul_kernels.cu
@@ -2495,3 +2495,52 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(CakeTensorMap const* A_loca
 #undef smem_a_addr
 #undef smem_b_addr
 #undef tma_full_addr
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128) void
+kernel_cake_blackwell_all_gather_matmul_fused_peer_copy(unsigned int* __restrict__ inp, long long* __restrict__ payload_peers, long long* __restrict__ signal_peers, unsigned int* __restrict__ counters, unsigned int ready_target)
+{
+    const int tid = threadIdx.x;
+    const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    uint32_t lane;
+    asm("mov.u32 %0, %%laneid;" : "=r"(lane));
+
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // === Task calls (dependency order) ===
+    int peer_slot = blockIdx.y;
+    unsigned int* destination = reinterpret_cast<unsigned int*>(payload_peers[peer_slot]);
+    unsigned int* signal = reinterpret_cast<unsigned int*>(signal_peers[peer_slot]);
+    #pragma unroll 1
+    for (int vector = blockIdx.x * 128 + tid; vector < 524288; vector += gridDim.x * 128) {
+        uint32_t _sysv_ld_0[4];
+        asm volatile("ld.volatile.global.v4.b32 {%0, %1, %2, %3}, [%4];" : "=r"(_sysv_ld_0[0]), "=r"(_sysv_ld_0[1]), "=r"(_sysv_ld_0[2]), "=r"(_sysv_ld_0[3]) : "l"(inp + (vector * 4)) : "memory");
+        asm volatile("st.volatile.global.v4.b32 [%0], {%1, %2, %3, %4};" :: "l"(destination + (vector * 4)), "r"(_sysv_ld_0[0]), "r"(_sysv_ld_0[1]), "r"(_sysv_ld_0[2]), "r"(_sysv_ld_0[3]) : "memory");
+    }
+    __syncthreads();
+    if (warp == 0) {
+        if (elect_sync()) {
+            unsigned int last_ticket = (unsigned int)(gridDim.x - 1);
+            uint32_t _atomic_inc_old_0;
+            asm volatile("atom.acq_rel.gpu.global.inc.u32 %0, [%1], %2;"
+                : "=r"(_atomic_inc_old_0) : "l"(&counters[peer_slot]), "r"(static_cast<uint32_t>(last_ticket)) : "memory");
+            if (_atomic_inc_old_0 == last_ticket) {
+                __threadfence_system();
+                asm volatile("st.relaxed.sys.u32 [%0], %1;" :: "l"((reinterpret_cast<unsigned int*>(signal) + (0))), "r"(static_cast<unsigned int>(ready_target)) : "memory");
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef CAKE_INF
+#undef NUM_MAIN_STAGES
+#undef THREADS

--- a/csrc/cake_all_gather_matmul/sm100a/cake_all_gather_matmul_kernels.cu
+++ b/csrc/cake_all_gather_matmul/sm100a/cake_all_gather_matmul_kernels.cu
@@ -28,6 +28,14 @@ struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
 #include <cuda_bf16.h>
 #include <cuda_fp8.h>
 
+static_assert(sizeof(CUtensorMap) == 128, "CUtensorMap ABI size must remain 128 bytes");
+
+// Keep the exported descriptor ABI independent of the CUDA header alignment.
+struct alignas(128) FlashInferTensorMap {
+  CUtensorMap value;
+};
+static_assert(sizeof(FlashInferTensorMap) == 128, "CUtensorMap ABI size must remain 128 bytes");
+static_assert(alignof(FlashInferTensorMap) == 128, "CUtensorMap ABI alignment must remain 128 bytes");
 #include <math_constants.h>
 
 __device__ __forceinline__ uint32_t elect_sync() {
@@ -81,9 +89,6 @@ __device__ __forceinline__ uint32_t mbarrier_try_wait_cluster(int mbar_addr, int
     return token;
 }
 
-// Match CUTLASS ClusterBarrier::wait: a large suspendTimeHint lets the hardware
-// take the blocking phase-check slowpath instead of spinning on TRYWAIT misses.
-
 __device__ __forceinline__ void mbarrier_wait(int mbar_addr, int phase) {
     uint32_t ticks = 0x989680;
     asm volatile(
@@ -97,6 +102,23 @@ __device__ __forceinline__ void mbarrier_wait(int mbar_addr, int phase) {
         "DONE:\n\t"
         "}\n"
         :: "r"(mbar_addr), "r"(phase), "r"(ticks) : "memory");
+}
+
+// Source-faithful relaxed CTA wait used only by a typed protocol that does
+// not attach the PTX acquire qualifier, such as FA4's interior P-ready edge.
+
+__device__ __forceinline__ void mbarrier_wait_relaxed(int mbar_addr, int phase) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "LAB_WAIT_RELAXED:\n\t"
+        "mbarrier.try_wait.parity.shared::cta.b64"
+        " P1, [%0], %1, 10000000;\n\t"
+        "@P1 bra.uni DONE_RELAXED;\n\t"
+        "bra.uni LAB_WAIT_RELAXED;\n\t"
+        "DONE_RELAXED:\n\t"
+        "}\n"
+        :: "r"(mbar_addr), "r"(phase) : "memory");
 }
 
 // Exact source ports may request the PTX suspendTimeHint operand explicitly.
@@ -324,7 +346,7 @@ __device__ __forceinline__ uint32_t make_warp_uniform(uint32_t val) {
     return result;
 }
 
-#define CAKE_INF CUDART_INF_F
+#define FLASHINFER_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
 #define THREADS 32
 
@@ -343,41 +365,52 @@ kernel_cake_blackwell_all_gather_matmul_barrier_ws2_p0(int32_t pg_world, int32_t
     const int num_bids = gridDim.x;
 
     // === Task calls (dependency order) ===
-    if (elect_sync()) {
-        // nvlink_barrier(pg_flags) phase=0
-        {
-            const int __ws = pg_world;
-            const int __me = pg_rank;
-            const int __slot = 0;
-            unsigned* __local_flag = pg_flags[__me] + __slot;
-            unsigned __old_sense = 0u;
-            const unsigned __delta = (__me == 0) ? (0x80000000u - (unsigned)(__ws - 1)) : 1u;
+    // nvlink_barrier(pg_flags) phase=0 owner_warp=0
+    {
+        const int __ws = pg_world;
+        const int __me = pg_rank;
+        const int __warp = warp;
+        const int __lane = lane;
+        if (__warp == 0) {
+            unsigned* __local_epoch = pg_flags[__me] + 0;
+            unsigned __previous_epoch;
+            asm volatile("ld.relaxed.sys.global.u32 %0, [%1];"
+                : "=r"(__previous_epoch) : "l"(__local_epoch) : "memory");
+            const unsigned __epoch = __previous_epoch + 1u;
+            const int __bank = (int)(__epoch & 1u);
+            const int __mailbox_base = 2 + (0 * 2 + __bank) * __ws;
             asm volatile("fence.proxy.async.global;" ::: "memory");
-            for (int __r = 0; __r < __ws; ++__r) {
-                unsigned* __peer_flag = pg_flags[__r] + __slot;
-                unsigned __old_peer;
-                asm volatile("atom.add.release.sys.u32 %0, [%1], %2;"
-                    : "=r"(__old_peer) : "l"(__peer_flag), "r"(__delta) : "memory");
-                if (__r == __me) __old_sense = __old_peer;
+            if (__lane < __ws) {
+                unsigned* __peer_mailbox = pg_flags[__lane] + __mailbox_base + __me;
+                asm volatile("st.release.sys.global.u32 [%0], %1;"
+                    :: "l"(__peer_mailbox), "r"(__epoch) : "memory");
+                unsigned* __local_mailbox = pg_flags[__me] + __mailbox_base + __lane;
+                while (true) {
+                    unsigned __v;
+                    asm volatile("ld.relaxed.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_mailbox) : "memory");
+                    if (__v != __epoch) continue;
+                    asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_mailbox) : "memory");
+                    if (__v == __epoch) break;
+                }
+                asm volatile("fence.proxy.alias;" ::: "memory");
             }
-            asm volatile("fence.proxy.alias;" ::: "memory");
-            while (true) {
-                unsigned __v;
-                asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_flag) : "memory");
-                if (((__old_sense ^ __v) & 0x80000000u) != 0u) break;
-            }
+            __syncwarp();
             asm volatile("fence.proxy.async.global;" ::: "memory");
+            if (__lane == 0) {
+                asm volatile("st.release.sys.global.u32 [%0], %1;"
+                    :: "l"(__local_epoch), "r"(__epoch) : "memory");
+            }
         }
     }
 }
 
 } // extern "C"
 
-#undef CAKE_INF
+#undef FLASHINFER_INF
 #undef NUM_MAIN_STAGES
 #undef THREADS
 
-#define CAKE_INF CUDART_INF_F
+#define FLASHINFER_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
 #define THREADS 32
 
@@ -396,41 +429,52 @@ kernel_cake_blackwell_all_gather_matmul_barrier_ws2_p1(int32_t pg_world, int32_t
     const int num_bids = gridDim.x;
 
     // === Task calls (dependency order) ===
-    if (elect_sync()) {
-        // nvlink_barrier(pg_flags) phase=1
-        {
-            const int __ws = pg_world;
-            const int __me = pg_rank;
-            const int __slot = 1;
-            unsigned* __local_flag = pg_flags[__me] + __slot;
-            unsigned __old_sense = 0u;
-            const unsigned __delta = (__me == 0) ? (0x80000000u - (unsigned)(__ws - 1)) : 1u;
+    // nvlink_barrier(pg_flags) phase=1 owner_warp=0
+    {
+        const int __ws = pg_world;
+        const int __me = pg_rank;
+        const int __warp = warp;
+        const int __lane = lane;
+        if (__warp == 0) {
+            unsigned* __local_epoch = pg_flags[__me] + 1;
+            unsigned __previous_epoch;
+            asm volatile("ld.relaxed.sys.global.u32 %0, [%1];"
+                : "=r"(__previous_epoch) : "l"(__local_epoch) : "memory");
+            const unsigned __epoch = __previous_epoch + 1u;
+            const int __bank = (int)(__epoch & 1u);
+            const int __mailbox_base = 2 + (1 * 2 + __bank) * __ws;
             asm volatile("fence.proxy.async.global;" ::: "memory");
-            for (int __r = 0; __r < __ws; ++__r) {
-                unsigned* __peer_flag = pg_flags[__r] + __slot;
-                unsigned __old_peer;
-                asm volatile("atom.add.release.sys.u32 %0, [%1], %2;"
-                    : "=r"(__old_peer) : "l"(__peer_flag), "r"(__delta) : "memory");
-                if (__r == __me) __old_sense = __old_peer;
+            if (__lane < __ws) {
+                unsigned* __peer_mailbox = pg_flags[__lane] + __mailbox_base + __me;
+                asm volatile("st.release.sys.global.u32 [%0], %1;"
+                    :: "l"(__peer_mailbox), "r"(__epoch) : "memory");
+                unsigned* __local_mailbox = pg_flags[__me] + __mailbox_base + __lane;
+                while (true) {
+                    unsigned __v;
+                    asm volatile("ld.relaxed.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_mailbox) : "memory");
+                    if (__v != __epoch) continue;
+                    asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_mailbox) : "memory");
+                    if (__v == __epoch) break;
+                }
+                asm volatile("fence.proxy.alias;" ::: "memory");
             }
-            asm volatile("fence.proxy.alias;" ::: "memory");
-            while (true) {
-                unsigned __v;
-                asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_flag) : "memory");
-                if (((__old_sense ^ __v) & 0x80000000u) != 0u) break;
-            }
+            __syncwarp();
             asm volatile("fence.proxy.async.global;" ::: "memory");
+            if (__lane == 0) {
+                asm volatile("st.release.sys.global.u32 [%0], %1;"
+                    :: "l"(__local_epoch), "r"(__epoch) : "memory");
+            }
         }
     }
 }
 
 } // extern "C"
 
-#undef CAKE_INF
+#undef FLASHINFER_INF
 #undef NUM_MAIN_STAGES
 #undef THREADS
 
-#define CAKE_INF CUDART_INF_F
+#define FLASHINFER_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
 #define THREADS 32
 
@@ -449,41 +493,52 @@ kernel_cake_blackwell_all_gather_matmul_barrier_ws4_p0(int32_t pg_world, int32_t
     const int num_bids = gridDim.x;
 
     // === Task calls (dependency order) ===
-    if (elect_sync()) {
-        // nvlink_barrier(pg_flags) phase=0
-        {
-            const int __ws = pg_world;
-            const int __me = pg_rank;
-            const int __slot = 0;
-            unsigned* __local_flag = pg_flags[__me] + __slot;
-            unsigned __old_sense = 0u;
-            const unsigned __delta = (__me == 0) ? (0x80000000u - (unsigned)(__ws - 1)) : 1u;
+    // nvlink_barrier(pg_flags) phase=0 owner_warp=0
+    {
+        const int __ws = pg_world;
+        const int __me = pg_rank;
+        const int __warp = warp;
+        const int __lane = lane;
+        if (__warp == 0) {
+            unsigned* __local_epoch = pg_flags[__me] + 0;
+            unsigned __previous_epoch;
+            asm volatile("ld.relaxed.sys.global.u32 %0, [%1];"
+                : "=r"(__previous_epoch) : "l"(__local_epoch) : "memory");
+            const unsigned __epoch = __previous_epoch + 1u;
+            const int __bank = (int)(__epoch & 1u);
+            const int __mailbox_base = 2 + (0 * 2 + __bank) * __ws;
             asm volatile("fence.proxy.async.global;" ::: "memory");
-            for (int __r = 0; __r < __ws; ++__r) {
-                unsigned* __peer_flag = pg_flags[__r] + __slot;
-                unsigned __old_peer;
-                asm volatile("atom.add.release.sys.u32 %0, [%1], %2;"
-                    : "=r"(__old_peer) : "l"(__peer_flag), "r"(__delta) : "memory");
-                if (__r == __me) __old_sense = __old_peer;
+            if (__lane < __ws) {
+                unsigned* __peer_mailbox = pg_flags[__lane] + __mailbox_base + __me;
+                asm volatile("st.release.sys.global.u32 [%0], %1;"
+                    :: "l"(__peer_mailbox), "r"(__epoch) : "memory");
+                unsigned* __local_mailbox = pg_flags[__me] + __mailbox_base + __lane;
+                while (true) {
+                    unsigned __v;
+                    asm volatile("ld.relaxed.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_mailbox) : "memory");
+                    if (__v != __epoch) continue;
+                    asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_mailbox) : "memory");
+                    if (__v == __epoch) break;
+                }
+                asm volatile("fence.proxy.alias;" ::: "memory");
             }
-            asm volatile("fence.proxy.alias;" ::: "memory");
-            while (true) {
-                unsigned __v;
-                asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_flag) : "memory");
-                if (((__old_sense ^ __v) & 0x80000000u) != 0u) break;
-            }
+            __syncwarp();
             asm volatile("fence.proxy.async.global;" ::: "memory");
+            if (__lane == 0) {
+                asm volatile("st.release.sys.global.u32 [%0], %1;"
+                    :: "l"(__local_epoch), "r"(__epoch) : "memory");
+            }
         }
     }
 }
 
 } // extern "C"
 
-#undef CAKE_INF
+#undef FLASHINFER_INF
 #undef NUM_MAIN_STAGES
 #undef THREADS
 
-#define CAKE_INF CUDART_INF_F
+#define FLASHINFER_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
 #define THREADS 32
 
@@ -502,41 +557,52 @@ kernel_cake_blackwell_all_gather_matmul_barrier_ws4_p1(int32_t pg_world, int32_t
     const int num_bids = gridDim.x;
 
     // === Task calls (dependency order) ===
-    if (elect_sync()) {
-        // nvlink_barrier(pg_flags) phase=1
-        {
-            const int __ws = pg_world;
-            const int __me = pg_rank;
-            const int __slot = 1;
-            unsigned* __local_flag = pg_flags[__me] + __slot;
-            unsigned __old_sense = 0u;
-            const unsigned __delta = (__me == 0) ? (0x80000000u - (unsigned)(__ws - 1)) : 1u;
+    // nvlink_barrier(pg_flags) phase=1 owner_warp=0
+    {
+        const int __ws = pg_world;
+        const int __me = pg_rank;
+        const int __warp = warp;
+        const int __lane = lane;
+        if (__warp == 0) {
+            unsigned* __local_epoch = pg_flags[__me] + 1;
+            unsigned __previous_epoch;
+            asm volatile("ld.relaxed.sys.global.u32 %0, [%1];"
+                : "=r"(__previous_epoch) : "l"(__local_epoch) : "memory");
+            const unsigned __epoch = __previous_epoch + 1u;
+            const int __bank = (int)(__epoch & 1u);
+            const int __mailbox_base = 2 + (1 * 2 + __bank) * __ws;
             asm volatile("fence.proxy.async.global;" ::: "memory");
-            for (int __r = 0; __r < __ws; ++__r) {
-                unsigned* __peer_flag = pg_flags[__r] + __slot;
-                unsigned __old_peer;
-                asm volatile("atom.add.release.sys.u32 %0, [%1], %2;"
-                    : "=r"(__old_peer) : "l"(__peer_flag), "r"(__delta) : "memory");
-                if (__r == __me) __old_sense = __old_peer;
+            if (__lane < __ws) {
+                unsigned* __peer_mailbox = pg_flags[__lane] + __mailbox_base + __me;
+                asm volatile("st.release.sys.global.u32 [%0], %1;"
+                    :: "l"(__peer_mailbox), "r"(__epoch) : "memory");
+                unsigned* __local_mailbox = pg_flags[__me] + __mailbox_base + __lane;
+                while (true) {
+                    unsigned __v;
+                    asm volatile("ld.relaxed.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_mailbox) : "memory");
+                    if (__v != __epoch) continue;
+                    asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_mailbox) : "memory");
+                    if (__v == __epoch) break;
+                }
+                asm volatile("fence.proxy.alias;" ::: "memory");
             }
-            asm volatile("fence.proxy.alias;" ::: "memory");
-            while (true) {
-                unsigned __v;
-                asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_flag) : "memory");
-                if (((__old_sense ^ __v) & 0x80000000u) != 0u) break;
-            }
+            __syncwarp();
             asm volatile("fence.proxy.async.global;" ::: "memory");
+            if (__lane == 0) {
+                asm volatile("st.release.sys.global.u32 [%0], %1;"
+                    :: "l"(__local_epoch), "r"(__epoch) : "memory");
+            }
         }
     }
 }
 
 } // extern "C"
 
-#undef CAKE_INF
+#undef FLASHINFER_INF
 #undef NUM_MAIN_STAGES
 #undef THREADS
 
-#define CAKE_INF CUDART_INF_F
+#define FLASHINFER_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
 #define THREADS 32
 
@@ -555,41 +621,52 @@ kernel_cake_blackwell_all_gather_matmul_barrier_ws8_p0(int32_t pg_world, int32_t
     const int num_bids = gridDim.x;
 
     // === Task calls (dependency order) ===
-    if (elect_sync()) {
-        // nvlink_barrier(pg_flags) phase=0
-        {
-            const int __ws = pg_world;
-            const int __me = pg_rank;
-            const int __slot = 0;
-            unsigned* __local_flag = pg_flags[__me] + __slot;
-            unsigned __old_sense = 0u;
-            const unsigned __delta = (__me == 0) ? (0x80000000u - (unsigned)(__ws - 1)) : 1u;
+    // nvlink_barrier(pg_flags) phase=0 owner_warp=0
+    {
+        const int __ws = pg_world;
+        const int __me = pg_rank;
+        const int __warp = warp;
+        const int __lane = lane;
+        if (__warp == 0) {
+            unsigned* __local_epoch = pg_flags[__me] + 0;
+            unsigned __previous_epoch;
+            asm volatile("ld.relaxed.sys.global.u32 %0, [%1];"
+                : "=r"(__previous_epoch) : "l"(__local_epoch) : "memory");
+            const unsigned __epoch = __previous_epoch + 1u;
+            const int __bank = (int)(__epoch & 1u);
+            const int __mailbox_base = 2 + (0 * 2 + __bank) * __ws;
             asm volatile("fence.proxy.async.global;" ::: "memory");
-            for (int __r = 0; __r < __ws; ++__r) {
-                unsigned* __peer_flag = pg_flags[__r] + __slot;
-                unsigned __old_peer;
-                asm volatile("atom.add.release.sys.u32 %0, [%1], %2;"
-                    : "=r"(__old_peer) : "l"(__peer_flag), "r"(__delta) : "memory");
-                if (__r == __me) __old_sense = __old_peer;
+            if (__lane < __ws) {
+                unsigned* __peer_mailbox = pg_flags[__lane] + __mailbox_base + __me;
+                asm volatile("st.release.sys.global.u32 [%0], %1;"
+                    :: "l"(__peer_mailbox), "r"(__epoch) : "memory");
+                unsigned* __local_mailbox = pg_flags[__me] + __mailbox_base + __lane;
+                while (true) {
+                    unsigned __v;
+                    asm volatile("ld.relaxed.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_mailbox) : "memory");
+                    if (__v != __epoch) continue;
+                    asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_mailbox) : "memory");
+                    if (__v == __epoch) break;
+                }
+                asm volatile("fence.proxy.alias;" ::: "memory");
             }
-            asm volatile("fence.proxy.alias;" ::: "memory");
-            while (true) {
-                unsigned __v;
-                asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_flag) : "memory");
-                if (((__old_sense ^ __v) & 0x80000000u) != 0u) break;
-            }
+            __syncwarp();
             asm volatile("fence.proxy.async.global;" ::: "memory");
+            if (__lane == 0) {
+                asm volatile("st.release.sys.global.u32 [%0], %1;"
+                    :: "l"(__local_epoch), "r"(__epoch) : "memory");
+            }
         }
     }
 }
 
 } // extern "C"
 
-#undef CAKE_INF
+#undef FLASHINFER_INF
 #undef NUM_MAIN_STAGES
 #undef THREADS
 
-#define CAKE_INF CUDART_INF_F
+#define FLASHINFER_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
 #define THREADS 32
 
@@ -608,41 +685,52 @@ kernel_cake_blackwell_all_gather_matmul_barrier_ws8_p1(int32_t pg_world, int32_t
     const int num_bids = gridDim.x;
 
     // === Task calls (dependency order) ===
-    if (elect_sync()) {
-        // nvlink_barrier(pg_flags) phase=1
-        {
-            const int __ws = pg_world;
-            const int __me = pg_rank;
-            const int __slot = 1;
-            unsigned* __local_flag = pg_flags[__me] + __slot;
-            unsigned __old_sense = 0u;
-            const unsigned __delta = (__me == 0) ? (0x80000000u - (unsigned)(__ws - 1)) : 1u;
+    // nvlink_barrier(pg_flags) phase=1 owner_warp=0
+    {
+        const int __ws = pg_world;
+        const int __me = pg_rank;
+        const int __warp = warp;
+        const int __lane = lane;
+        if (__warp == 0) {
+            unsigned* __local_epoch = pg_flags[__me] + 1;
+            unsigned __previous_epoch;
+            asm volatile("ld.relaxed.sys.global.u32 %0, [%1];"
+                : "=r"(__previous_epoch) : "l"(__local_epoch) : "memory");
+            const unsigned __epoch = __previous_epoch + 1u;
+            const int __bank = (int)(__epoch & 1u);
+            const int __mailbox_base = 2 + (1 * 2 + __bank) * __ws;
             asm volatile("fence.proxy.async.global;" ::: "memory");
-            for (int __r = 0; __r < __ws; ++__r) {
-                unsigned* __peer_flag = pg_flags[__r] + __slot;
-                unsigned __old_peer;
-                asm volatile("atom.add.release.sys.u32 %0, [%1], %2;"
-                    : "=r"(__old_peer) : "l"(__peer_flag), "r"(__delta) : "memory");
-                if (__r == __me) __old_sense = __old_peer;
+            if (__lane < __ws) {
+                unsigned* __peer_mailbox = pg_flags[__lane] + __mailbox_base + __me;
+                asm volatile("st.release.sys.global.u32 [%0], %1;"
+                    :: "l"(__peer_mailbox), "r"(__epoch) : "memory");
+                unsigned* __local_mailbox = pg_flags[__me] + __mailbox_base + __lane;
+                while (true) {
+                    unsigned __v;
+                    asm volatile("ld.relaxed.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_mailbox) : "memory");
+                    if (__v != __epoch) continue;
+                    asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_mailbox) : "memory");
+                    if (__v == __epoch) break;
+                }
+                asm volatile("fence.proxy.alias;" ::: "memory");
             }
-            asm volatile("fence.proxy.alias;" ::: "memory");
-            while (true) {
-                unsigned __v;
-                asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_flag) : "memory");
-                if (((__old_sense ^ __v) & 0x80000000u) != 0u) break;
-            }
+            __syncwarp();
             asm volatile("fence.proxy.async.global;" ::: "memory");
+            if (__lane == 0) {
+                asm volatile("st.release.sys.global.u32 [%0], %1;"
+                    :: "l"(__local_epoch), "r"(__epoch) : "memory");
+            }
         }
     }
 }
 
 } // extern "C"
 
-#undef CAKE_INF
+#undef FLASHINFER_INF
 #undef NUM_MAIN_STAGES
 #undef THREADS
 
-#define CAKE_INF CUDART_INF_F
+#define FLASHINFER_INF CUDART_INF_F
 #define TMEM_NCOLS 512
 #define TMEM_ACCUM_OFFSET 0
 #define NUM_TMA_PIPE_STAGES 4
@@ -659,7 +747,7 @@ kernel_cake_blackwell_all_gather_matmul_barrier_ws8_p1(int32_t pg_world, int32_t
 extern "C" {
 
 __global__ __launch_bounds__(192) void
-kernel_cake_blackwell_all_gather_matmul_float16_ws2(CakeTensorMap const* A_local, CakeTensorMap const* A_scratch, CakeTensorMap const* B, __half* __restrict__ C, __half* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
+kernel_cake_blackwell_all_gather_matmul_float16_ws2(FlashInferTensorMap const* A_local, FlashInferTensorMap const* A_scratch, FlashInferTensorMap const* B, __half* __restrict__ C, __half* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
 {
     const int tid = threadIdx.x;
     const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
@@ -727,6 +815,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws2(CakeTensorMap const* A_local
     if (warp == 0) {
         int _tmem_hold = smem + 96;
         asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
+        __syncwarp();
         asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
     }
 
@@ -931,7 +1020,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws2(CakeTensorMap const* A_local
 
 } // extern "C"
 
-#undef CAKE_INF
+#undef FLASHINFER_INF
 #undef NUM_MAINLOOP_PIPE_STAGES
 #undef NUM_TMA_PIPE_STAGES
 #undef SMEM_SMEM_A_OFF
@@ -951,7 +1040,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws2(CakeTensorMap const* A_local
 #undef smem_b_addr
 #undef tma_full_addr
 
-#define CAKE_INF CUDART_INF_F
+#define FLASHINFER_INF CUDART_INF_F
 #define TMEM_NCOLS 512
 #define TMEM_ACCUM_OFFSET 0
 #define NUM_TMA_PIPE_STAGES 4
@@ -968,7 +1057,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws2(CakeTensorMap const* A_local
 extern "C" {
 
 __global__ __launch_bounds__(192) void
-kernel_cake_blackwell_all_gather_matmul_bfloat16_ws2(CakeTensorMap const* A_local, CakeTensorMap const* A_scratch, CakeTensorMap const* B, __nv_bfloat16* __restrict__ C, __nv_bfloat16* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
+kernel_cake_blackwell_all_gather_matmul_bfloat16_ws2(FlashInferTensorMap const* A_local, FlashInferTensorMap const* A_scratch, FlashInferTensorMap const* B, __nv_bfloat16* __restrict__ C, __nv_bfloat16* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
 {
     const int tid = threadIdx.x;
     const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
@@ -1036,6 +1125,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws2(CakeTensorMap const* A_loca
     if (warp == 0) {
         int _tmem_hold = smem + 96;
         asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
+        __syncwarp();
         asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
     }
 
@@ -1240,7 +1330,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws2(CakeTensorMap const* A_loca
 
 } // extern "C"
 
-#undef CAKE_INF
+#undef FLASHINFER_INF
 #undef NUM_MAINLOOP_PIPE_STAGES
 #undef NUM_TMA_PIPE_STAGES
 #undef SMEM_SMEM_A_OFF
@@ -1260,7 +1350,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws2(CakeTensorMap const* A_loca
 #undef smem_b_addr
 #undef tma_full_addr
 
-#define CAKE_INF CUDART_INF_F
+#define FLASHINFER_INF CUDART_INF_F
 #define TMEM_NCOLS 512
 #define TMEM_ACCUM_OFFSET 0
 #define NUM_TMA_PIPE_STAGES 4
@@ -1277,7 +1367,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws2(CakeTensorMap const* A_loca
 extern "C" {
 
 __global__ __launch_bounds__(192) void
-kernel_cake_blackwell_all_gather_matmul_float16_ws4(CakeTensorMap const* A_local, CakeTensorMap const* A_scratch, CakeTensorMap const* B, __half* __restrict__ C, __half* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
+kernel_cake_blackwell_all_gather_matmul_float16_ws4(FlashInferTensorMap const* A_local, FlashInferTensorMap const* A_scratch, FlashInferTensorMap const* B, __half* __restrict__ C, __half* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
 {
     const int tid = threadIdx.x;
     const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
@@ -1345,6 +1435,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws4(CakeTensorMap const* A_local
     if (warp == 0) {
         int _tmem_hold = smem + 96;
         asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
+        __syncwarp();
         asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
     }
 
@@ -1549,7 +1640,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws4(CakeTensorMap const* A_local
 
 } // extern "C"
 
-#undef CAKE_INF
+#undef FLASHINFER_INF
 #undef NUM_MAINLOOP_PIPE_STAGES
 #undef NUM_TMA_PIPE_STAGES
 #undef SMEM_SMEM_A_OFF
@@ -1569,7 +1660,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws4(CakeTensorMap const* A_local
 #undef smem_b_addr
 #undef tma_full_addr
 
-#define CAKE_INF CUDART_INF_F
+#define FLASHINFER_INF CUDART_INF_F
 #define TMEM_NCOLS 512
 #define TMEM_ACCUM_OFFSET 0
 #define NUM_TMA_PIPE_STAGES 4
@@ -1586,7 +1677,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws4(CakeTensorMap const* A_local
 extern "C" {
 
 __global__ __launch_bounds__(192) void
-kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4(CakeTensorMap const* A_local, CakeTensorMap const* A_scratch, CakeTensorMap const* B, __nv_bfloat16* __restrict__ C, __nv_bfloat16* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
+kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4(FlashInferTensorMap const* A_local, FlashInferTensorMap const* A_scratch, FlashInferTensorMap const* B, __nv_bfloat16* __restrict__ C, __nv_bfloat16* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
 {
     const int tid = threadIdx.x;
     const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
@@ -1654,6 +1745,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4(CakeTensorMap const* A_loca
     if (warp == 0) {
         int _tmem_hold = smem + 96;
         asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
+        __syncwarp();
         asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
     }
 
@@ -1858,7 +1950,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4(CakeTensorMap const* A_loca
 
 } // extern "C"
 
-#undef CAKE_INF
+#undef FLASHINFER_INF
 #undef NUM_MAINLOOP_PIPE_STAGES
 #undef NUM_TMA_PIPE_STAGES
 #undef SMEM_SMEM_A_OFF
@@ -1878,7 +1970,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4(CakeTensorMap const* A_loca
 #undef smem_b_addr
 #undef tma_full_addr
 
-#define CAKE_INF CUDART_INF_F
+#define FLASHINFER_INF CUDART_INF_F
 #define TMEM_NCOLS 512
 #define TMEM_ACCUM_OFFSET 0
 #define NUM_TMA_PIPE_STAGES 4
@@ -1895,7 +1987,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4(CakeTensorMap const* A_loca
 extern "C" {
 
 __global__ __launch_bounds__(192) void
-kernel_cake_blackwell_all_gather_matmul_float16_ws8(CakeTensorMap const* A_local, CakeTensorMap const* A_scratch, CakeTensorMap const* B, __half* __restrict__ C, __half* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
+kernel_cake_blackwell_all_gather_matmul_float16_ws8(FlashInferTensorMap const* A_local, FlashInferTensorMap const* A_scratch, FlashInferTensorMap const* B, __half* __restrict__ C, __half* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
 {
     const int tid = threadIdx.x;
     const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
@@ -1963,6 +2055,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws8(CakeTensorMap const* A_local
     if (warp == 0) {
         int _tmem_hold = smem + 96;
         asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
+        __syncwarp();
         asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
     }
 
@@ -2167,7 +2260,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws8(CakeTensorMap const* A_local
 
 } // extern "C"
 
-#undef CAKE_INF
+#undef FLASHINFER_INF
 #undef NUM_MAINLOOP_PIPE_STAGES
 #undef NUM_TMA_PIPE_STAGES
 #undef SMEM_SMEM_A_OFF
@@ -2187,7 +2280,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws8(CakeTensorMap const* A_local
 #undef smem_b_addr
 #undef tma_full_addr
 
-#define CAKE_INF CUDART_INF_F
+#define FLASHINFER_INF CUDART_INF_F
 #define TMEM_NCOLS 512
 #define TMEM_ACCUM_OFFSET 0
 #define NUM_TMA_PIPE_STAGES 4
@@ -2204,7 +2297,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws8(CakeTensorMap const* A_local
 extern "C" {
 
 __global__ __launch_bounds__(192) void
-kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(CakeTensorMap const* A_local, CakeTensorMap const* A_scratch, CakeTensorMap const* B, __nv_bfloat16* __restrict__ C, __nv_bfloat16* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
+kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(FlashInferTensorMap const* A_local, FlashInferTensorMap const* A_scratch, FlashInferTensorMap const* B, __nv_bfloat16* __restrict__ C, __nv_bfloat16* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
 {
     const int tid = threadIdx.x;
     const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
@@ -2272,6 +2365,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(CakeTensorMap const* A_loca
     if (warp == 0) {
         int _tmem_hold = smem + 96;
         asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
+        __syncwarp();
         asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
     }
 
@@ -2476,7 +2570,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(CakeTensorMap const* A_loca
 
 } // extern "C"
 
-#undef CAKE_INF
+#undef FLASHINFER_INF
 #undef NUM_MAINLOOP_PIPE_STAGES
 #undef NUM_TMA_PIPE_STAGES
 #undef SMEM_SMEM_A_OFF
@@ -2496,7 +2590,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(CakeTensorMap const* A_loca
 #undef smem_b_addr
 #undef tma_full_addr
 
-#define CAKE_INF CUDART_INF_F
+#define FLASHINFER_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
 #define THREADS 128
 
@@ -2541,6 +2635,6 @@ kernel_cake_blackwell_all_gather_matmul_fused_peer_copy(unsigned int* __restrict
 
 } // extern "C"
 
-#undef CAKE_INF
+#undef FLASHINFER_INF
 #undef NUM_MAIN_STAGES
 #undef THREADS

--- a/csrc/cake_all_gather_matmul/sm100a/manifest.json
+++ b/csrc/cake_all_gather_matmul/sm100a/manifest.json
@@ -91,6 +91,6 @@
     }
   },
   "schema_version": 1,
-  "source_sha256": "6ba37efcba102135f0155ef5e162143ad71bc27e52699c9aae05b9d9ace99433",
+  "source_sha256": "1eb41812ff454293bcf3ae1eee78318cc3648feb045d3788989b3b4f637ba087",
   "tma_abi": "pointer"
 }

--- a/csrc/cake_all_gather_matmul/sm100a/manifest.json
+++ b/csrc/cake_all_gather_matmul/sm100a/manifest.json
@@ -21,6 +21,16 @@
         2048
       ]
     },
+    "prepared_packed_qkv": {
+      "dtypes": [
+        "bfloat16"
+      ],
+      "n_by_world_size": {
+        "8": [
+          1280
+        ]
+      }
+    },
     "world_sizes": [
       2,
       4,
@@ -103,6 +113,6 @@
     }
   },
   "schema_version": 1,
-  "source_sha256": "aed09c12a2d0f1151992f7e20e4d0a2997b897a54b23f3dd06cb0a303aba30fe",
+  "source_sha256": "ef39c0d6ddfa1e038fc50bdf6137e8df872142faaadfe31a3a1fbe271e11d94d",
   "tma_abi": "pointer"
 }

--- a/csrc/cake_all_gather_matmul/sm100a/manifest.json
+++ b/csrc/cake_all_gather_matmul/sm100a/manifest.json
@@ -27,7 +27,7 @@
       8
     ]
   },
-  "kernel_count": 12,
+  "kernel_count": 13,
   "kernel_symbols": [
     "kernel_cake_blackwell_all_gather_matmul_barrier_ws2_p0",
     "kernel_cake_blackwell_all_gather_matmul_barrier_ws2_p1",
@@ -40,7 +40,8 @@
     "kernel_cake_blackwell_all_gather_matmul_float16_ws4",
     "kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4",
     "kernel_cake_blackwell_all_gather_matmul_float16_ws8",
-    "kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8"
+    "kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8",
+    "kernel_cake_blackwell_all_gather_matmul_fused_peer_copy"
   ],
   "launch": {
     "barrier": {
@@ -51,6 +52,17 @@
         1,
         1
       ]
+    },
+    "fused_peer_copy": {
+      "block_threads": 128,
+      "dynamic_smem_bytes": 0,
+      "grid": [
+        32,
+        7,
+        1
+      ],
+      "ordering": "start_barrier -> fused_peer_copy -> comm_join -> completion_barrier -> main",
+      "when": "sm_103a, bfloat16, world_size=8, M=512, N=1280"
     },
     "main": {
       "block_threads": 192,
@@ -91,6 +103,6 @@
     }
   },
   "schema_version": 1,
-  "source_sha256": "1eb41812ff454293bcf3ae1eee78318cc3648feb045d3788989b3b4f637ba087",
+  "source_sha256": "aed09c12a2d0f1151992f7e20e4d0a2997b897a54b23f3dd06cb0a303aba30fe",
   "tma_abi": "pointer"
 }

--- a/csrc/cake_all_gather_matmul/sm103a/cake_all_gather_matmul_kernels.cu
+++ b/csrc/cake_all_gather_matmul/sm103a/cake_all_gather_matmul_kernels.cu
@@ -2495,3 +2495,52 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(CakeTensorMap const* A_loca
 #undef smem_a_addr
 #undef smem_b_addr
 #undef tma_full_addr
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128) void
+kernel_cake_blackwell_all_gather_matmul_fused_peer_copy(unsigned int* __restrict__ inp, long long* __restrict__ payload_peers, long long* __restrict__ signal_peers, unsigned int* __restrict__ counters, unsigned int ready_target)
+{
+    const int tid = threadIdx.x;
+    const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    uint32_t lane;
+    asm("mov.u32 %0, %%laneid;" : "=r"(lane));
+
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // === Task calls (dependency order) ===
+    int peer_slot = blockIdx.y;
+    unsigned int* destination = reinterpret_cast<unsigned int*>(payload_peers[peer_slot]);
+    unsigned int* signal = reinterpret_cast<unsigned int*>(signal_peers[peer_slot]);
+    #pragma unroll 1
+    for (int vector = blockIdx.x * 128 + tid; vector < 524288; vector += gridDim.x * 128) {
+        uint32_t _sysv_ld_0[4];
+        asm volatile("ld.volatile.global.v4.b32 {%0, %1, %2, %3}, [%4];" : "=r"(_sysv_ld_0[0]), "=r"(_sysv_ld_0[1]), "=r"(_sysv_ld_0[2]), "=r"(_sysv_ld_0[3]) : "l"(inp + (vector * 4)) : "memory");
+        asm volatile("st.volatile.global.v4.b32 [%0], {%1, %2, %3, %4};" :: "l"(destination + (vector * 4)), "r"(_sysv_ld_0[0]), "r"(_sysv_ld_0[1]), "r"(_sysv_ld_0[2]), "r"(_sysv_ld_0[3]) : "memory");
+    }
+    __syncthreads();
+    if (warp == 0) {
+        if (elect_sync()) {
+            unsigned int last_ticket = (unsigned int)(gridDim.x - 1);
+            uint32_t _atomic_inc_old_0;
+            asm volatile("atom.acq_rel.gpu.global.inc.u32 %0, [%1], %2;"
+                : "=r"(_atomic_inc_old_0) : "l"(&counters[peer_slot]), "r"(static_cast<uint32_t>(last_ticket)) : "memory");
+            if (_atomic_inc_old_0 == last_ticket) {
+                __threadfence_system();
+                asm volatile("st.relaxed.sys.u32 [%0], %1;" :: "l"((reinterpret_cast<unsigned int*>(signal) + (0))), "r"(static_cast<unsigned int>(ready_target)) : "memory");
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef CAKE_INF
+#undef NUM_MAIN_STAGES
+#undef THREADS

--- a/csrc/cake_all_gather_matmul/sm103a/cake_all_gather_matmul_kernels.cu
+++ b/csrc/cake_all_gather_matmul/sm103a/cake_all_gather_matmul_kernels.cu
@@ -28,6 +28,14 @@ struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
 #include <cuda_bf16.h>
 #include <cuda_fp8.h>
 
+static_assert(sizeof(CUtensorMap) == 128, "CUtensorMap ABI size must remain 128 bytes");
+
+// Keep the exported descriptor ABI independent of the CUDA header alignment.
+struct alignas(128) FlashInferTensorMap {
+  CUtensorMap value;
+};
+static_assert(sizeof(FlashInferTensorMap) == 128, "CUtensorMap ABI size must remain 128 bytes");
+static_assert(alignof(FlashInferTensorMap) == 128, "CUtensorMap ABI alignment must remain 128 bytes");
 #include <math_constants.h>
 
 __device__ __forceinline__ uint32_t elect_sync() {
@@ -81,9 +89,6 @@ __device__ __forceinline__ uint32_t mbarrier_try_wait_cluster(int mbar_addr, int
     return token;
 }
 
-// Match CUTLASS ClusterBarrier::wait: a large suspendTimeHint lets the hardware
-// take the blocking phase-check slowpath instead of spinning on TRYWAIT misses.
-
 __device__ __forceinline__ void mbarrier_wait(int mbar_addr, int phase) {
     uint32_t ticks = 0x989680;
     asm volatile(
@@ -97,6 +102,23 @@ __device__ __forceinline__ void mbarrier_wait(int mbar_addr, int phase) {
         "DONE:\n\t"
         "}\n"
         :: "r"(mbar_addr), "r"(phase), "r"(ticks) : "memory");
+}
+
+// Source-faithful relaxed CTA wait used only by a typed protocol that does
+// not attach the PTX acquire qualifier, such as FA4's interior P-ready edge.
+
+__device__ __forceinline__ void mbarrier_wait_relaxed(int mbar_addr, int phase) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "LAB_WAIT_RELAXED:\n\t"
+        "mbarrier.try_wait.parity.shared::cta.b64"
+        " P1, [%0], %1, 10000000;\n\t"
+        "@P1 bra.uni DONE_RELAXED;\n\t"
+        "bra.uni LAB_WAIT_RELAXED;\n\t"
+        "DONE_RELAXED:\n\t"
+        "}\n"
+        :: "r"(mbar_addr), "r"(phase) : "memory");
 }
 
 // Exact source ports may request the PTX suspendTimeHint operand explicitly.
@@ -324,7 +346,7 @@ __device__ __forceinline__ uint32_t make_warp_uniform(uint32_t val) {
     return result;
 }
 
-#define CAKE_INF CUDART_INF_F
+#define FLASHINFER_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
 #define THREADS 32
 
@@ -343,41 +365,52 @@ kernel_cake_blackwell_all_gather_matmul_barrier_ws2_p0(int32_t pg_world, int32_t
     const int num_bids = gridDim.x;
 
     // === Task calls (dependency order) ===
-    if (elect_sync()) {
-        // nvlink_barrier(pg_flags) phase=0
-        {
-            const int __ws = pg_world;
-            const int __me = pg_rank;
-            const int __slot = 0;
-            unsigned* __local_flag = pg_flags[__me] + __slot;
-            unsigned __old_sense = 0u;
-            const unsigned __delta = (__me == 0) ? (0x80000000u - (unsigned)(__ws - 1)) : 1u;
+    // nvlink_barrier(pg_flags) phase=0 owner_warp=0
+    {
+        const int __ws = pg_world;
+        const int __me = pg_rank;
+        const int __warp = warp;
+        const int __lane = lane;
+        if (__warp == 0) {
+            unsigned* __local_epoch = pg_flags[__me] + 0;
+            unsigned __previous_epoch;
+            asm volatile("ld.relaxed.sys.global.u32 %0, [%1];"
+                : "=r"(__previous_epoch) : "l"(__local_epoch) : "memory");
+            const unsigned __epoch = __previous_epoch + 1u;
+            const int __bank = (int)(__epoch & 1u);
+            const int __mailbox_base = 2 + (0 * 2 + __bank) * __ws;
             asm volatile("fence.proxy.async.global;" ::: "memory");
-            for (int __r = 0; __r < __ws; ++__r) {
-                unsigned* __peer_flag = pg_flags[__r] + __slot;
-                unsigned __old_peer;
-                asm volatile("atom.add.release.sys.u32 %0, [%1], %2;"
-                    : "=r"(__old_peer) : "l"(__peer_flag), "r"(__delta) : "memory");
-                if (__r == __me) __old_sense = __old_peer;
+            if (__lane < __ws) {
+                unsigned* __peer_mailbox = pg_flags[__lane] + __mailbox_base + __me;
+                asm volatile("st.release.sys.global.u32 [%0], %1;"
+                    :: "l"(__peer_mailbox), "r"(__epoch) : "memory");
+                unsigned* __local_mailbox = pg_flags[__me] + __mailbox_base + __lane;
+                while (true) {
+                    unsigned __v;
+                    asm volatile("ld.relaxed.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_mailbox) : "memory");
+                    if (__v != __epoch) continue;
+                    asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_mailbox) : "memory");
+                    if (__v == __epoch) break;
+                }
+                asm volatile("fence.proxy.alias;" ::: "memory");
             }
-            asm volatile("fence.proxy.alias;" ::: "memory");
-            while (true) {
-                unsigned __v;
-                asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_flag) : "memory");
-                if (((__old_sense ^ __v) & 0x80000000u) != 0u) break;
-            }
+            __syncwarp();
             asm volatile("fence.proxy.async.global;" ::: "memory");
+            if (__lane == 0) {
+                asm volatile("st.release.sys.global.u32 [%0], %1;"
+                    :: "l"(__local_epoch), "r"(__epoch) : "memory");
+            }
         }
     }
 }
 
 } // extern "C"
 
-#undef CAKE_INF
+#undef FLASHINFER_INF
 #undef NUM_MAIN_STAGES
 #undef THREADS
 
-#define CAKE_INF CUDART_INF_F
+#define FLASHINFER_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
 #define THREADS 32
 
@@ -396,41 +429,52 @@ kernel_cake_blackwell_all_gather_matmul_barrier_ws2_p1(int32_t pg_world, int32_t
     const int num_bids = gridDim.x;
 
     // === Task calls (dependency order) ===
-    if (elect_sync()) {
-        // nvlink_barrier(pg_flags) phase=1
-        {
-            const int __ws = pg_world;
-            const int __me = pg_rank;
-            const int __slot = 1;
-            unsigned* __local_flag = pg_flags[__me] + __slot;
-            unsigned __old_sense = 0u;
-            const unsigned __delta = (__me == 0) ? (0x80000000u - (unsigned)(__ws - 1)) : 1u;
+    // nvlink_barrier(pg_flags) phase=1 owner_warp=0
+    {
+        const int __ws = pg_world;
+        const int __me = pg_rank;
+        const int __warp = warp;
+        const int __lane = lane;
+        if (__warp == 0) {
+            unsigned* __local_epoch = pg_flags[__me] + 1;
+            unsigned __previous_epoch;
+            asm volatile("ld.relaxed.sys.global.u32 %0, [%1];"
+                : "=r"(__previous_epoch) : "l"(__local_epoch) : "memory");
+            const unsigned __epoch = __previous_epoch + 1u;
+            const int __bank = (int)(__epoch & 1u);
+            const int __mailbox_base = 2 + (1 * 2 + __bank) * __ws;
             asm volatile("fence.proxy.async.global;" ::: "memory");
-            for (int __r = 0; __r < __ws; ++__r) {
-                unsigned* __peer_flag = pg_flags[__r] + __slot;
-                unsigned __old_peer;
-                asm volatile("atom.add.release.sys.u32 %0, [%1], %2;"
-                    : "=r"(__old_peer) : "l"(__peer_flag), "r"(__delta) : "memory");
-                if (__r == __me) __old_sense = __old_peer;
+            if (__lane < __ws) {
+                unsigned* __peer_mailbox = pg_flags[__lane] + __mailbox_base + __me;
+                asm volatile("st.release.sys.global.u32 [%0], %1;"
+                    :: "l"(__peer_mailbox), "r"(__epoch) : "memory");
+                unsigned* __local_mailbox = pg_flags[__me] + __mailbox_base + __lane;
+                while (true) {
+                    unsigned __v;
+                    asm volatile("ld.relaxed.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_mailbox) : "memory");
+                    if (__v != __epoch) continue;
+                    asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_mailbox) : "memory");
+                    if (__v == __epoch) break;
+                }
+                asm volatile("fence.proxy.alias;" ::: "memory");
             }
-            asm volatile("fence.proxy.alias;" ::: "memory");
-            while (true) {
-                unsigned __v;
-                asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_flag) : "memory");
-                if (((__old_sense ^ __v) & 0x80000000u) != 0u) break;
-            }
+            __syncwarp();
             asm volatile("fence.proxy.async.global;" ::: "memory");
+            if (__lane == 0) {
+                asm volatile("st.release.sys.global.u32 [%0], %1;"
+                    :: "l"(__local_epoch), "r"(__epoch) : "memory");
+            }
         }
     }
 }
 
 } // extern "C"
 
-#undef CAKE_INF
+#undef FLASHINFER_INF
 #undef NUM_MAIN_STAGES
 #undef THREADS
 
-#define CAKE_INF CUDART_INF_F
+#define FLASHINFER_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
 #define THREADS 32
 
@@ -449,41 +493,52 @@ kernel_cake_blackwell_all_gather_matmul_barrier_ws4_p0(int32_t pg_world, int32_t
     const int num_bids = gridDim.x;
 
     // === Task calls (dependency order) ===
-    if (elect_sync()) {
-        // nvlink_barrier(pg_flags) phase=0
-        {
-            const int __ws = pg_world;
-            const int __me = pg_rank;
-            const int __slot = 0;
-            unsigned* __local_flag = pg_flags[__me] + __slot;
-            unsigned __old_sense = 0u;
-            const unsigned __delta = (__me == 0) ? (0x80000000u - (unsigned)(__ws - 1)) : 1u;
+    // nvlink_barrier(pg_flags) phase=0 owner_warp=0
+    {
+        const int __ws = pg_world;
+        const int __me = pg_rank;
+        const int __warp = warp;
+        const int __lane = lane;
+        if (__warp == 0) {
+            unsigned* __local_epoch = pg_flags[__me] + 0;
+            unsigned __previous_epoch;
+            asm volatile("ld.relaxed.sys.global.u32 %0, [%1];"
+                : "=r"(__previous_epoch) : "l"(__local_epoch) : "memory");
+            const unsigned __epoch = __previous_epoch + 1u;
+            const int __bank = (int)(__epoch & 1u);
+            const int __mailbox_base = 2 + (0 * 2 + __bank) * __ws;
             asm volatile("fence.proxy.async.global;" ::: "memory");
-            for (int __r = 0; __r < __ws; ++__r) {
-                unsigned* __peer_flag = pg_flags[__r] + __slot;
-                unsigned __old_peer;
-                asm volatile("atom.add.release.sys.u32 %0, [%1], %2;"
-                    : "=r"(__old_peer) : "l"(__peer_flag), "r"(__delta) : "memory");
-                if (__r == __me) __old_sense = __old_peer;
+            if (__lane < __ws) {
+                unsigned* __peer_mailbox = pg_flags[__lane] + __mailbox_base + __me;
+                asm volatile("st.release.sys.global.u32 [%0], %1;"
+                    :: "l"(__peer_mailbox), "r"(__epoch) : "memory");
+                unsigned* __local_mailbox = pg_flags[__me] + __mailbox_base + __lane;
+                while (true) {
+                    unsigned __v;
+                    asm volatile("ld.relaxed.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_mailbox) : "memory");
+                    if (__v != __epoch) continue;
+                    asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_mailbox) : "memory");
+                    if (__v == __epoch) break;
+                }
+                asm volatile("fence.proxy.alias;" ::: "memory");
             }
-            asm volatile("fence.proxy.alias;" ::: "memory");
-            while (true) {
-                unsigned __v;
-                asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_flag) : "memory");
-                if (((__old_sense ^ __v) & 0x80000000u) != 0u) break;
-            }
+            __syncwarp();
             asm volatile("fence.proxy.async.global;" ::: "memory");
+            if (__lane == 0) {
+                asm volatile("st.release.sys.global.u32 [%0], %1;"
+                    :: "l"(__local_epoch), "r"(__epoch) : "memory");
+            }
         }
     }
 }
 
 } // extern "C"
 
-#undef CAKE_INF
+#undef FLASHINFER_INF
 #undef NUM_MAIN_STAGES
 #undef THREADS
 
-#define CAKE_INF CUDART_INF_F
+#define FLASHINFER_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
 #define THREADS 32
 
@@ -502,41 +557,52 @@ kernel_cake_blackwell_all_gather_matmul_barrier_ws4_p1(int32_t pg_world, int32_t
     const int num_bids = gridDim.x;
 
     // === Task calls (dependency order) ===
-    if (elect_sync()) {
-        // nvlink_barrier(pg_flags) phase=1
-        {
-            const int __ws = pg_world;
-            const int __me = pg_rank;
-            const int __slot = 1;
-            unsigned* __local_flag = pg_flags[__me] + __slot;
-            unsigned __old_sense = 0u;
-            const unsigned __delta = (__me == 0) ? (0x80000000u - (unsigned)(__ws - 1)) : 1u;
+    // nvlink_barrier(pg_flags) phase=1 owner_warp=0
+    {
+        const int __ws = pg_world;
+        const int __me = pg_rank;
+        const int __warp = warp;
+        const int __lane = lane;
+        if (__warp == 0) {
+            unsigned* __local_epoch = pg_flags[__me] + 1;
+            unsigned __previous_epoch;
+            asm volatile("ld.relaxed.sys.global.u32 %0, [%1];"
+                : "=r"(__previous_epoch) : "l"(__local_epoch) : "memory");
+            const unsigned __epoch = __previous_epoch + 1u;
+            const int __bank = (int)(__epoch & 1u);
+            const int __mailbox_base = 2 + (1 * 2 + __bank) * __ws;
             asm volatile("fence.proxy.async.global;" ::: "memory");
-            for (int __r = 0; __r < __ws; ++__r) {
-                unsigned* __peer_flag = pg_flags[__r] + __slot;
-                unsigned __old_peer;
-                asm volatile("atom.add.release.sys.u32 %0, [%1], %2;"
-                    : "=r"(__old_peer) : "l"(__peer_flag), "r"(__delta) : "memory");
-                if (__r == __me) __old_sense = __old_peer;
+            if (__lane < __ws) {
+                unsigned* __peer_mailbox = pg_flags[__lane] + __mailbox_base + __me;
+                asm volatile("st.release.sys.global.u32 [%0], %1;"
+                    :: "l"(__peer_mailbox), "r"(__epoch) : "memory");
+                unsigned* __local_mailbox = pg_flags[__me] + __mailbox_base + __lane;
+                while (true) {
+                    unsigned __v;
+                    asm volatile("ld.relaxed.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_mailbox) : "memory");
+                    if (__v != __epoch) continue;
+                    asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_mailbox) : "memory");
+                    if (__v == __epoch) break;
+                }
+                asm volatile("fence.proxy.alias;" ::: "memory");
             }
-            asm volatile("fence.proxy.alias;" ::: "memory");
-            while (true) {
-                unsigned __v;
-                asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_flag) : "memory");
-                if (((__old_sense ^ __v) & 0x80000000u) != 0u) break;
-            }
+            __syncwarp();
             asm volatile("fence.proxy.async.global;" ::: "memory");
+            if (__lane == 0) {
+                asm volatile("st.release.sys.global.u32 [%0], %1;"
+                    :: "l"(__local_epoch), "r"(__epoch) : "memory");
+            }
         }
     }
 }
 
 } // extern "C"
 
-#undef CAKE_INF
+#undef FLASHINFER_INF
 #undef NUM_MAIN_STAGES
 #undef THREADS
 
-#define CAKE_INF CUDART_INF_F
+#define FLASHINFER_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
 #define THREADS 32
 
@@ -555,41 +621,52 @@ kernel_cake_blackwell_all_gather_matmul_barrier_ws8_p0(int32_t pg_world, int32_t
     const int num_bids = gridDim.x;
 
     // === Task calls (dependency order) ===
-    if (elect_sync()) {
-        // nvlink_barrier(pg_flags) phase=0
-        {
-            const int __ws = pg_world;
-            const int __me = pg_rank;
-            const int __slot = 0;
-            unsigned* __local_flag = pg_flags[__me] + __slot;
-            unsigned __old_sense = 0u;
-            const unsigned __delta = (__me == 0) ? (0x80000000u - (unsigned)(__ws - 1)) : 1u;
+    // nvlink_barrier(pg_flags) phase=0 owner_warp=0
+    {
+        const int __ws = pg_world;
+        const int __me = pg_rank;
+        const int __warp = warp;
+        const int __lane = lane;
+        if (__warp == 0) {
+            unsigned* __local_epoch = pg_flags[__me] + 0;
+            unsigned __previous_epoch;
+            asm volatile("ld.relaxed.sys.global.u32 %0, [%1];"
+                : "=r"(__previous_epoch) : "l"(__local_epoch) : "memory");
+            const unsigned __epoch = __previous_epoch + 1u;
+            const int __bank = (int)(__epoch & 1u);
+            const int __mailbox_base = 2 + (0 * 2 + __bank) * __ws;
             asm volatile("fence.proxy.async.global;" ::: "memory");
-            for (int __r = 0; __r < __ws; ++__r) {
-                unsigned* __peer_flag = pg_flags[__r] + __slot;
-                unsigned __old_peer;
-                asm volatile("atom.add.release.sys.u32 %0, [%1], %2;"
-                    : "=r"(__old_peer) : "l"(__peer_flag), "r"(__delta) : "memory");
-                if (__r == __me) __old_sense = __old_peer;
+            if (__lane < __ws) {
+                unsigned* __peer_mailbox = pg_flags[__lane] + __mailbox_base + __me;
+                asm volatile("st.release.sys.global.u32 [%0], %1;"
+                    :: "l"(__peer_mailbox), "r"(__epoch) : "memory");
+                unsigned* __local_mailbox = pg_flags[__me] + __mailbox_base + __lane;
+                while (true) {
+                    unsigned __v;
+                    asm volatile("ld.relaxed.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_mailbox) : "memory");
+                    if (__v != __epoch) continue;
+                    asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_mailbox) : "memory");
+                    if (__v == __epoch) break;
+                }
+                asm volatile("fence.proxy.alias;" ::: "memory");
             }
-            asm volatile("fence.proxy.alias;" ::: "memory");
-            while (true) {
-                unsigned __v;
-                asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_flag) : "memory");
-                if (((__old_sense ^ __v) & 0x80000000u) != 0u) break;
-            }
+            __syncwarp();
             asm volatile("fence.proxy.async.global;" ::: "memory");
+            if (__lane == 0) {
+                asm volatile("st.release.sys.global.u32 [%0], %1;"
+                    :: "l"(__local_epoch), "r"(__epoch) : "memory");
+            }
         }
     }
 }
 
 } // extern "C"
 
-#undef CAKE_INF
+#undef FLASHINFER_INF
 #undef NUM_MAIN_STAGES
 #undef THREADS
 
-#define CAKE_INF CUDART_INF_F
+#define FLASHINFER_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
 #define THREADS 32
 
@@ -608,41 +685,52 @@ kernel_cake_blackwell_all_gather_matmul_barrier_ws8_p1(int32_t pg_world, int32_t
     const int num_bids = gridDim.x;
 
     // === Task calls (dependency order) ===
-    if (elect_sync()) {
-        // nvlink_barrier(pg_flags) phase=1
-        {
-            const int __ws = pg_world;
-            const int __me = pg_rank;
-            const int __slot = 1;
-            unsigned* __local_flag = pg_flags[__me] + __slot;
-            unsigned __old_sense = 0u;
-            const unsigned __delta = (__me == 0) ? (0x80000000u - (unsigned)(__ws - 1)) : 1u;
+    // nvlink_barrier(pg_flags) phase=1 owner_warp=0
+    {
+        const int __ws = pg_world;
+        const int __me = pg_rank;
+        const int __warp = warp;
+        const int __lane = lane;
+        if (__warp == 0) {
+            unsigned* __local_epoch = pg_flags[__me] + 1;
+            unsigned __previous_epoch;
+            asm volatile("ld.relaxed.sys.global.u32 %0, [%1];"
+                : "=r"(__previous_epoch) : "l"(__local_epoch) : "memory");
+            const unsigned __epoch = __previous_epoch + 1u;
+            const int __bank = (int)(__epoch & 1u);
+            const int __mailbox_base = 2 + (1 * 2 + __bank) * __ws;
             asm volatile("fence.proxy.async.global;" ::: "memory");
-            for (int __r = 0; __r < __ws; ++__r) {
-                unsigned* __peer_flag = pg_flags[__r] + __slot;
-                unsigned __old_peer;
-                asm volatile("atom.add.release.sys.u32 %0, [%1], %2;"
-                    : "=r"(__old_peer) : "l"(__peer_flag), "r"(__delta) : "memory");
-                if (__r == __me) __old_sense = __old_peer;
+            if (__lane < __ws) {
+                unsigned* __peer_mailbox = pg_flags[__lane] + __mailbox_base + __me;
+                asm volatile("st.release.sys.global.u32 [%0], %1;"
+                    :: "l"(__peer_mailbox), "r"(__epoch) : "memory");
+                unsigned* __local_mailbox = pg_flags[__me] + __mailbox_base + __lane;
+                while (true) {
+                    unsigned __v;
+                    asm volatile("ld.relaxed.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_mailbox) : "memory");
+                    if (__v != __epoch) continue;
+                    asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_mailbox) : "memory");
+                    if (__v == __epoch) break;
+                }
+                asm volatile("fence.proxy.alias;" ::: "memory");
             }
-            asm volatile("fence.proxy.alias;" ::: "memory");
-            while (true) {
-                unsigned __v;
-                asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(__v) : "l"(__local_flag) : "memory");
-                if (((__old_sense ^ __v) & 0x80000000u) != 0u) break;
-            }
+            __syncwarp();
             asm volatile("fence.proxy.async.global;" ::: "memory");
+            if (__lane == 0) {
+                asm volatile("st.release.sys.global.u32 [%0], %1;"
+                    :: "l"(__local_epoch), "r"(__epoch) : "memory");
+            }
         }
     }
 }
 
 } // extern "C"
 
-#undef CAKE_INF
+#undef FLASHINFER_INF
 #undef NUM_MAIN_STAGES
 #undef THREADS
 
-#define CAKE_INF CUDART_INF_F
+#define FLASHINFER_INF CUDART_INF_F
 #define TMEM_NCOLS 512
 #define TMEM_ACCUM_OFFSET 0
 #define NUM_TMA_PIPE_STAGES 4
@@ -659,7 +747,7 @@ kernel_cake_blackwell_all_gather_matmul_barrier_ws8_p1(int32_t pg_world, int32_t
 extern "C" {
 
 __global__ __launch_bounds__(192) void
-kernel_cake_blackwell_all_gather_matmul_float16_ws2(CakeTensorMap const* A_local, CakeTensorMap const* A_scratch, CakeTensorMap const* B, __half* __restrict__ C, __half* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
+kernel_cake_blackwell_all_gather_matmul_float16_ws2(FlashInferTensorMap const* A_local, FlashInferTensorMap const* A_scratch, FlashInferTensorMap const* B, __half* __restrict__ C, __half* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
 {
     const int tid = threadIdx.x;
     const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
@@ -727,6 +815,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws2(CakeTensorMap const* A_local
     if (warp == 0) {
         int _tmem_hold = smem + 96;
         asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
+        __syncwarp();
         asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
     }
 
@@ -931,7 +1020,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws2(CakeTensorMap const* A_local
 
 } // extern "C"
 
-#undef CAKE_INF
+#undef FLASHINFER_INF
 #undef NUM_MAINLOOP_PIPE_STAGES
 #undef NUM_TMA_PIPE_STAGES
 #undef SMEM_SMEM_A_OFF
@@ -951,7 +1040,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws2(CakeTensorMap const* A_local
 #undef smem_b_addr
 #undef tma_full_addr
 
-#define CAKE_INF CUDART_INF_F
+#define FLASHINFER_INF CUDART_INF_F
 #define TMEM_NCOLS 512
 #define TMEM_ACCUM_OFFSET 0
 #define NUM_TMA_PIPE_STAGES 4
@@ -968,7 +1057,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws2(CakeTensorMap const* A_local
 extern "C" {
 
 __global__ __launch_bounds__(192) void
-kernel_cake_blackwell_all_gather_matmul_bfloat16_ws2(CakeTensorMap const* A_local, CakeTensorMap const* A_scratch, CakeTensorMap const* B, __nv_bfloat16* __restrict__ C, __nv_bfloat16* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
+kernel_cake_blackwell_all_gather_matmul_bfloat16_ws2(FlashInferTensorMap const* A_local, FlashInferTensorMap const* A_scratch, FlashInferTensorMap const* B, __nv_bfloat16* __restrict__ C, __nv_bfloat16* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
 {
     const int tid = threadIdx.x;
     const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
@@ -1036,6 +1125,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws2(CakeTensorMap const* A_loca
     if (warp == 0) {
         int _tmem_hold = smem + 96;
         asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
+        __syncwarp();
         asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
     }
 
@@ -1240,7 +1330,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws2(CakeTensorMap const* A_loca
 
 } // extern "C"
 
-#undef CAKE_INF
+#undef FLASHINFER_INF
 #undef NUM_MAINLOOP_PIPE_STAGES
 #undef NUM_TMA_PIPE_STAGES
 #undef SMEM_SMEM_A_OFF
@@ -1260,7 +1350,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws2(CakeTensorMap const* A_loca
 #undef smem_b_addr
 #undef tma_full_addr
 
-#define CAKE_INF CUDART_INF_F
+#define FLASHINFER_INF CUDART_INF_F
 #define TMEM_NCOLS 512
 #define TMEM_ACCUM_OFFSET 0
 #define NUM_TMA_PIPE_STAGES 4
@@ -1277,7 +1367,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws2(CakeTensorMap const* A_loca
 extern "C" {
 
 __global__ __launch_bounds__(192) void
-kernel_cake_blackwell_all_gather_matmul_float16_ws4(CakeTensorMap const* A_local, CakeTensorMap const* A_scratch, CakeTensorMap const* B, __half* __restrict__ C, __half* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
+kernel_cake_blackwell_all_gather_matmul_float16_ws4(FlashInferTensorMap const* A_local, FlashInferTensorMap const* A_scratch, FlashInferTensorMap const* B, __half* __restrict__ C, __half* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
 {
     const int tid = threadIdx.x;
     const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
@@ -1345,6 +1435,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws4(CakeTensorMap const* A_local
     if (warp == 0) {
         int _tmem_hold = smem + 96;
         asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
+        __syncwarp();
         asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
     }
 
@@ -1549,7 +1640,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws4(CakeTensorMap const* A_local
 
 } // extern "C"
 
-#undef CAKE_INF
+#undef FLASHINFER_INF
 #undef NUM_MAINLOOP_PIPE_STAGES
 #undef NUM_TMA_PIPE_STAGES
 #undef SMEM_SMEM_A_OFF
@@ -1569,7 +1660,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws4(CakeTensorMap const* A_local
 #undef smem_b_addr
 #undef tma_full_addr
 
-#define CAKE_INF CUDART_INF_F
+#define FLASHINFER_INF CUDART_INF_F
 #define TMEM_NCOLS 512
 #define TMEM_ACCUM_OFFSET 0
 #define NUM_TMA_PIPE_STAGES 4
@@ -1586,7 +1677,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws4(CakeTensorMap const* A_local
 extern "C" {
 
 __global__ __launch_bounds__(192) void
-kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4(CakeTensorMap const* A_local, CakeTensorMap const* A_scratch, CakeTensorMap const* B, __nv_bfloat16* __restrict__ C, __nv_bfloat16* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
+kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4(FlashInferTensorMap const* A_local, FlashInferTensorMap const* A_scratch, FlashInferTensorMap const* B, __nv_bfloat16* __restrict__ C, __nv_bfloat16* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
 {
     const int tid = threadIdx.x;
     const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
@@ -1654,6 +1745,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4(CakeTensorMap const* A_loca
     if (warp == 0) {
         int _tmem_hold = smem + 96;
         asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
+        __syncwarp();
         asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
     }
 
@@ -1858,7 +1950,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4(CakeTensorMap const* A_loca
 
 } // extern "C"
 
-#undef CAKE_INF
+#undef FLASHINFER_INF
 #undef NUM_MAINLOOP_PIPE_STAGES
 #undef NUM_TMA_PIPE_STAGES
 #undef SMEM_SMEM_A_OFF
@@ -1878,7 +1970,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4(CakeTensorMap const* A_loca
 #undef smem_b_addr
 #undef tma_full_addr
 
-#define CAKE_INF CUDART_INF_F
+#define FLASHINFER_INF CUDART_INF_F
 #define TMEM_NCOLS 512
 #define TMEM_ACCUM_OFFSET 0
 #define NUM_TMA_PIPE_STAGES 4
@@ -1895,7 +1987,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4(CakeTensorMap const* A_loca
 extern "C" {
 
 __global__ __launch_bounds__(192) void
-kernel_cake_blackwell_all_gather_matmul_float16_ws8(CakeTensorMap const* A_local, CakeTensorMap const* A_scratch, CakeTensorMap const* B, __half* __restrict__ C, __half* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
+kernel_cake_blackwell_all_gather_matmul_float16_ws8(FlashInferTensorMap const* A_local, FlashInferTensorMap const* A_scratch, FlashInferTensorMap const* B, __half* __restrict__ C, __half* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
 {
     const int tid = threadIdx.x;
     const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
@@ -1963,6 +2055,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws8(CakeTensorMap const* A_local
     if (warp == 0) {
         int _tmem_hold = smem + 96;
         asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
+        __syncwarp();
         asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
     }
 
@@ -2167,7 +2260,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws8(CakeTensorMap const* A_local
 
 } // extern "C"
 
-#undef CAKE_INF
+#undef FLASHINFER_INF
 #undef NUM_MAINLOOP_PIPE_STAGES
 #undef NUM_TMA_PIPE_STAGES
 #undef SMEM_SMEM_A_OFF
@@ -2187,7 +2280,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws8(CakeTensorMap const* A_local
 #undef smem_b_addr
 #undef tma_full_addr
 
-#define CAKE_INF CUDART_INF_F
+#define FLASHINFER_INF CUDART_INF_F
 #define TMEM_NCOLS 512
 #define TMEM_ACCUM_OFFSET 0
 #define NUM_TMA_PIPE_STAGES 4
@@ -2204,7 +2297,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws8(CakeTensorMap const* A_local
 extern "C" {
 
 __global__ __launch_bounds__(192) void
-kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(CakeTensorMap const* A_local, CakeTensorMap const* A_scratch, CakeTensorMap const* B, __nv_bfloat16* __restrict__ C, __nv_bfloat16* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
+kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(FlashInferTensorMap const* A_local, FlashInferTensorMap const* A_scratch, FlashInferTensorMap const* B, __nv_bfloat16* __restrict__ C, __nv_bfloat16* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
 {
     const int tid = threadIdx.x;
     const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
@@ -2272,6 +2365,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(CakeTensorMap const* A_loca
     if (warp == 0) {
         int _tmem_hold = smem + 96;
         asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
+        __syncwarp();
         asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
     }
 
@@ -2476,7 +2570,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(CakeTensorMap const* A_loca
 
 } // extern "C"
 
-#undef CAKE_INF
+#undef FLASHINFER_INF
 #undef NUM_MAINLOOP_PIPE_STAGES
 #undef NUM_TMA_PIPE_STAGES
 #undef SMEM_SMEM_A_OFF
@@ -2496,7 +2590,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(CakeTensorMap const* A_loca
 #undef smem_b_addr
 #undef tma_full_addr
 
-#define CAKE_INF CUDART_INF_F
+#define FLASHINFER_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
 #define THREADS 128
 
@@ -2541,6 +2635,6 @@ kernel_cake_blackwell_all_gather_matmul_fused_peer_copy(unsigned int* __restrict
 
 } // extern "C"
 
-#undef CAKE_INF
+#undef FLASHINFER_INF
 #undef NUM_MAIN_STAGES
 #undef THREADS

--- a/csrc/cake_all_gather_matmul/sm103a/cake_all_gather_matmul_kernels.cu
+++ b/csrc/cake_all_gather_matmul/sm103a/cake_all_gather_matmul_kernels.cu
@@ -81,40 +81,22 @@ __device__ __forceinline__ uint32_t mbarrier_try_wait_cluster(int mbar_addr, int
     return token;
 }
 
-
-// CTA-local pipelines have short, resident producer/consumer edges.  Omitting
-// suspendTimeHint keeps a miss on the lightweight TRYWAIT retry path; the
-// explicit loop still makes this helper blocking until acquire succeeds.
+// Match CUTLASS ClusterBarrier::wait: a large suspendTimeHint lets the hardware
+// take the blocking phase-check slowpath instead of spinning on TRYWAIT misses.
 
 __device__ __forceinline__ void mbarrier_wait(int mbar_addr, int phase) {
+    uint32_t ticks = 0x989680;
     asm volatile(
         "{\n\t"
         ".reg .pred P1;\n\t"
         "LAB_WAIT:\n\t"
         "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64"
-        " P1, [%0], %1;\n\t"
+        " P1, [%0], %1, %2;\n\t"
         "@P1 bra.uni DONE;\n\t"
         "bra.uni LAB_WAIT;\n\t"
         "DONE:\n\t"
         "}\n"
-        :: "r"(mbar_addr), "r"(phase) : "memory");
-}
-
-// Source-faithful relaxed CTA wait used only by a typed protocol that does
-// not attach the PTX acquire qualifier, such as FA4's interior P-ready edge.
-
-__device__ __forceinline__ void mbarrier_wait_relaxed(int mbar_addr, int phase) {
-    asm volatile(
-        "{\n\t"
-        ".reg .pred P1;\n\t"
-        "LAB_WAIT_RELAXED:\n\t"
-        "mbarrier.try_wait.parity.shared::cta.b64"
-        " P1, [%0], %1, 10000000;\n\t"
-        "@P1 bra.uni DONE_RELAXED;\n\t"
-        "bra.uni LAB_WAIT_RELAXED;\n\t"
-        "DONE_RELAXED:\n\t"
-        "}\n"
-        :: "r"(mbar_addr), "r"(phase) : "memory");
+        :: "r"(mbar_addr), "r"(phase), "r"(ticks) : "memory");
 }
 
 // Exact source ports may request the PTX suspendTimeHint operand explicitly.
@@ -696,6 +678,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws2(CakeTensorMap const* A_local
 
     const int bid = blockIdx.x;
     const int num_bids = gridDim.x;
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 96);
     if (tid == 0) {
         asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(A_local)) : "memory");
         asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(A_scratch)) : "memory");
@@ -741,7 +724,6 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws2(CakeTensorMap const* A_local
     __syncwarp();
 
     // TMEM alloc (512 columns, 512 used)
-    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 96);
     if (warp == 0) {
         int _tmem_hold = smem + 96;
         asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
@@ -1005,6 +987,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws2(CakeTensorMap const* A_loca
 
     const int bid = blockIdx.x;
     const int num_bids = gridDim.x;
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 96);
     if (tid == 0) {
         asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(A_local)) : "memory");
         asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(A_scratch)) : "memory");
@@ -1050,7 +1033,6 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws2(CakeTensorMap const* A_loca
     __syncwarp();
 
     // TMEM alloc (512 columns, 512 used)
-    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 96);
     if (warp == 0) {
         int _tmem_hold = smem + 96;
         asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
@@ -1314,6 +1296,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws4(CakeTensorMap const* A_local
 
     const int bid = blockIdx.x;
     const int num_bids = gridDim.x;
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 96);
     if (tid == 0) {
         asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(A_local)) : "memory");
         asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(A_scratch)) : "memory");
@@ -1359,7 +1342,6 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws4(CakeTensorMap const* A_local
     __syncwarp();
 
     // TMEM alloc (512 columns, 512 used)
-    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 96);
     if (warp == 0) {
         int _tmem_hold = smem + 96;
         asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
@@ -1623,6 +1605,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4(CakeTensorMap const* A_loca
 
     const int bid = blockIdx.x;
     const int num_bids = gridDim.x;
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 96);
     if (tid == 0) {
         asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(A_local)) : "memory");
         asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(A_scratch)) : "memory");
@@ -1668,7 +1651,6 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4(CakeTensorMap const* A_loca
     __syncwarp();
 
     // TMEM alloc (512 columns, 512 used)
-    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 96);
     if (warp == 0) {
         int _tmem_hold = smem + 96;
         asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
@@ -1932,6 +1914,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws8(CakeTensorMap const* A_local
 
     const int bid = blockIdx.x;
     const int num_bids = gridDim.x;
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 96);
     if (tid == 0) {
         asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(A_local)) : "memory");
         asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(A_scratch)) : "memory");
@@ -1977,7 +1960,6 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws8(CakeTensorMap const* A_local
     __syncwarp();
 
     // TMEM alloc (512 columns, 512 used)
-    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 96);
     if (warp == 0) {
         int _tmem_hold = smem + 96;
         asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
@@ -2241,6 +2223,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(CakeTensorMap const* A_loca
 
     const int bid = blockIdx.x;
     const int num_bids = gridDim.x;
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 96);
     if (tid == 0) {
         asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(A_local)) : "memory");
         asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(A_scratch)) : "memory");
@@ -2286,7 +2269,6 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(CakeTensorMap const* A_loca
     __syncwarp();
 
     // TMEM alloc (512 columns, 512 used)
-    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 96);
     if (warp == 0) {
         int _tmem_hold = smem + 96;
         asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");

--- a/csrc/cake_all_gather_matmul/sm103a/cake_all_gather_matmul_kernels.cu
+++ b/csrc/cake_all_gather_matmul/sm103a/cake_all_gather_matmul_kernels.cu
@@ -20,11 +20,13 @@
 #include <stdint.h>
 
 // Pointer-ABI TMA descriptors are encoded by the CUDA driver and stored in
-// device memory. Keep the generated kernel pointee self-contained and
+// device memory.  Keep the generated kernel pointee self-contained and
 // layout-identical to the compiler's opaque 128-byte descriptor type.
 struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+#include <stdint.h>
 #include <cuda.h>
 #include <cuda_bf16.h>
+#include <cuda_fp8.h>
 
 #include <math_constants.h>
 
@@ -44,6 +46,11 @@ __device__ __forceinline__ uint32_t elect_sync() {
 __device__ __forceinline__ void mbarrier_init(int mbar_addr, int count) {
     asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;"
         :: "r"(mbar_addr), "r"(count) : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_init_generic(void* mbar_addr, int count) {
+    asm volatile("mbarrier.init.b64 [%0], %1;"
+        :: "l"(mbar_addr), "r"(count));
 }
 
 __device__ __forceinline__ uint32_t mbarrier_try_wait(int mbar_addr, int phase) {
@@ -74,6 +81,7 @@ __device__ __forceinline__ uint32_t mbarrier_try_wait_cluster(int mbar_addr, int
     return token;
 }
 
+
 // CTA-local pipelines have short, resident producer/consumer edges.  Omitting
 // suspendTimeHint keeps a miss on the lightweight TRYWAIT retry path; the
 // explicit loop still makes this helper blocking until acquire succeeds.
@@ -92,19 +100,104 @@ __device__ __forceinline__ void mbarrier_wait(int mbar_addr, int phase) {
         :: "r"(mbar_addr), "r"(phase) : "memory");
 }
 
+// Source-faithful relaxed CTA wait used only by a typed protocol that does
+// not attach the PTX acquire qualifier, such as FA4's interior P-ready edge.
+
+__device__ __forceinline__ void mbarrier_wait_relaxed(int mbar_addr, int phase) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "LAB_WAIT_RELAXED:\n\t"
+        "mbarrier.try_wait.parity.shared::cta.b64"
+        " P1, [%0], %1, 10000000;\n\t"
+        "@P1 bra.uni DONE_RELAXED;\n\t"
+        "bra.uni LAB_WAIT_RELAXED;\n\t"
+        "DONE_RELAXED:\n\t"
+        "}\n"
+        :: "r"(mbar_addr), "r"(phase) : "memory");
+}
+
+// Exact source ports may request the PTX suspendTimeHint operand explicitly.
+// The hint is expressed in nanoseconds and is kept separate from the canonical
+// no-hint CTA helper so unrelated schedules retain their existing retry path.
+
+__device__ __forceinline__ void mbarrier_wait_suspend(
+        int mbar_addr, int phase, uint32_t suspend_time_hint) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "LAB_WAIT_SUSPEND:\n\t"
+        "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64"
+        " P1, [%0], %1, %2;\n\t"
+        "@P1 bra.uni DONE_SUSPEND;\n\t"
+        "bra.uni LAB_WAIT_SUSPEND;\n\t"
+        "DONE_SUSPEND:\n\t"
+        "}\n"
+        :: "r"(mbar_addr), "r"(phase), "r"(suspend_time_hint) : "memory");
+}
+
 __device__ __forceinline__ void mbarrier_wait_cluster(int mbar_addr, int phase) {
-    uint32_t ticks = 0x989680;
     asm volatile(
         "{\n\t"
         ".reg .pred P1;\n\t"
         "LAB_WAIT_CLUSTER:\n\t"
         "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64"
-        " P1, [%0], %1, %2;\n\t"
+        " P1, [%0], %1;\n\t"
         "@P1 bra.uni DONE_CLUSTER;\n\t"
         "bra.uni LAB_WAIT_CLUSTER;\n\t"
         "DONE_CLUSTER:\n\t"
         "}\n"
-        :: "r"(mbar_addr), "r"(phase), "r"(ticks) : "memory");
+        :: "r"(mbar_addr), "r"(phase) : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_wait_hint(
+        int mbar_addr, int phase, uint32_t suspend_time_hint) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        ".reg .u32 WAIT_ADDR;\n\t"
+        "mov.u32 WAIT_ADDR, %0;\n\t"
+        "LAB_WAIT_HINT:\n\t"
+        "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64"
+        " P1, [WAIT_ADDR], %1, %2;\n\t"
+        "@P1 bra.uni DONE_HINT;\n\t"
+        "bra.uni LAB_WAIT_HINT;\n\t"
+        "DONE_HINT:\n\t"
+        "}\n"
+        :: "r"(mbar_addr), "r"(phase), "r"(suspend_time_hint) : "memory");
+}
+
+// Exact unqualified CTA wait used by source schedules whose PTX intentionally
+// omits the acquire qualifier while retaining a typed suspendTimeHint operand.
+
+__device__ __forceinline__ void mbarrier_wait_relaxed_hint(
+        int mbar_addr, int phase, uint32_t suspend_time_hint) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "LAB_WAIT_RELAXED_HINT:\n\t"
+        "mbarrier.try_wait.parity.shared::cta.b64"
+        " P1, [%0], %1, %2;\n\t"
+        "@P1 bra DONE_RELAXED_HINT;\n\t"
+        "bra LAB_WAIT_RELAXED_HINT;\n\t"
+        "DONE_RELAXED_HINT:\n\t"
+        "}\n"
+        :: "r"(mbar_addr), "r"(phase), "r"(suspend_time_hint));
+}
+
+__device__ __forceinline__ void mbarrier_wait_cluster_hint(
+        int mbar_addr, int phase, uint32_t suspend_time_hint) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "LAB_WAIT_CLUSTER_HINT:\n\t"
+        "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64"
+        " P1, [%0], %1, %2;\n\t"
+        "@P1 bra.uni DONE_CLUSTER_HINT;\n\t"
+        "bra.uni LAB_WAIT_CLUSTER_HINT;\n\t"
+        "DONE_CLUSTER_HINT:\n\t"
+        "}\n"
+        :: "r"(mbar_addr), "r"(phase), "r"(suspend_time_hint) : "memory");
 }
 
 __device__ __forceinline__ void mbarrier_wait_token(int mbar_addr, int phase, uint32_t token) {
@@ -113,9 +206,30 @@ __device__ __forceinline__ void mbarrier_wait_token(int mbar_addr, int phase, ui
     }
 }
 
+__device__ __forceinline__ void mbarrier_wait_token_suspend(
+        int mbar_addr, int phase, uint32_t token, uint32_t suspend_time_hint) {
+    if (token == 0) {
+        mbarrier_wait_suspend(mbar_addr, phase, suspend_time_hint);
+    }
+}
+
 __device__ __forceinline__ void mbarrier_wait_token_cluster(int mbar_addr, int phase, uint32_t token) {
     if (token == 0) {
         mbarrier_wait_cluster(mbar_addr, phase);
+    }
+}
+
+__device__ __forceinline__ void mbarrier_wait_token_hint(
+        int mbar_addr, int phase, uint32_t token, uint32_t suspend_time_hint) {
+    if (token == 0) {
+        mbarrier_wait_hint(mbar_addr, phase, suspend_time_hint);
+    }
+}
+
+__device__ __forceinline__ void mbarrier_wait_token_cluster_hint(
+        int mbar_addr, int phase, uint32_t token, uint32_t suspend_time_hint) {
+    if (token == 0) {
+        mbarrier_wait_cluster_hint(mbar_addr, phase, suspend_time_hint);
     }
 }
 
@@ -228,7 +342,7 @@ __device__ __forceinline__ uint32_t make_warp_uniform(uint32_t val) {
     return result;
 }
 
-#define LOOM_INF CUDART_INF_F
+#define CAKE_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
 #define THREADS 32
 
@@ -238,8 +352,9 @@ __global__ __launch_bounds__(32) void
 kernel_cake_blackwell_all_gather_matmul_barrier_ws2_p0(int32_t pg_world, int32_t pg_rank, unsigned* const* __restrict__ pg_flags)
 {
     const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+    const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    uint32_t lane;
+    asm("mov.u32 %0, %%laneid;" : "=r"(lane));
 
 
     const int bid = blockIdx.x;
@@ -276,11 +391,11 @@ kernel_cake_blackwell_all_gather_matmul_barrier_ws2_p0(int32_t pg_world, int32_t
 
 } // extern "C"
 
-#undef LOOM_INF
+#undef CAKE_INF
 #undef NUM_MAIN_STAGES
 #undef THREADS
 
-#define LOOM_INF CUDART_INF_F
+#define CAKE_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
 #define THREADS 32
 
@@ -290,8 +405,9 @@ __global__ __launch_bounds__(32) void
 kernel_cake_blackwell_all_gather_matmul_barrier_ws2_p1(int32_t pg_world, int32_t pg_rank, unsigned* const* __restrict__ pg_flags)
 {
     const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+    const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    uint32_t lane;
+    asm("mov.u32 %0, %%laneid;" : "=r"(lane));
 
 
     const int bid = blockIdx.x;
@@ -328,11 +444,11 @@ kernel_cake_blackwell_all_gather_matmul_barrier_ws2_p1(int32_t pg_world, int32_t
 
 } // extern "C"
 
-#undef LOOM_INF
+#undef CAKE_INF
 #undef NUM_MAIN_STAGES
 #undef THREADS
 
-#define LOOM_INF CUDART_INF_F
+#define CAKE_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
 #define THREADS 32
 
@@ -342,8 +458,9 @@ __global__ __launch_bounds__(32) void
 kernel_cake_blackwell_all_gather_matmul_barrier_ws4_p0(int32_t pg_world, int32_t pg_rank, unsigned* const* __restrict__ pg_flags)
 {
     const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+    const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    uint32_t lane;
+    asm("mov.u32 %0, %%laneid;" : "=r"(lane));
 
 
     const int bid = blockIdx.x;
@@ -380,11 +497,11 @@ kernel_cake_blackwell_all_gather_matmul_barrier_ws4_p0(int32_t pg_world, int32_t
 
 } // extern "C"
 
-#undef LOOM_INF
+#undef CAKE_INF
 #undef NUM_MAIN_STAGES
 #undef THREADS
 
-#define LOOM_INF CUDART_INF_F
+#define CAKE_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
 #define THREADS 32
 
@@ -394,8 +511,9 @@ __global__ __launch_bounds__(32) void
 kernel_cake_blackwell_all_gather_matmul_barrier_ws4_p1(int32_t pg_world, int32_t pg_rank, unsigned* const* __restrict__ pg_flags)
 {
     const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+    const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    uint32_t lane;
+    asm("mov.u32 %0, %%laneid;" : "=r"(lane));
 
 
     const int bid = blockIdx.x;
@@ -432,11 +550,11 @@ kernel_cake_blackwell_all_gather_matmul_barrier_ws4_p1(int32_t pg_world, int32_t
 
 } // extern "C"
 
-#undef LOOM_INF
+#undef CAKE_INF
 #undef NUM_MAIN_STAGES
 #undef THREADS
 
-#define LOOM_INF CUDART_INF_F
+#define CAKE_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
 #define THREADS 32
 
@@ -446,8 +564,9 @@ __global__ __launch_bounds__(32) void
 kernel_cake_blackwell_all_gather_matmul_barrier_ws8_p0(int32_t pg_world, int32_t pg_rank, unsigned* const* __restrict__ pg_flags)
 {
     const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+    const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    uint32_t lane;
+    asm("mov.u32 %0, %%laneid;" : "=r"(lane));
 
 
     const int bid = blockIdx.x;
@@ -484,11 +603,11 @@ kernel_cake_blackwell_all_gather_matmul_barrier_ws8_p0(int32_t pg_world, int32_t
 
 } // extern "C"
 
-#undef LOOM_INF
+#undef CAKE_INF
 #undef NUM_MAIN_STAGES
 #undef THREADS
 
-#define LOOM_INF CUDART_INF_F
+#define CAKE_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
 #define THREADS 32
 
@@ -498,8 +617,9 @@ __global__ __launch_bounds__(32) void
 kernel_cake_blackwell_all_gather_matmul_barrier_ws8_p1(int32_t pg_world, int32_t pg_rank, unsigned* const* __restrict__ pg_flags)
 {
     const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+    const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    uint32_t lane;
+    asm("mov.u32 %0, %%laneid;" : "=r"(lane));
 
 
     const int bid = blockIdx.x;
@@ -536,11 +656,11 @@ kernel_cake_blackwell_all_gather_matmul_barrier_ws8_p1(int32_t pg_world, int32_t
 
 } // extern "C"
 
-#undef LOOM_INF
+#undef CAKE_INF
 #undef NUM_MAIN_STAGES
 #undef THREADS
 
-#define LOOM_INF CUDART_INF_F
+#define CAKE_INF CUDART_INF_F
 #define TMEM_NCOLS 512
 #define TMEM_ACCUM_OFFSET 0
 #define NUM_TMA_PIPE_STAGES 4
@@ -560,12 +680,14 @@ __global__ __launch_bounds__(192) void
 kernel_cake_blackwell_all_gather_matmul_float16_ws2(CakeTensorMap const* A_local, CakeTensorMap const* A_scratch, CakeTensorMap const* B, __half* __restrict__ C, __half* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
 {
     const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+    const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    uint32_t lane;
+    asm("mov.u32 %0, %%laneid;" : "=r"(lane));
 
     extern __shared__ __align__(1024) char smem_raw[];
     int smem;
     smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
     const int mbar_base = smem;
     #define tma_full_addr (mbar_base + 0)
     #define mma_done_addr (mbar_base + 32)
@@ -588,7 +710,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws2(CakeTensorMap const* A_local
     __half* smem_b = reinterpret_cast<__half*>(smem_raw + 17408);
     const int smem_b_addr = smem + 17408;
 
-    // Mbarrier init (4 groups, 12 barriers)
+    // Mbarrier init (4 pipeline groups, 0 ordered-sequence groups, 12 barriers)
     // Mbarriers at smem_raw[0..96)
 
     if (warp == 0) {
@@ -771,7 +893,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws2(CakeTensorMap const* A_local
         { // epilogue_main
             unsigned int epi_stage = 0;
             const int epi_warp = warp % 4;
-            const int epi_tid = epi_warp * 32 + lane;
+            const int epi_tid = (unsigned int)(epi_warp * 32) + lane;
             unsigned int _phase_mainloop_done = 0;
             #pragma unroll 1
             for (int peer_pass_1 = 0; peer_pass_1 < 2; peer_pass_1++) {
@@ -827,7 +949,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws2(CakeTensorMap const* A_local
 
 } // extern "C"
 
-#undef LOOM_INF
+#undef CAKE_INF
 #undef NUM_MAINLOOP_PIPE_STAGES
 #undef NUM_TMA_PIPE_STAGES
 #undef SMEM_SMEM_A_OFF
@@ -846,7 +968,8 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws2(CakeTensorMap const* A_local
 #undef smem_a_addr
 #undef smem_b_addr
 #undef tma_full_addr
-#define LOOM_INF CUDART_INF_F
+
+#define CAKE_INF CUDART_INF_F
 #define TMEM_NCOLS 512
 #define TMEM_ACCUM_OFFSET 0
 #define NUM_TMA_PIPE_STAGES 4
@@ -866,12 +989,14 @@ __global__ __launch_bounds__(192) void
 kernel_cake_blackwell_all_gather_matmul_bfloat16_ws2(CakeTensorMap const* A_local, CakeTensorMap const* A_scratch, CakeTensorMap const* B, __nv_bfloat16* __restrict__ C, __nv_bfloat16* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
 {
     const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+    const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    uint32_t lane;
+    asm("mov.u32 %0, %%laneid;" : "=r"(lane));
 
     extern __shared__ __align__(1024) char smem_raw[];
     int smem;
     smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
     const int mbar_base = smem;
     #define tma_full_addr (mbar_base + 0)
     #define mma_done_addr (mbar_base + 32)
@@ -894,7 +1019,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws2(CakeTensorMap const* A_loca
     __nv_bfloat16* smem_b = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
     const int smem_b_addr = smem + 17408;
 
-    // Mbarrier init (4 groups, 12 barriers)
+    // Mbarrier init (4 pipeline groups, 0 ordered-sequence groups, 12 barriers)
     // Mbarriers at smem_raw[0..96)
 
     if (warp == 0) {
@@ -1077,7 +1202,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws2(CakeTensorMap const* A_loca
         { // epilogue_main
             unsigned int epi_stage = 0;
             const int epi_warp = warp % 4;
-            const int epi_tid = epi_warp * 32 + lane;
+            const int epi_tid = (unsigned int)(epi_warp * 32) + lane;
             unsigned int _phase_mainloop_done = 0;
             #pragma unroll 1
             for (int peer_pass_1 = 0; peer_pass_1 < 2; peer_pass_1++) {
@@ -1133,7 +1258,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws2(CakeTensorMap const* A_loca
 
 } // extern "C"
 
-#undef LOOM_INF
+#undef CAKE_INF
 #undef NUM_MAINLOOP_PIPE_STAGES
 #undef NUM_TMA_PIPE_STAGES
 #undef SMEM_SMEM_A_OFF
@@ -1152,7 +1277,8 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws2(CakeTensorMap const* A_loca
 #undef smem_a_addr
 #undef smem_b_addr
 #undef tma_full_addr
-#define LOOM_INF CUDART_INF_F
+
+#define CAKE_INF CUDART_INF_F
 #define TMEM_NCOLS 512
 #define TMEM_ACCUM_OFFSET 0
 #define NUM_TMA_PIPE_STAGES 4
@@ -1172,12 +1298,14 @@ __global__ __launch_bounds__(192) void
 kernel_cake_blackwell_all_gather_matmul_float16_ws4(CakeTensorMap const* A_local, CakeTensorMap const* A_scratch, CakeTensorMap const* B, __half* __restrict__ C, __half* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
 {
     const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+    const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    uint32_t lane;
+    asm("mov.u32 %0, %%laneid;" : "=r"(lane));
 
     extern __shared__ __align__(1024) char smem_raw[];
     int smem;
     smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
     const int mbar_base = smem;
     #define tma_full_addr (mbar_base + 0)
     #define mma_done_addr (mbar_base + 32)
@@ -1200,7 +1328,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws4(CakeTensorMap const* A_local
     __half* smem_b = reinterpret_cast<__half*>(smem_raw + 17408);
     const int smem_b_addr = smem + 17408;
 
-    // Mbarrier init (4 groups, 12 barriers)
+    // Mbarrier init (4 pipeline groups, 0 ordered-sequence groups, 12 barriers)
     // Mbarriers at smem_raw[0..96)
 
     if (warp == 0) {
@@ -1383,7 +1511,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws4(CakeTensorMap const* A_local
         { // epilogue_main
             unsigned int epi_stage = 0;
             const int epi_warp = warp % 4;
-            const int epi_tid = epi_warp * 32 + lane;
+            const int epi_tid = (unsigned int)(epi_warp * 32) + lane;
             unsigned int _phase_mainloop_done = 0;
             #pragma unroll 1
             for (int peer_pass_1 = 0; peer_pass_1 < 4; peer_pass_1++) {
@@ -1439,7 +1567,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws4(CakeTensorMap const* A_local
 
 } // extern "C"
 
-#undef LOOM_INF
+#undef CAKE_INF
 #undef NUM_MAINLOOP_PIPE_STAGES
 #undef NUM_TMA_PIPE_STAGES
 #undef SMEM_SMEM_A_OFF
@@ -1459,7 +1587,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws4(CakeTensorMap const* A_local
 #undef smem_b_addr
 #undef tma_full_addr
 
-#define LOOM_INF CUDART_INF_F
+#define CAKE_INF CUDART_INF_F
 #define TMEM_NCOLS 512
 #define TMEM_ACCUM_OFFSET 0
 #define NUM_TMA_PIPE_STAGES 4
@@ -1479,12 +1607,14 @@ __global__ __launch_bounds__(192) void
 kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4(CakeTensorMap const* A_local, CakeTensorMap const* A_scratch, CakeTensorMap const* B, __nv_bfloat16* __restrict__ C, __nv_bfloat16* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
 {
     const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+    const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    uint32_t lane;
+    asm("mov.u32 %0, %%laneid;" : "=r"(lane));
 
     extern __shared__ __align__(1024) char smem_raw[];
     int smem;
     smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
     const int mbar_base = smem;
     #define tma_full_addr (mbar_base + 0)
     #define mma_done_addr (mbar_base + 32)
@@ -1507,7 +1637,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4(CakeTensorMap const* A_loca
     __nv_bfloat16* smem_b = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
     const int smem_b_addr = smem + 17408;
 
-    // Mbarrier init (4 groups, 12 barriers)
+    // Mbarrier init (4 pipeline groups, 0 ordered-sequence groups, 12 barriers)
     // Mbarriers at smem_raw[0..96)
 
     if (warp == 0) {
@@ -1690,7 +1820,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4(CakeTensorMap const* A_loca
         { // epilogue_main
             unsigned int epi_stage = 0;
             const int epi_warp = warp % 4;
-            const int epi_tid = epi_warp * 32 + lane;
+            const int epi_tid = (unsigned int)(epi_warp * 32) + lane;
             unsigned int _phase_mainloop_done = 0;
             #pragma unroll 1
             for (int peer_pass_1 = 0; peer_pass_1 < 4; peer_pass_1++) {
@@ -1746,7 +1876,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4(CakeTensorMap const* A_loca
 
 } // extern "C"
 
-#undef LOOM_INF
+#undef CAKE_INF
 #undef NUM_MAINLOOP_PIPE_STAGES
 #undef NUM_TMA_PIPE_STAGES
 #undef SMEM_SMEM_A_OFF
@@ -1766,7 +1896,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4(CakeTensorMap const* A_loca
 #undef smem_b_addr
 #undef tma_full_addr
 
-#define LOOM_INF CUDART_INF_F
+#define CAKE_INF CUDART_INF_F
 #define TMEM_NCOLS 512
 #define TMEM_ACCUM_OFFSET 0
 #define NUM_TMA_PIPE_STAGES 4
@@ -1786,12 +1916,14 @@ __global__ __launch_bounds__(192) void
 kernel_cake_blackwell_all_gather_matmul_float16_ws8(CakeTensorMap const* A_local, CakeTensorMap const* A_scratch, CakeTensorMap const* B, __half* __restrict__ C, __half* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
 {
     const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+    const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    uint32_t lane;
+    asm("mov.u32 %0, %%laneid;" : "=r"(lane));
 
     extern __shared__ __align__(1024) char smem_raw[];
     int smem;
     smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
     const int mbar_base = smem;
     #define tma_full_addr (mbar_base + 0)
     #define mma_done_addr (mbar_base + 32)
@@ -1814,7 +1946,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws8(CakeTensorMap const* A_local
     __half* smem_b = reinterpret_cast<__half*>(smem_raw + 17408);
     const int smem_b_addr = smem + 17408;
 
-    // Mbarrier init (4 groups, 12 barriers)
+    // Mbarrier init (4 pipeline groups, 0 ordered-sequence groups, 12 barriers)
     // Mbarriers at smem_raw[0..96)
 
     if (warp == 0) {
@@ -1997,7 +2129,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws8(CakeTensorMap const* A_local
         { // epilogue_main
             unsigned int epi_stage = 0;
             const int epi_warp = warp % 4;
-            const int epi_tid = epi_warp * 32 + lane;
+            const int epi_tid = (unsigned int)(epi_warp * 32) + lane;
             unsigned int _phase_mainloop_done = 0;
             #pragma unroll 1
             for (int peer_pass_1 = 0; peer_pass_1 < 8; peer_pass_1++) {
@@ -2053,7 +2185,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws8(CakeTensorMap const* A_local
 
 } // extern "C"
 
-#undef LOOM_INF
+#undef CAKE_INF
 #undef NUM_MAINLOOP_PIPE_STAGES
 #undef NUM_TMA_PIPE_STAGES
 #undef SMEM_SMEM_A_OFF
@@ -2073,7 +2205,7 @@ kernel_cake_blackwell_all_gather_matmul_float16_ws8(CakeTensorMap const* A_local
 #undef smem_b_addr
 #undef tma_full_addr
 
-#define LOOM_INF CUDART_INF_F
+#define CAKE_INF CUDART_INF_F
 #define TMEM_NCOLS 512
 #define TMEM_ACCUM_OFFSET 0
 #define NUM_TMA_PIPE_STAGES 4
@@ -2093,12 +2225,14 @@ __global__ __launch_bounds__(192) void
 kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(CakeTensorMap const* A_local, CakeTensorMap const* A_scratch, CakeTensorMap const* B, __nv_bfloat16* __restrict__ C, __nv_bfloat16* __restrict__ scratch_payload, unsigned int* __restrict__ ready, unsigned int ready_target, int rank, int M)
 {
     const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+    const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    uint32_t lane;
+    asm("mov.u32 %0, %%laneid;" : "=r"(lane));
 
     extern __shared__ __align__(1024) char smem_raw[];
     int smem;
     smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
     const int mbar_base = smem;
     #define tma_full_addr (mbar_base + 0)
     #define mma_done_addr (mbar_base + 32)
@@ -2121,7 +2255,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(CakeTensorMap const* A_loca
     __nv_bfloat16* smem_b = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
     const int smem_b_addr = smem + 17408;
 
-    // Mbarrier init (4 groups, 12 barriers)
+    // Mbarrier init (4 pipeline groups, 0 ordered-sequence groups, 12 barriers)
     // Mbarriers at smem_raw[0..96)
 
     if (warp == 0) {
@@ -2176,7 +2310,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(CakeTensorMap const* A_loca
             unsigned int load_stage = 0;
             unsigned int load_phase = 1;
             #pragma unroll
-            for (int peer_pass = 0; peer_pass < 8; peer_pass++) {
+            for (int peer_pass = blockIdx.y; peer_pass < 8; peer_pass += gridDim.y) {
                 int peer = (rank - peer_pass + 8) % 8;
                 #pragma unroll 1
                 for (int chunk_idx = 0; chunk_idx < (M + ((M < 2432) ? M : 2432) - 1) / ((M < 2432) ? M : 2432); chunk_idx++) {
@@ -2237,7 +2371,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(CakeTensorMap const* A_loca
             unsigned int _phase_epilogue_done = 1;
             unsigned int _phase_tma_full = 0;
             #pragma unroll
-            for (int _peer_pass = 0; _peer_pass < 8; _peer_pass++) {
+            for (int _peer_pass = blockIdx.y; _peer_pass < 8; _peer_pass += gridDim.y) {
                 #pragma unroll 1
                 for (int chunk_idx_1 = 0; chunk_idx_1 < (M + ((M < 2432) ? M : 2432) - 1) / ((M < 2432) ? M : 2432); chunk_idx_1++) {
                     int rows_left_1 = M - chunk_idx_1 * ((M < 2432) ? M : 2432);
@@ -2304,10 +2438,10 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(CakeTensorMap const* A_loca
         { // epilogue_main
             unsigned int epi_stage = 0;
             const int epi_warp = warp % 4;
-            const int epi_tid = epi_warp * 32 + lane;
+            const int epi_tid = (unsigned int)(epi_warp * 32) + lane;
             unsigned int _phase_mainloop_done = 0;
             #pragma unroll 1
-            for (int peer_pass_1 = 0; peer_pass_1 < 8; peer_pass_1++) {
+            for (int peer_pass_1 = blockIdx.y; peer_pass_1 < 8; peer_pass_1 += gridDim.y) {
                 int peer_1 = (rank - peer_pass_1 + 8) % 8;
                 #pragma unroll 1
                 for (int chunk_idx_2 = 0; chunk_idx_2 < (M + ((M < 2432) ? M : 2432) - 1) / ((M < 2432) ? M : 2432); chunk_idx_2++) {
@@ -2360,7 +2494,7 @@ kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8(CakeTensorMap const* A_loca
 
 } // extern "C"
 
-#undef LOOM_INF
+#undef CAKE_INF
 #undef NUM_MAINLOOP_PIPE_STAGES
 #undef NUM_TMA_PIPE_STAGES
 #undef SMEM_SMEM_A_OFF

--- a/csrc/cake_all_gather_matmul/sm103a/manifest.json
+++ b/csrc/cake_all_gather_matmul/sm103a/manifest.json
@@ -117,6 +117,6 @@
     }
   },
   "schema_version": 1,
-  "source_sha256": "aed09c12a2d0f1151992f7e20e4d0a2997b897a54b23f3dd06cb0a303aba30fe",
+  "source_sha256": "ef39c0d6ddfa1e038fc50bdf6137e8df872142faaadfe31a3a1fbe271e11d94d",
   "tma_abi": "pointer"
 }

--- a/csrc/cake_all_gather_matmul/sm103a/manifest.json
+++ b/csrc/cake_all_gather_matmul/sm103a/manifest.json
@@ -21,6 +21,11 @@
         2048
       ]
     },
+    "world_sizes": [
+      2,
+      4,
+      8
+    ],
     "prepared_packed_qkv": {
       "dtypes": [
         "bfloat16"
@@ -33,12 +38,7 @@
           1280
         ]
       }
-    },
-    "world_sizes": [
-      2,
-      4,
-      8
-    ]
+    }
   },
   "kernel_count": 12,
   "kernel_symbols": [
@@ -68,7 +68,8 @@
     "main": {
       "block_threads": 192,
       "dynamic_smem_bytes": 197632,
-      "grid_x": "(min(M, 2432) / 128) * (N / 256)"
+      "grid_x": "(min(M, 2432) / 128) * (N / 256)",
+      "grid_y": "4 if world_size == 8 and M == 512 and N == 1280 else 1"
     }
   },
   "route_coverage": {
@@ -104,6 +105,6 @@
     }
   },
   "schema_version": 1,
-  "source_sha256": "6ba37efcba102135f0155ef5e162143ad71bc27e52699c9aae05b9d9ace99433",
+  "source_sha256": "b6100fed6f90c86ec9f882d99f6fbd2199f2fe91b458e9a82f9e4a6d20f77fdc",
   "tma_abi": "pointer"
 }

--- a/csrc/cake_all_gather_matmul/sm103a/manifest.json
+++ b/csrc/cake_all_gather_matmul/sm103a/manifest.json
@@ -105,6 +105,6 @@
     }
   },
   "schema_version": 1,
-  "source_sha256": "b6100fed6f90c86ec9f882d99f6fbd2199f2fe91b458e9a82f9e4a6d20f77fdc",
+  "source_sha256": "1eb41812ff454293bcf3ae1eee78318cc3648feb045d3788989b3b4f637ba087",
   "tma_abi": "pointer"
 }

--- a/csrc/cake_all_gather_matmul/sm103a/manifest.json
+++ b/csrc/cake_all_gather_matmul/sm103a/manifest.json
@@ -21,11 +21,6 @@
         2048
       ]
     },
-    "world_sizes": [
-      2,
-      4,
-      8
-    ],
     "prepared_packed_qkv": {
       "dtypes": [
         "bfloat16"
@@ -38,9 +33,14 @@
           1280
         ]
       }
-    }
+    },
+    "world_sizes": [
+      2,
+      4,
+      8
+    ]
   },
-  "kernel_count": 12,
+  "kernel_count": 13,
   "kernel_symbols": [
     "kernel_cake_blackwell_all_gather_matmul_barrier_ws2_p0",
     "kernel_cake_blackwell_all_gather_matmul_barrier_ws2_p1",
@@ -53,7 +53,8 @@
     "kernel_cake_blackwell_all_gather_matmul_float16_ws4",
     "kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4",
     "kernel_cake_blackwell_all_gather_matmul_float16_ws8",
-    "kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8"
+    "kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8",
+    "kernel_cake_blackwell_all_gather_matmul_fused_peer_copy"
   ],
   "launch": {
     "barrier": {
@@ -64,6 +65,17 @@
         1,
         1
       ]
+    },
+    "fused_peer_copy": {
+      "block_threads": 128,
+      "dynamic_smem_bytes": 0,
+      "grid": [
+        32,
+        7,
+        1
+      ],
+      "ordering": "start_barrier -> fused_peer_copy -> comm_join -> completion_barrier -> main",
+      "when": "sm_103a, bfloat16, world_size=8, M=512, N=1280"
     },
     "main": {
       "block_threads": 192,
@@ -105,6 +117,6 @@
     }
   },
   "schema_version": 1,
-  "source_sha256": "1eb41812ff454293bcf3ae1eee78318cc3648feb045d3788989b3b4f637ba087",
+  "source_sha256": "aed09c12a2d0f1151992f7e20e4d0a2997b897a54b23f3dd06cb0a303aba30fe",
   "tma_abi": "pointer"
 }

--- a/flashinfer/comm/all_gather_matmul/all_gather_matmul.py
+++ b/flashinfer/comm/all_gather_matmul/all_gather_matmul.py
@@ -105,17 +105,18 @@ def prepare_all_gather_matmul(
     The returned callable binds ``w`` and ``group`` and accepts a new input
     tensor with the same shape, dtype, and device as ``inp``. Both
     ``backend="auto"`` and ``backend="cake"`` select the source-built
-    prepared SM103/BF16 launcher for the exact TP4/N=2560 or TP8/N=1280
-    profile. Unsupported inputs raise during preparation instead of falling
-    back to another implementation.
+    prepared BF16 launcher for TP8/N=1280 on SM100 or SM103, or TP4/N=2560
+    on SM103. SM100 TP8 uses asynchronous peer copies; the fused peer-copy
+    specialization remains specific to SM103. Unsupported inputs raise during
+    preparation instead of falling back to another implementation.
     """
     if backend not in {"auto", "cake"}:
         raise ValueError("backend must be exactly 'auto' or 'cake'")
 
     from .cake_all_gather_matmul import (
-        _prepare_all_gather_matmul_cake_packed_qkv_sm103,
+        _prepare_all_gather_matmul_cake_packed_qkv,
     )
 
-    return _prepare_all_gather_matmul_cake_packed_qkv_sm103(
+    return _prepare_all_gather_matmul_cake_packed_qkv(
         inp, w, group, verbose=verbose
     )

--- a/flashinfer/comm/all_gather_matmul/all_gather_matmul.py
+++ b/flashinfer/comm/all_gather_matmul/all_gather_matmul.py
@@ -117,6 +117,4 @@ def prepare_all_gather_matmul(
         _prepare_all_gather_matmul_cake_packed_qkv,
     )
 
-    return _prepare_all_gather_matmul_cake_packed_qkv(
-        inp, w, group, verbose=verbose
-    )
+    return _prepare_all_gather_matmul_cake_packed_qkv(inp, w, group, verbose=verbose)

--- a/flashinfer/comm/all_gather_matmul/cake_all_gather_matmul.py
+++ b/flashinfer/comm/all_gather_matmul/cake_all_gather_matmul.py
@@ -1275,8 +1275,9 @@ def _prepared_descriptor_storage(
         world_size,
         rows,
     )
-    with torch.cuda.stream(main_stream):
-        descriptors.copy_(host_descriptors, non_blocking=True)
+    # Both prepared call sites pass this device's current stream. Tensor.copy_
+    # uses the destination device's current stream and tracks pinned-source lifetime.
+    descriptors.copy_(host_descriptors, non_blocking=True)
     ready_event = torch.cuda.Event(enable_timing=False)
     ready_event.record(main_stream)
     entry = _PreparedDescriptorEntry(

--- a/flashinfer/comm/all_gather_matmul/cake_all_gather_matmul.py
+++ b/flashinfer/comm/all_gather_matmul/cake_all_gather_matmul.py
@@ -130,8 +130,8 @@ constexpr int64_t kDescriptorCount = 3;
 constexpr int32_t kMainThreads = 192;
 constexpr int32_t kMainSmemBytes = CAKE_MAIN_SMEM_BYTES;
 constexpr uint32_t kFusedPeerCopyCtas = CAKE_FUSED_PEER_COPY_CTAS;
-constexpr bool kPackedQkvExperimentSupported =
-    CAKE_PACKED_QKV_EXPERIMENT_SUPPORTED;
+constexpr bool kSm103PackedQkvSpecialization =
+    CAKE_SM103_PACKED_QKV_SPECIALIZATION;
 
 static_assert(sizeof(CUtensorMap) == 128);
 
@@ -329,16 +329,14 @@ inline tvm::ffi::CubinKernel& MainKernel(int64_t world_size, int64_t dtype_code,
   TVM_FFI_CHECK(n == 1280 || n == 2048 || n == 2560, ValueError)
       << "n must be 1280, 2048, or 2560";
   if (n == 2560) {
-    TVM_FFI_CHECK(kPackedQkvExperimentSupported && world_size == 4 &&
+    TVM_FFI_CHECK(kSm103PackedQkvSpecialization && world_size == 4 &&
                       dtype_code == 0,
                   ValueError)
         << "the packed-QKV experiment requires SM103, world_size=4, and bfloat16";
   }
   if (n == 1280) {
-    TVM_FFI_CHECK(kPackedQkvExperimentSupported && world_size == 8 &&
-                      dtype_code == 0,
-                  ValueError)
-        << "N=1280 requires the SM103, world_size=8, bfloat16 packed-QKV route";
+    TVM_FFI_CHECK(world_size == 8 && dtype_code == 0, ValueError)
+        << "N=1280 requires the world_size=8, bfloat16 packed-QKV route";
   }
   static auto bf16_ws2 = TVM_FFI_EMBED_CUBIN_GET_KERNEL(
       CAKE_MODULE_IDENT,
@@ -470,7 +468,8 @@ void RunMain(TensorView inp, TensorView scratch, TensorView weight,
   const uint32_t grid_x =
       static_cast<uint32_t>((chunk_rows / 128) * (n / 256));
   const uint32_t grid_y =
-      static_cast<uint32_t>(world_size == 8 && rows == 512 && n == 1280 ? 4 : 1);
+      static_cast<uint32_t>(kSm103PackedQkvSpecialization && world_size == 8 &&
+                            rows == 512 && n == 1280 ? 4 : 1);
   CUstream stream = reinterpret_cast<CUstream>(
       static_cast<uintptr_t>(cuda_stream));
   TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(
@@ -544,12 +543,12 @@ void RunPreparedPackedQkvImpl(
                 TypeError)
       << "flag_peers must have int64 dtype";
   TVM_FFI_CHECK(
-      kPackedQkvExperimentSupported &&
-          ((world_size == 4 && weight.size(1) == 2560) ||
-           (world_size == 8 && weight.size(1) == 1280)),
+      ((kSm103PackedQkvSpecialization && world_size == 4 &&
+        weight.size(1) == 2560) ||
+       (world_size == 8 && weight.size(1) == 1280)),
       ValueError)
-      << "prepared packed-QKV launch requires SM103 and exact profile "
-         "world_size=4,N=2560 or world_size=8,N=1280";
+      << "prepared packed-QKV launch requires SM100/SM103 world_size=8,N=1280 "
+         "or SM103 world_size=4,N=2560";
   TVM_FFI_CHECK(rank >= 0 && rank < world_size, ValueError)
       << "rank is outside the process group";
   TVM_FFI_CHECK(flag_peers.ndim() == 1 &&
@@ -636,7 +635,7 @@ void RunPreparedPackedQkvImpl(
   }
 
   if (fused != nullptr) {
-    TVM_FFI_CHECK(kPackedQkvExperimentSupported && world_size == 8 &&
+    TVM_FFI_CHECK(kSm103PackedQkvSpecialization && world_size == 8 &&
                       rows == 512 && weight.size(1) == 1280, ValueError)
         << "fused peer copy requires exact SM103 TP8 M512 N1280";
     const std::array<const TensorView*, 3> buffers = {
@@ -1024,11 +1023,12 @@ def _constraints_for_arch(arch: str) -> dict[str, Any]:
         },
         "world_sizes": list(_COMMON_CONSTRAINTS["world_sizes"]),
     }
-    if arch == "sm_103a":
-        constraints["prepared_packed_qkv"] = {
-            "dtypes": ["bfloat16"],
-            "n_by_world_size": {"4": [2560], "8": [1280]},
-        }
+    constraints["prepared_packed_qkv"] = {
+        "dtypes": ["bfloat16"],
+        "n_by_world_size": (
+            {"4": [2560], "8": [1280]} if arch == "sm_103a" else {"8": [1280]}
+        ),
+    }
     return constraints
 
 
@@ -1043,7 +1043,7 @@ def _render_host_source(module_ident: str, manifest: dict[str, Any]) -> str:
         .replace("CAKE_MAIN_SMEM_BYTES", str(main_smem_bytes))
         .replace("CAKE_FUSED_PEER_COPY_CTAS", str(_FUSED_PEER_COPY_CTAS))
         .replace(
-            "CAKE_PACKED_QKV_EXPERIMENT_SUPPORTED",
+            "CAKE_SM103_PACKED_QKV_SPECIALIZATION",
             "true" if manifest["arch"] == "sm_103a" else "false",
         )
     )
@@ -1053,7 +1053,7 @@ def _render_host_source(module_ident: str, manifest: dict[str, Any]) -> str:
             "CAKE_MODULE_IDENT",
             "CAKE_MAIN_SMEM_BYTES",
             "CAKE_FUSED_PEER_COPY_CTAS",
-            "CAKE_PACKED_QKV_EXPERIMENT_SUPPORTED",
+            "CAKE_SM103_PACKED_QKV_SPECIALIZATION",
         )
     ):
         raise RuntimeError("Cake all-gather matmul host launch template is incomplete")
@@ -1265,8 +1265,12 @@ def _validate_inputs(
             "the Cake backend requires the NVSHMEM symmetric-memory backend"
         )
     arch = _target_arch(inp.device)
-    if packed_qkv_experiment and (arch != "sm_103a" or inp.dtype != torch.bfloat16):
-        raise ValueError("the packed-QKV experiment requires SM103 and bfloat16")
+    if packed_qkv_experiment and (
+        inp.dtype != torch.bfloat16 or (world_size == 4 and arch != "sm_103a")
+    ):
+        raise ValueError(
+            "packed-QKV requires bfloat16 and SM100/SM103 TP8 or SM103 TP4"
+        )
     return device_index, rank, world_size, _group_name(group)
 
 
@@ -1281,13 +1285,15 @@ def _ensure_launch_state(
 ) -> None:
     if state.flags is not None:
         return
-    flags = symm_mem.empty(2, dtype=torch.uint32, device=device_index)
+    # Two phase epochs followed by two world-sized mailbox banks per phase.
+    flag_slots = 2 + 4 * world_size
+    flags = symm_mem.empty(flag_slots, dtype=torch.uint32, device=device_index)
     handle = symm_mem.rendezvous(flags, group=group_name)
     if int(handle.rank) != rank or int(handle.world_size) != world_size:
         raise RuntimeError("barrier symmetric-memory topology does not match group")
     flags.zero_()
     peer_ptrs = [
-        int(handle.get_buffer(peer, (2,), torch.uint32, 0).data_ptr())
+        int(handle.get_buffer(peer, (flag_slots,), torch.uint32, 0).data_ptr())
         for peer in range(world_size)
     ]
     state.flags = flags
@@ -1463,7 +1469,7 @@ def _validate_prepared_view(
 
 
 @dataclass(frozen=True)
-class _PreparedPackedQkvSm103Launcher:
+class _PreparedPackedQkvLauncher:
     group: dist.ProcessGroup = field(repr=False)
     group_id: int
     group_name: str
@@ -1607,14 +1613,14 @@ class _PreparedPackedQkvSm103Launcher:
                 raise
 
 
-def _prepare_all_gather_matmul_cake_packed_qkv_sm103(
+def _prepare_all_gather_matmul_cake_packed_qkv(
     inp: torch.Tensor,
     w: torch.Tensor,
     group: dist.ProcessGroup,
     *,
     verbose: bool = False,
-) -> _PreparedPackedQkvSm103Launcher:
-    """Bind immutable host state for an exact SM103/BF16 packed-QKV route."""
+) -> _PreparedPackedQkvLauncher:
+    """Bind BF16 packed QKV for SM100/SM103 TP8 or SM103 TP4."""
 
     device_index, rank, world_size, group_name = _validate_inputs(
         inp, w, group, packed_qkv_experiment=True
@@ -1772,7 +1778,12 @@ def _prepare_all_gather_matmul_cake_packed_qkv_sm103(
                 weight_fingerprint=weight_fingerprint,
             )
             native_bound = None
-            if world_size == 8 and rows == 512 and int(w.shape[1]) == 1280:
+            if (
+                arch == "sm_103a"
+                and world_size == 8
+                and rows == 512
+                and int(w.shape[1]) == 1280
+            ):
                 if workspace.fused_copy_buffers is None:
                     if state.initialization_event is not None:
                         main_stream.wait_event(state.initialization_event)
@@ -1800,7 +1811,7 @@ def _prepare_all_gather_matmul_cake_packed_qkv_sm103(
                     int(signal_pad.data_ptr()),
                     *native_expected_peer_args,
                 )
-            launcher = _PreparedPackedQkvSm103Launcher(
+            launcher = _PreparedPackedQkvLauncher(
                 group=group,
                 group_id=id(group),
                 group_name=group_name,

--- a/flashinfer/comm/all_gather_matmul/cake_all_gather_matmul.py
+++ b/flashinfer/comm/all_gather_matmul/cake_all_gather_matmul.py
@@ -39,6 +39,7 @@ _TENSOR_MAP_BYTES = 128
 _DESCRIPTOR_COUNT = 3
 _DESCRIPTOR_CACHE_MAX_ENTRIES = 256
 _MAIN_KERNEL_COUNT = 6
+_FUSED_PEER_COPY_CTAS = 32
 _SUPPORTED_WORLD_SIZES = frozenset((2, 4, 8))
 _SUPPORTED_DTYPES = frozenset((torch.bfloat16, torch.float16))
 _KERNEL_SYMBOLS = (
@@ -54,6 +55,7 @@ _KERNEL_SYMBOLS = (
     "kernel_cake_blackwell_all_gather_matmul_bfloat16_ws4",
     "kernel_cake_blackwell_all_gather_matmul_float16_ws8",
     "kernel_cake_blackwell_all_gather_matmul_bfloat16_ws8",
+    "kernel_cake_blackwell_all_gather_matmul_fused_peer_copy",
 )
 _MANIFEST_KEYS = frozenset(
     {
@@ -127,6 +129,7 @@ constexpr int64_t kTensorMapBytes = sizeof(CUtensorMap);
 constexpr int64_t kDescriptorCount = 3;
 constexpr int32_t kMainThreads = 192;
 constexpr int32_t kMainSmemBytes = CAKE_MAIN_SMEM_BYTES;
+constexpr uint32_t kFusedPeerCopyCtas = CAKE_FUSED_PEER_COPY_CTAS;
 constexpr bool kPackedQkvExperimentSupported =
     CAKE_PACKED_QKV_EXPERIMENT_SUPPORTED;
 
@@ -476,7 +479,20 @@ void RunMain(TensorView inp, TensorView scratch, TensorView weight,
                     kMainSmemBytes));
 }
 
-void RunPreparedPackedQkv(
+struct FusedPeerCopyState {
+  TensorView payload_peers;
+  TensorView signal_peers;
+  TensorView counters;
+};
+
+inline tvm::ffi::CubinKernel& FusedPeerCopyKernel() {
+  static auto kernel = TVM_FFI_EMBED_CUBIN_GET_KERNEL(
+      CAKE_MODULE_IDENT,
+      "kernel_cake_blackwell_all_gather_matmul_fused_peer_copy");
+  return kernel;
+}
+
+void RunPreparedPackedQkvImpl(
     TensorView inp, TensorView scratch, TensorView weight, TensorView out,
     TensorView descriptor_storage, TensorView ready, TensorView flag_peers,
     TensorView peer_scratch_0, TensorView peer_signal_0,
@@ -496,7 +512,7 @@ void RunPreparedPackedQkv(
     int64_t expected_peer_signal_3, int64_t expected_peer_scratch_4,
     int64_t expected_peer_signal_4, int64_t expected_peer_scratch_5,
     int64_t expected_peer_signal_5, int64_t expected_peer_scratch_6,
-    int64_t expected_peer_signal_6) {
+    int64_t expected_peer_signal_6, const FusedPeerCopyState* fused) {
   CheckCommonInputs(inp, scratch, weight, out, world_size, rows);
   CheckCudaTensor(descriptor_storage, "descriptor_storage");
   CheckCudaTensor(ready, "ready");
@@ -619,6 +635,28 @@ void RunPreparedPackedQkv(
         << "prepared peer storage changed after binding";
   }
 
+  if (fused != nullptr) {
+    TVM_FFI_CHECK(kPackedQkvExperimentSupported && world_size == 8 &&
+                      rows == 512 && weight.size(1) == 1280, ValueError)
+        << "fused peer copy requires exact SM103 TP8 M512 N1280";
+    const std::array<const TensorView*, 3> buffers = {
+        &fused->payload_peers, &fused->signal_peers, &fused->counters};
+    for (int index = 0; index < 3; ++index) {
+      const auto& tensor = *buffers[index];
+      CheckCudaTensor(tensor, "fused copy buffer");
+      CheckSameDevice(tensor, inp, "fused copy buffer");
+      CheckContiguous(tensor, "fused copy buffer");
+      const auto ty = tensor.dtype();
+      TVM_FFI_CHECK(tensor.ndim() == 1 && tensor.numel() == 7 &&
+                        ty.lanes == 1 &&
+                        ((index < 2 && ty.code == kDLInt && ty.bits == 64) ||
+                         (index == 2 && ty.code == kDLUInt && ty.bits == 32)),
+                    ValueError) << "invalid fused copy pointer table or counters";
+    }
+    (void)FusedPeerCopyKernel().GetHandle();
+    (void)BarrierKernel(world_size, 1 - phase).GetHandle();
+  }
+
   // Resolve every kernel/capability check before this rank enters the collective.
   (void)BarrierKernel(world_size, phase);
   (void)ConfiguredMainKernel(world_size, 0, weight.size(1),
@@ -638,6 +676,29 @@ void RunPreparedPackedQkv(
   TVM_FFI_CHECK(cuStreamWaitEvent(comm_stream, bridge_event, 0) == CUDA_SUCCESS,
                 RuntimeError)
       << "waiting for the prepared barrier on the comm stream failed";
+
+  if (fused != nullptr) {
+    void* input_ptr = inp.data_ptr();
+    void* payload_ptr = fused->payload_peers.data_ptr();
+    void* signal_ptr = fused->signal_peers.data_ptr();
+    void* counters_ptr = fused->counters.data_ptr();
+    uint32_t exact_epoch = static_cast<uint32_t>(ready_target);
+    void* args[] = {&input_ptr, &payload_ptr, &signal_ptr,
+                    &counters_ptr, &exact_epoch};
+    TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(
+        FusedPeerCopyKernel().Launch(
+            args, tvm::ffi::dim3(kFusedPeerCopyCtas, 7, 1),
+            tvm::ffi::dim3(128, 1, 1), comm_stream, 0));
+    TVM_FFI_CHECK(cuEventRecord(bridge_event, comm_stream) == CUDA_SUCCESS,
+                  RuntimeError) << "recording fused-copy completion failed";
+    TVM_FFI_CHECK(cuStreamWaitEvent(main_stream, bridge_event, 0) == CUDA_SUCCESS,
+                  RuntimeError) << "waiting for fused-copy completion failed";
+    // This existing rendezvous supplies alias/async ordering before TMA.
+    RunBarrier(flag_peers, world_size, rank, 1 - phase, main_cuda_stream);
+    RunMain(inp, scratch, weight, out, descriptor_storage, ready, ready_target,
+            world_size, rank, rows, 0, main_cuda_stream);
+    return;
+  }
 
   const size_t row_bytes = 8192 * sizeof(uint16_t);
   const CUdeviceptr input_base = static_cast<CUdeviceptr>(
@@ -682,11 +743,84 @@ void RunPreparedPackedQkv(
       << "waiting for prepared peer copies on the main stream failed";
 }
 
+void RunPreparedPackedQkv(
+    TensorView inp, TensorView scratch, TensorView weight, TensorView out,
+    TensorView descriptor_storage, TensorView ready, TensorView flag_peers,
+    TensorView peer_scratch_0, TensorView peer_signal_0,
+    TensorView peer_scratch_1, TensorView peer_signal_1,
+    TensorView peer_scratch_2, TensorView peer_signal_2,
+    TensorView peer_scratch_3, TensorView peer_signal_3,
+    TensorView peer_scratch_4, TensorView peer_signal_4,
+    TensorView peer_scratch_5, TensorView peer_signal_5,
+    TensorView peer_scratch_6, TensorView peer_signal_6,
+    int64_t world_size, int64_t rank, int64_t rows, int64_t phase,
+    int64_t ready_target, int64_t main_cuda_stream, int64_t comm_cuda_stream,
+    int64_t bridge_cuda_event, int64_t expected_scratch_ptr,
+    int64_t expected_ready_ptr, int64_t expected_peer_scratch_0,
+    int64_t expected_peer_signal_0, int64_t expected_peer_scratch_1,
+    int64_t expected_peer_signal_1, int64_t expected_peer_scratch_2,
+    int64_t expected_peer_signal_2, int64_t expected_peer_scratch_3,
+    int64_t expected_peer_signal_3, int64_t expected_peer_scratch_4,
+    int64_t expected_peer_signal_4, int64_t expected_peer_scratch_5,
+    int64_t expected_peer_signal_5, int64_t expected_peer_scratch_6,
+    int64_t expected_peer_signal_6) {
+  RunPreparedPackedQkvImpl(
+      inp,
+      scratch,
+      weight,
+      out,
+      descriptor_storage,
+      ready,
+      flag_peers,
+      peer_scratch_0,
+      peer_signal_0,
+      peer_scratch_1,
+      peer_signal_1,
+      peer_scratch_2,
+      peer_signal_2,
+      peer_scratch_3,
+      peer_signal_3,
+      peer_scratch_4,
+      peer_signal_4,
+      peer_scratch_5,
+      peer_signal_5,
+      peer_scratch_6,
+      peer_signal_6,
+      world_size,
+      rank,
+      rows,
+      phase,
+      ready_target,
+      main_cuda_stream,
+      comm_cuda_stream,
+      bridge_cuda_event,
+      expected_scratch_ptr,
+      expected_ready_ptr,
+      expected_peer_scratch_0,
+      expected_peer_signal_0,
+      expected_peer_scratch_1,
+      expected_peer_signal_1,
+      expected_peer_scratch_2,
+      expected_peer_signal_2,
+      expected_peer_scratch_3,
+      expected_peer_signal_3,
+      expected_peer_scratch_4,
+      expected_peer_signal_4,
+      expected_peer_scratch_5,
+      expected_peer_signal_5,
+      expected_peer_scratch_6,
+      expected_peer_signal_6,
+      nullptr);
+}
+
 tvm::ffi::Function BindPreparedPackedQkv(
     tvm::ffi::Tensor scratch,
     tvm::ffi::Tensor weight,
     tvm::ffi::Tensor ready,
     tvm::ffi::Tensor flag_peers,
+    tvm::ffi::Tensor payload_peers,
+    tvm::ffi::Tensor signal_peers,
+    tvm::ffi::Tensor copy_counters,
     tvm::ffi::Tensor peer_scratch_0,
     tvm::ffi::Tensor peer_signal_0,
     tvm::ffi::Tensor peer_scratch_1,
@@ -722,12 +856,14 @@ tvm::ffi::Function BindPreparedPackedQkv(
     int64_t expected_peer_signal_5,
     int64_t expected_peer_scratch_6,
     int64_t expected_peer_signal_6) {
-  // Retain owning tensor handles once; each invocation still executes the
-  // original validated launcher and its unchanged stream/event protocol.
+  // Retain the peer tables and completion counters with the existing owners.
+  // The shared launcher validates before its two-rendezvous exact route.
   return tvm::ffi::Function::FromTyped(
       [=](TensorView inp, TensorView out, TensorView descriptor_storage,
           int64_t phase, int64_t ready_target, int64_t main_cuda_stream) {
-        RunPreparedPackedQkv(
+        const FusedPeerCopyState fused{
+            payload_peers, signal_peers, copy_counters};
+        RunPreparedPackedQkvImpl(
             inp,
             scratch,
             weight,
@@ -772,7 +908,7 @@ tvm::ffi::Function BindPreparedPackedQkv(
             expected_peer_scratch_5,
             expected_peer_signal_5,
             expected_peer_scratch_6,
-            expected_peer_signal_6);
+            expected_peer_signal_6, &fused);
       });
 }
 
@@ -863,6 +999,13 @@ def _launch_contract(source: bytes, arch: str) -> dict[str, Any]:
             "grid_x": "(min(M, 2432) / 128) * (N / 256)",
         },
     }
+    launch["fused_peer_copy"] = {
+        "block_threads": 128,
+        "dynamic_smem_bytes": 0,
+        "grid": [_FUSED_PEER_COPY_CTAS, 7, 1],
+        "when": "sm_103a, bfloat16, world_size=8, M=512, N=1280",
+        "ordering": "start_barrier -> fused_peer_copy -> comm_join -> completion_barrier -> main",
+    }
     if arch == "sm_103a":
         launch["main"]["grid_y"] = (
             "4 if world_size == 8 and M == 512 and N == 1280 else 1"
@@ -898,6 +1041,7 @@ def _render_host_source(module_ident: str, manifest: dict[str, Any]) -> str:
     rendered = (
         _HOST_SOURCE.replace("CAKE_MODULE_IDENT", module_ident)
         .replace("CAKE_MAIN_SMEM_BYTES", str(main_smem_bytes))
+        .replace("CAKE_FUSED_PEER_COPY_CTAS", str(_FUSED_PEER_COPY_CTAS))
         .replace(
             "CAKE_PACKED_QKV_EXPERIMENT_SUPPORTED",
             "true" if manifest["arch"] == "sm_103a" else "false",
@@ -908,6 +1052,7 @@ def _render_host_source(module_ident: str, manifest: dict[str, Any]) -> str:
         for placeholder in (
             "CAKE_MODULE_IDENT",
             "CAKE_MAIN_SMEM_BYTES",
+            "CAKE_FUSED_PEER_COPY_CTAS",
             "CAKE_PACKED_QKV_EXPERIMENT_SUPPORTED",
         )
     ):
@@ -934,7 +1079,7 @@ def _program_source(arch: str) -> tuple[Path, dict[str, Any]]:
         "arch": arch,
         "compile_flags": ["--use_fast_math"],
         "tma_abi": "pointer",
-        "kernel_count": 12,
+        "kernel_count": 13,
         "launch": _launch_contract(source_bytes, arch),
         "constraints": _constraints_for_arch(arch),
         "kernel_symbols": list(_KERNEL_SYMBOLS),
@@ -1035,6 +1180,9 @@ class _Workspace:
     prepared_descriptor_cache: OrderedDict[
         tuple[Any, ...], _PreparedDescriptorEntry
     ] = field(default_factory=OrderedDict, repr=False)
+    fused_copy_buffers: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = field(
+        default=None, repr=False
+    )
 
 
 _CACHE_LOCK = RLock()
@@ -1445,7 +1593,7 @@ class _PreparedPackedQkvSm103Launcher:
                 if state.tail_event is None:
                     state.tail_event = torch.cuda.Event(enable_timing=False)
                 state.tail_event.record(main_stream)
-                state.next_phase = 1 - phase
+                state.next_phase = phase if self.native_bound is not None else 1 - phase
                 state.tail_stream = main_stream_id
                 if self.verbose and self.rank == 0:
                     print(
@@ -1625,11 +1773,23 @@ def _prepare_all_gather_matmul_cake_packed_qkv_sm103(
             )
             native_bound = None
             if world_size == 8 and rows == 512 and int(w.shape[1]) == 1280:
+                if workspace.fused_copy_buffers is None:
+                    if state.initialization_event is not None:
+                        main_stream.wait_event(state.initialization_event)
+                    workspace.fused_copy_buffers = (
+                        torch.tensor(peer_scratch_ptrs, dtype=torch.int64, device=device),
+                        torch.tensor(peer_signal_ptrs, dtype=torch.int64, device=device),
+                        torch.zeros(7, dtype=torch.uint32, device=device),
+                    )
+                    state.initialization_event = torch.cuda.Event(enable_timing=False)
+                    state.initialization_event.record(main_stream)
+                    state.initialization_stream = int(main_stream.cuda_stream)
                 native_bound = module.bind_prepared_packed_qkv(
                     workspace.scratch,
                     w,
                     signal_pad,
                     state.flag_peers,
+                    *workspace.fused_copy_buffers,
                     *native_peer_args,
                     world_size,
                     rank,

--- a/flashinfer/comm/all_gather_matmul/cake_all_gather_matmul.py
+++ b/flashinfer/comm/all_gather_matmul/cake_all_gather_matmul.py
@@ -682,6 +682,100 @@ void RunPreparedPackedQkv(
       << "waiting for prepared peer copies on the main stream failed";
 }
 
+tvm::ffi::Function BindPreparedPackedQkv(
+    tvm::ffi::Tensor scratch,
+    tvm::ffi::Tensor weight,
+    tvm::ffi::Tensor ready,
+    tvm::ffi::Tensor flag_peers,
+    tvm::ffi::Tensor peer_scratch_0,
+    tvm::ffi::Tensor peer_signal_0,
+    tvm::ffi::Tensor peer_scratch_1,
+    tvm::ffi::Tensor peer_signal_1,
+    tvm::ffi::Tensor peer_scratch_2,
+    tvm::ffi::Tensor peer_signal_2,
+    tvm::ffi::Tensor peer_scratch_3,
+    tvm::ffi::Tensor peer_signal_3,
+    tvm::ffi::Tensor peer_scratch_4,
+    tvm::ffi::Tensor peer_signal_4,
+    tvm::ffi::Tensor peer_scratch_5,
+    tvm::ffi::Tensor peer_signal_5,
+    tvm::ffi::Tensor peer_scratch_6,
+    tvm::ffi::Tensor peer_signal_6,
+    int64_t world_size,
+    int64_t rank,
+    int64_t rows,
+    int64_t comm_cuda_stream,
+    int64_t bridge_cuda_event,
+    int64_t expected_scratch_ptr,
+    int64_t expected_ready_ptr,
+    int64_t expected_peer_scratch_0,
+    int64_t expected_peer_signal_0,
+    int64_t expected_peer_scratch_1,
+    int64_t expected_peer_signal_1,
+    int64_t expected_peer_scratch_2,
+    int64_t expected_peer_signal_2,
+    int64_t expected_peer_scratch_3,
+    int64_t expected_peer_signal_3,
+    int64_t expected_peer_scratch_4,
+    int64_t expected_peer_signal_4,
+    int64_t expected_peer_scratch_5,
+    int64_t expected_peer_signal_5,
+    int64_t expected_peer_scratch_6,
+    int64_t expected_peer_signal_6) {
+  // Retain owning tensor handles once; each invocation still executes the
+  // original validated launcher and its unchanged stream/event protocol.
+  return tvm::ffi::Function::FromTyped(
+      [=](TensorView inp, TensorView out, TensorView descriptor_storage,
+          int64_t phase, int64_t ready_target, int64_t main_cuda_stream) {
+        RunPreparedPackedQkv(
+            inp,
+            scratch,
+            weight,
+            out,
+            descriptor_storage,
+            ready,
+            flag_peers,
+            peer_scratch_0,
+            peer_signal_0,
+            peer_scratch_1,
+            peer_signal_1,
+            peer_scratch_2,
+            peer_signal_2,
+            peer_scratch_3,
+            peer_signal_3,
+            peer_scratch_4,
+            peer_signal_4,
+            peer_scratch_5,
+            peer_signal_5,
+            peer_scratch_6,
+            peer_signal_6,
+            world_size,
+            rank,
+            rows,
+            phase,
+            ready_target,
+            main_cuda_stream,
+            comm_cuda_stream,
+            bridge_cuda_event,
+            expected_scratch_ptr,
+            expected_ready_ptr,
+            expected_peer_scratch_0,
+            expected_peer_signal_0,
+            expected_peer_scratch_1,
+            expected_peer_signal_1,
+            expected_peer_scratch_2,
+            expected_peer_signal_2,
+            expected_peer_scratch_3,
+            expected_peer_signal_3,
+            expected_peer_scratch_4,
+            expected_peer_signal_4,
+            expected_peer_scratch_5,
+            expected_peer_signal_5,
+            expected_peer_scratch_6,
+            expected_peer_signal_6);
+      });
+}
+
 }  // namespace flashinfer_cake_all_gather_matmul
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(
@@ -691,6 +785,10 @@ TVM_FFI_DLL_EXPORT_TYPED_FUNC(
     run_barrier, flashinfer_cake_all_gather_matmul::RunBarrier);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(
     run_main, flashinfer_cake_all_gather_matmul::RunMain);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(
+    bind_prepared_packed_qkv,
+    flashinfer_cake_all_gather_matmul::BindPreparedPackedQkv);
+
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(
     run_prepared_packed_qkv,
     flashinfer_cake_all_gather_matmul::RunPreparedPackedQkv);
@@ -1244,6 +1342,7 @@ class _PreparedPackedQkvSm103Launcher:
     peer_signal_ptrs: tuple[int, ...]
     native_peer_args: tuple[Any, ...] = field(repr=False)
     native_expected_peer_args: tuple[int, ...]
+    native_bound: Any = field(default=None, repr=False)
     verbose: bool = False
 
     def _validate_hot_input(self, inp: torch.Tensor) -> None:
@@ -1316,27 +1415,32 @@ class _PreparedPackedQkvSm103Launcher:
                     )
                 state.ready_epoch += 1
                 ready_target = state.ready_epoch
-                self.module.run_prepared_packed_qkv(
-                    inp,
-                    workspace.scratch,
-                    w,
-                    output,
-                    descriptors,
-                    self.signal_pad,
-                    state.flag_peers,
-                    *self.native_peer_args,
-                    self.world_size,
-                    self.rank,
-                    self.rows,
-                    phase,
-                    ready_target,
-                    main_stream_id,
-                    int(workspace.comm_stream.cuda_stream),
-                    int(workspace.bridge_event.cuda_event),
-                    int(self.scratch_fingerprint[0]),
-                    self.signal_pad_ptr,
-                    *self.native_expected_peer_args,
-                )
+                if self.native_bound is not None:
+                    self.native_bound(
+                        inp, output, descriptors, phase, ready_target, main_stream_id
+                    )
+                else:
+                    self.module.run_prepared_packed_qkv(
+                        inp,
+                        workspace.scratch,
+                        w,
+                        output,
+                        descriptors,
+                        self.signal_pad,
+                        state.flag_peers,
+                        *self.native_peer_args,
+                        self.world_size,
+                        self.rank,
+                        self.rows,
+                        phase,
+                        ready_target,
+                        main_stream_id,
+                        int(workspace.comm_stream.cuda_stream),
+                        int(workspace.bridge_event.cuda_event),
+                        int(self.scratch_fingerprint[0]),
+                        self.signal_pad_ptr,
+                        *self.native_expected_peer_args,
+                    )
                 if state.tail_event is None:
                     state.tail_event = torch.cuda.Event(enable_timing=False)
                 state.tail_event.record(main_stream)
@@ -1518,6 +1622,23 @@ def _prepare_all_gather_matmul_cake_packed_qkv_sm103(
                 scratch_fingerprint=scratch_fingerprint,
                 weight_fingerprint=weight_fingerprint,
             )
+            native_bound = None
+            if world_size == 8 and rows == 512 and int(w.shape[1]) == 1280:
+                native_bound = module.bind_prepared_packed_qkv(
+                    workspace.scratch,
+                    w,
+                    signal_pad,
+                    state.flag_peers,
+                    *native_peer_args,
+                    world_size,
+                    rank,
+                    rows,
+                    int(workspace.comm_stream.cuda_stream),
+                    int(workspace.bridge_event.cuda_event),
+                    int(scratch_fingerprint[0]),
+                    int(signal_pad.data_ptr()),
+                    *native_expected_peer_args,
+                )
             launcher = _PreparedPackedQkvSm103Launcher(
                 group=group,
                 group_id=id(group),
@@ -1546,6 +1667,7 @@ def _prepare_all_gather_matmul_cake_packed_qkv_sm103(
                 peer_signal_ptrs=peer_signal_ptrs,
                 native_peer_args=native_peer_args,
                 native_expected_peer_args=native_expected_peer_args,
+                native_bound=native_bound,
                 verbose=verbose,
             )
             return launcher

--- a/flashinfer/comm/all_gather_matmul/cake_all_gather_matmul.py
+++ b/flashinfer/comm/all_gather_matmul/cake_all_gather_matmul.py
@@ -466,10 +466,12 @@ void RunMain(TensorView inp, TensorView scratch, TensorView weight,
 
   const uint32_t grid_x =
       static_cast<uint32_t>((chunk_rows / 128) * (n / 256));
+  const uint32_t grid_y =
+      static_cast<uint32_t>(world_size == 8 && rows == 512 && n == 1280 ? 4 : 1);
   CUstream stream = reinterpret_cast<CUstream>(
       static_cast<uintptr_t>(cuda_stream));
   TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(
-      kernel.Launch(args, tvm::ffi::dim3(grid_x, 1, 1),
+      kernel.Launch(args, tvm::ffi::dim3(grid_x, grid_y, 1),
                     tvm::ffi::dim3(kMainThreads, 1, 1), stream,
                     kMainSmemBytes));
 }
@@ -750,8 +752,8 @@ def _resolved_main_smem_bytes(source: bytes) -> int:
     return values[0]
 
 
-def _launch_contract(source: bytes) -> dict[str, Any]:
-    return {
+def _launch_contract(source: bytes, arch: str) -> dict[str, Any]:
+    launch = {
         "barrier": {
             "block_threads": 32,
             "dynamic_smem_bytes": 0,
@@ -763,6 +765,11 @@ def _launch_contract(source: bytes) -> dict[str, Any]:
             "grid_x": "(min(M, 2432) / 128) * (N / 256)",
         },
     }
+    if arch == "sm_103a":
+        launch["main"]["grid_y"] = (
+            "4 if world_size == 8 and M == 512 and N == 1280 else 1"
+        )
+    return launch
 
 
 def _constraints_for_arch(arch: str) -> dict[str, Any]:
@@ -830,7 +837,7 @@ def _program_source(arch: str) -> tuple[Path, dict[str, Any]]:
         "compile_flags": ["--use_fast_math"],
         "tma_abi": "pointer",
         "kernel_count": 12,
-        "launch": _launch_contract(source_bytes),
+        "launch": _launch_contract(source_bytes, arch),
         "constraints": _constraints_for_arch(arch),
         "kernel_symbols": list(_KERNEL_SYMBOLS),
         "route_coverage": _ROUTE_COVERAGE,

--- a/flashinfer/comm/all_gather_matmul/cake_all_gather_matmul.py
+++ b/flashinfer/comm/all_gather_matmul/cake_all_gather_matmul.py
@@ -1788,8 +1788,12 @@ def _prepare_all_gather_matmul_cake_packed_qkv(
                     if state.initialization_event is not None:
                         main_stream.wait_event(state.initialization_event)
                     workspace.fused_copy_buffers = (
-                        torch.tensor(peer_scratch_ptrs, dtype=torch.int64, device=device),
-                        torch.tensor(peer_signal_ptrs, dtype=torch.int64, device=device),
+                        torch.tensor(
+                            peer_scratch_ptrs, dtype=torch.int64, device=device
+                        ),
+                        torch.tensor(
+                            peer_signal_ptrs, dtype=torch.int64, device=device
+                        ),
                         torch.zeros(7, dtype=torch.uint32, device=device),
                     )
                     state.initialization_event = torch.cuda.Event(enable_timing=False)

--- a/tests/comm/test_all_gather_matmul_cake.py
+++ b/tests/comm/test_all_gather_matmul_cake.py
@@ -55,7 +55,7 @@ def _manifest(backend, source: bytes, arch: str):
         "arch": arch,
         "compile_flags": ["--use_fast_math"],
         "tma_abi": "pointer",
-        "kernel_count": 12,
+        "kernel_count": 13,
         "launch": backend._launch_contract(source, arch),
         "constraints": backend._constraints_for_arch(arch),
         "kernel_symbols": list(backend._KERNEL_SYMBOLS),

--- a/tests/comm/test_all_gather_matmul_cake.py
+++ b/tests/comm/test_all_gather_matmul_cake.py
@@ -56,7 +56,7 @@ def _manifest(backend, source: bytes, arch: str):
         "compile_flags": ["--use_fast_math"],
         "tma_abi": "pointer",
         "kernel_count": 12,
-        "launch": backend._launch_contract(source),
+        "launch": backend._launch_contract(source, arch),
         "constraints": backend._constraints_for_arch(arch),
         "kernel_symbols": list(backend._KERNEL_SYMBOLS),
         "route_coverage": copy.deepcopy(backend._ROUTE_COVERAGE),
@@ -162,14 +162,14 @@ def test_source_launch_contract_rejects_missing_or_divergent_main_smem(source):
     backend = _backend()
 
     with pytest.raises(RuntimeError, match="one uniform SMEM_TOTAL"):
-        backend._launch_contract(source)
+        backend._launch_contract(source, "sm_100a")
 
 
 @pytest.mark.parametrize("arch", ["sm_100a", "sm_103a"])
 def test_packaged_program_has_self_contained_pointer_abi(arch):
     backend = _backend()
 
-    source_path, _ = backend._program_source(arch)
+    source_path, manifest = backend._program_source(arch)
     source = source_path.read_bytes()
 
     assert (
@@ -178,6 +178,12 @@ def test_packaged_program_has_self_contained_pointer_abi(arch):
     )
     assert source.count(b"CakeTensorMap const*") == 18
     assert backend._resolved_main_smem_bytes(source) == 197632
+    if arch == "sm_103a":
+        assert manifest["launch"]["main"]["grid_y"] == (
+            "4 if world_size == 8 and M == 512 and N == 1280 else 1"
+        )
+    else:
+        assert "grid_y" not in manifest["launch"]["main"]
 
 
 def test_packaged_bf16_ws4_derives_private_packed_width_from_grid():
@@ -212,9 +218,10 @@ def test_packaged_bf16_ws4_derives_private_packed_width_from_grid():
         "                      dtype_code == 0" in rendered
     )
 
-    sm100_source, sm100_manifest = backend._program_source("sm_100a")
-    assert sm100_source.read_bytes() == source_path.read_bytes()
+    _, sm100_manifest = backend._program_source("sm_100a")
     assert "prepared_packed_qkv" not in sm100_manifest["constraints"]
+    sm100_rendered = backend._render_host_source("test_module", sm100_manifest)
+    assert "kPackedQkvExperimentSupported =\n    false;" in sm100_rendered
 
 
 @pytest.mark.parametrize(

--- a/tests/comm/test_all_gather_matmul_cake.py
+++ b/tests/comm/test_all_gather_matmul_cake.py
@@ -944,11 +944,17 @@ def test_validate_inputs_keeps_packed_qkv_routes_private(
     ("arch", "dtype", "world_size", "n", "message"),
     [
         (
-            "sm_100a", torch.bfloat16, 4, 2560,
+            "sm_100a",
+            torch.bfloat16,
+            4,
+            2560,
             "requires bfloat16 and SM100/SM103 TP8 or SM103 TP4",
         ),
         (
-            "sm_103a", torch.float16, 4, 2560,
+            "sm_103a",
+            torch.float16,
+            4,
+            2560,
             "requires bfloat16 and SM100/SM103 TP8 or SM103 TP4",
         ),
         ("sm_103a", torch.bfloat16, 2, 2560, "requires exact K=8192"),
@@ -1156,9 +1162,7 @@ def _fake_prepared_packed_qkv(
             descriptor_entry,
         )[1],
     )
-    launcher = backend._prepare_all_gather_matmul_cake_packed_qkv(
-        inp, weight, group
-    )
+    launcher = backend._prepare_all_gather_matmul_cake_packed_qkv(inp, weight, group)
     calls = SimpleNamespace(
         validation=validation_calls,
         arch=arch_calls,

--- a/tests/comm/test_all_gather_matmul_cake.py
+++ b/tests/comm/test_all_gather_matmul_cake.py
@@ -101,9 +101,9 @@ def test_host_launch_consumes_manifest_smem(tmp_path, monkeypatch):
     rendered = backend._render_host_source("test_module", manifest)
 
     assert "constexpr int32_t kMainSmemBytes = 197632;" in rendered
-    assert "kPackedQkvExperimentSupported =\n    false;" in rendered
+    assert "kSm103PackedQkvSpecialization =\n    false;" in rendered
     assert "CAKE_MAIN_SMEM_BYTES" not in rendered
-    assert "CAKE_PACKED_QKV_EXPERIMENT_SUPPORTED" not in rendered
+    assert "CAKE_SM103_PACKED_QKV_SPECIALIZATION" not in rendered
     assert "main_cuda_stream != 0" not in rendered
     assert "comm_cuda_stream != 0 && bridge_cuda_event != 0" in rendered
     assert source_path.read_bytes().count(b"#define SMEM_TOTAL 197632") == 6
@@ -144,8 +144,9 @@ def test_host_prepared_launcher_has_fixed_tp8_peer_abi(tmp_path, monkeypatch):
     assert "std::array<const TensorView*, 7> peer_signal" in rendered
     assert "std::array<int64_t, 7> expected_peer_scratch" in rendered
     assert "std::array<int64_t, 7> expected_peer_signal" in rendered
-    assert "world_size == 4 && weight.size(1) == 2560" in rendered
-    assert "world_size == 8 && weight.size(1) == 1280" in rendered
+    normalized = " ".join(rendered.split())
+    assert "world_size == 4 && weight.size(1) == 2560" in normalized
+    assert "world_size == 8 && weight.size(1) == 1280" in normalized
     assert "int64_t ready_target, int64_t main_cuda_stream" in rendered
     assert "static_cast<uint32_t>(ready_target)" in rendered
     assert "cuMemsetD32Async" not in rendered
@@ -176,7 +177,7 @@ def test_packaged_program_has_self_contained_pointer_abi(arch):
         source.count(b"struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };")
         == 1
     )
-    assert source.count(b"CakeTensorMap const*") == 18
+    assert source.count(b"FlashInferTensorMap const*") == 18
     assert backend._resolved_main_smem_bytes(source) == 197632
     if arch == "sm_103a":
         assert manifest["launch"]["main"]["grid_y"] == (
@@ -212,16 +213,16 @@ def test_packaged_bf16_ws4_derives_private_packed_width_from_grid():
     }
     assert manifest["launch"]["main"]["grid_x"] == ("(min(M, 2432) / 128) * (N / 256)")
     rendered = backend._render_host_source("test_module", manifest)
-    assert "kPackedQkvExperimentSupported =\n    true;" in rendered
-    assert (
-        "kPackedQkvExperimentSupported && world_size == 8 &&\n"
-        "                      dtype_code == 0" in rendered
-    )
+    assert "kSm103PackedQkvSpecialization =\n    true;" in rendered
+    assert "world_size == 8 && dtype_code == 0" in rendered
 
     _, sm100_manifest = backend._program_source("sm_100a")
-    assert "prepared_packed_qkv" not in sm100_manifest["constraints"]
+    assert sm100_manifest["constraints"]["prepared_packed_qkv"] == {
+        "dtypes": ["bfloat16"],
+        "n_by_world_size": {"8": [1280]},
+    }
     sm100_rendered = backend._render_host_source("test_module", sm100_manifest)
-    assert "kPackedQkvExperimentSupported =\n    false;" in sm100_rendered
+    assert "kSm103PackedQkvSpecialization =\n    false;" in sm100_rendered
 
 
 @pytest.mark.parametrize(
@@ -748,7 +749,7 @@ def test_ensure_launch_state_records_initialization_after_device_state(monkeypat
         world_size = 4
 
         def get_buffer(self, peer, shape, dtype, offset):
-            assert shape == (2,)
+            assert shape == (18,)
             assert dtype == torch.uint32
             assert offset == 0
             return FakePeer(1000 + peer)
@@ -936,14 +937,20 @@ def test_validate_inputs_keeps_packed_qkv_routes_private(
         inp, weight, subgroup, packed_qkv_experiment=True
     ) == (3, rank, world_size, "tp-group")
     assert "_all_gather_matmul_cake_packed_qkv_sm103_tp4" not in backend.__all__
-    assert "_prepare_all_gather_matmul_cake_packed_qkv_sm103" not in backend.__all__
+    assert "_prepare_all_gather_matmul_cake_packed_qkv" not in backend.__all__
 
 
 @pytest.mark.parametrize(
     ("arch", "dtype", "world_size", "n", "message"),
     [
-        ("sm_100a", torch.bfloat16, 4, 2560, "requires SM103 and bfloat16"),
-        ("sm_103a", torch.float16, 4, 2560, "requires SM103 and bfloat16"),
+        (
+            "sm_100a", torch.bfloat16, 4, 2560,
+            "requires bfloat16 and SM100/SM103 TP8 or SM103 TP4",
+        ),
+        (
+            "sm_103a", torch.float16, 4, 2560,
+            "requires bfloat16 and SM100/SM103 TP8 or SM103 TP4",
+        ),
         ("sm_103a", torch.bfloat16, 2, 2560, "requires exact K=8192"),
         ("sm_103a", torch.bfloat16, 4, 1280, "requires exact K=8192"),
         ("sm_103a", torch.bfloat16, 8, 2560, "requires exact K=8192"),
@@ -1149,7 +1156,7 @@ def _fake_prepared_packed_qkv(
             descriptor_entry,
         )[1],
     )
-    launcher = backend._prepare_all_gather_matmul_cake_packed_qkv_sm103(
+    launcher = backend._prepare_all_gather_matmul_cake_packed_qkv(
         inp, weight, group
     )
     calls = SimpleNamespace(
@@ -1242,7 +1249,7 @@ def test_prepare_packed_qkv_binds_host_identity_once(monkeypatch):
     assert calls.arch == [torch.device("cuda:3")]
     assert calls.module == ["sm_103a"]
     assert len(calls.descriptor) == 1
-    assert "_prepare_all_gather_matmul_cake_packed_qkv_sm103" not in backend.__all__
+    assert "_prepare_all_gather_matmul_cake_packed_qkv" not in backend.__all__
     with pytest.raises(AttributeError):
         launcher.peer_routes = ()
 

--- a/tests/comm/test_all_gather_matmul_cake_e2e.py
+++ b/tests/comm/test_all_gather_matmul_cake_e2e.py
@@ -64,7 +64,9 @@ def _run_cake_subgroup(rank: int, world_size: int, port: int, dtype: torch.dtype
         assert packed_first.data_ptr() != packed_second.data_ptr()
         torch.testing.assert_close(packed_first, packed_first_snapshot, atol=0, rtol=0)
         torch.testing.assert_close(packed_first, packed_expected, atol=1e-2, rtol=1e-2)
-        torch.testing.assert_close(packed_second, -packed_expected, atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(
+            packed_second, -packed_expected, atol=1e-2, rtol=1e-2
+        )
         del (
             active_inp,
             packed_expected,

--- a/tests/comm/test_all_gather_matmul_cake_e2e.py
+++ b/tests/comm/test_all_gather_matmul_cake_e2e.py
@@ -38,29 +38,33 @@ def _run_cake_subgroup(rank: int, world_size: int, port: int, dtype: torch.dtype
     if (
         world_size == 8
         and dtype == torch.bfloat16
-        and get_compute_capability(device) == (10, 3)
+        and get_compute_capability(device) in ((10, 0), (10, 3))
     ):
+        packed_rows = 512
         packed_weight = torch.randn(8192, 1280, dtype=dtype, device=device)
-        active_inp = symm_mem.empty(rows, 8192, dtype=dtype, device=device).normal_()
+        active_inp = symm_mem.empty(
+            packed_rows, 8192, dtype=dtype, device=device
+        ).normal_()
         packed_gathered = torch.empty(
-            world_size * rows, 8192, dtype=dtype, device=device
+            world_size * packed_rows, 8192, dtype=dtype, device=device
         )
         dist.all_gather_into_tensor(packed_gathered, active_inp, group=group)
         packed_expected = packed_gathered @ packed_weight
         packed_launcher = prepare_all_gather_matmul(
-            inp, packed_weight, group, backend="cake"
+            active_inp, packed_weight, group, backend="cake"
         )
         packed_stream = torch.cuda.Stream(device=device)
         packed_stream.wait_stream(torch.cuda.current_stream(device))
         with torch.cuda.stream(packed_stream):
             packed_first = packed_launcher(active_inp)
             packed_first_snapshot = packed_first.clone()
+            active_inp.neg_()
             packed_second = packed_launcher(active_inp)
         torch.cuda.current_stream(device).wait_stream(packed_stream)
         assert packed_first.data_ptr() != packed_second.data_ptr()
         torch.testing.assert_close(packed_first, packed_first_snapshot, atol=0, rtol=0)
         torch.testing.assert_close(packed_first, packed_expected, atol=1e-2, rtol=1e-2)
-        torch.testing.assert_close(packed_second, packed_expected, atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(packed_second, -packed_expected, atol=1e-2, rtol=1e-2)
         del (
             active_inp,
             packed_expected,

--- a/tests/comm/test_all_gather_matmul_dispatch.py
+++ b/tests/comm/test_all_gather_matmul_dispatch.py
@@ -77,7 +77,7 @@ def test_prepare_backend_forwards_exact_binding(monkeypatch, backend):
         calls.append((actual_inp, actual_weight, actual_group, verbose))
         return launcher
 
-    backend_module._prepare_all_gather_matmul_cake_packed_qkv_sm103 = fake_prepare
+    backend_module._prepare_all_gather_matmul_cake_packed_qkv = fake_prepare
     monkeypatch.setitem(sys.modules, backend_module.__name__, backend_module)
 
     assert (
@@ -98,7 +98,7 @@ def test_prepare_unsupported_input_failure_propagates(monkeypatch):
     def reject(*args, **kwargs):
         raise ValueError("unsupported prepared configuration")
 
-    backend_module._prepare_all_gather_matmul_cake_packed_qkv_sm103 = reject
+    backend_module._prepare_all_gather_matmul_cake_packed_qkv = reject
     monkeypatch.setitem(sys.modules, backend_module.__name__, backend_module)
 
     with pytest.raises(ValueError, match="unsupported prepared configuration"):


### PR DESCRIPTION
TP8 packed QKV uses four CTA rows and a serialized fused peer-copy helper on SM103 for BF16 local M=512, K=8192, N=1280. SM100 supports the same packed-QKV shape through the generic peer-copy route with grid y=1. The host allocates `2 + 4 * world_size` uint32 mailbox flags, matching the double-buffered synchronization protocol. Architecture-specific manifests and dispatch select the appropriate exported kernel.

Published head: `92b9e398676f7229883a21b59e306794e73dd93d` (tree `f9a5cf651d35fd49f6c58766766722d71e20f72a`). This successor applies the CI-requested line wrapping in four Python files; all four Python ASTs and all generated/native payloads are unchanged from tested commit `f037814544ab714be40ffc02fcd3e935b4ca6c6f` (tree `ff92f6abb73d12096010c63705e884642193f559`). Hardware measurements below retain their actual f037 official-wheel identity; they are not new executions at the formatting successor.

## Source and export identity

The earlier source performance runs below executed a retained source projection directly. After the SM100 packed-QKV dispatch metadata update, canonical export regenerated both architecture outputs and verified that their generated CUDA bytes were unchanged. The final source integration adds documentation and contract aggregation metadata to that export-proven source. The public candidate contains those exact exports plus its host allocation and architecture-dispatch updates. These source timings are distinct from final-wheel public-API timings.

Both packaged CUDA exports are 121254 bytes, SHA256 `ef39c0d6ddfa1e038fc50bdf6137e8df872142faaadfe31a3a1fbe271e11d94d`. Manifest SHA256: SM100 `ef58c02589f20ced592af02e908bb01d7255b0c77a051a71ea1118559b6a9b55`; SM103 `b70379dcb14659d8102e00776ff6a126cd5996a448d363489452444d856ab37d`. The recorded public correctness and sanitizer payload had exactly tree ff92, installed as a candidate overlay using the preceding package metadata. The subsequent official wheel was built from actual commit f037; no preceding run is relabeled as an official-wheel execution.

## Latest prepared-source comparison: eight B200 and eight B300 GPUs

These executions use standalone source tree `f7d1b20d76cbb673957fb9fc76a68771261fce83` and canonical timer SHA256 `2a7c5f4789acecedca349c6239ed1f07aff2956146738db1bb240265a72dbdca`. They are fresh executions of that tree; the retained earlier-source measurements and sanitizer runs below keep their original identities. All 209 inputs to the retained native module match this source tree, so that unchanged module was reused. The source tree label does not identify a new FlashInfer package build.

For source versus cuTile, both architectures use identical BF16 TP8 workloads, K8192/N2048, global M=8×local M, standard-normal inputs, seed 52, the same cuTile baseline commit `c656c1196286e99d68656f14118a535dc5248c80` (wheel SHA256 `df00e8f880c50d0941d4266869180b7ec2685e09f371c1469e4e098ebec83676`), canonical cold-L2 CUPTI, paired ABBA and maximum-rank medians. Each cuTile/source ratio must be strictly greater than 1.0×.

| Local M | B200 source ms | B200 cuTile ms | B200 cuTile/source | B300 source ms | B300 cuTile ms | B300 cuTile/source |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 65536 | 26.1815210 | 31.0165200 | 1.184672× | 25.6586900 | 30.7232445 | 1.197382× |
| 32768 | 13.1660490 | 15.9422045 | 1.210857× | 13.0759460 | 15.9366535 | 1.218776× |
| 16384 | 6.1277045 | 8.1512165 | 1.330223× | 6.1721185 | 8.1296240 | 1.317153× |
| 8192 | 3.1344920 | 4.7942985 | 1.529530× | 3.2382530 | 4.7614855 | 1.470387× |
| 4096 | 1.6085275 | 2.6841110 | 1.668676× | 1.5362035 | 2.5514250 | 1.660864× |
| 2048 | 0.9356660 | 1.1649305 | 1.245028× | 0.8405770 | 1.0266560 | 1.221371× |
| 1024 | 0.7077295 | 1.0610580 | 1.499242× | 0.7093420 | 0.9972320 | 1.405855× |

All seven comparative rows pass on each architecture. B200 geometric mean is **1.370700×**, minimum **1.184672×**; B300 geometric mean is **1.347343×**, minimum **1.197382×**. Each architecture also passes correctness-only FP16 M16384, BF16 M19456 and packed-QKV BF16 M512/K8192/N1280, for ten correctness rows and eight rank completions. The seven N2048 rows use grid y=1; their speedups do not establish N1280 performance.

B200 verifies 80 candidate rank correctness checks, 56 baseline preflight checks, complete routes with zero external fallbacks, and 84,576 reportable rank/arm CUPTI samples. Measured-row runtime is **182.087188 s**, registered command **217.796813 s**, managed runtime **292.065210 s**, and submission-to-terminal physical turnaround **292.914876 s**. Result SHA256: `fc4d6d4cf6db7aa9b54d1fdc14531f07a9972a83c70ad50500408709261d7863`; original registered-report SHA256: `e014fca416de3607fe456f36b2408d0f5be2f1b8b05453d667f2caba99259635`.

B300 verifies 80 candidate rank correctness checks, 56 baseline preflight checks, complete routes with zero external fallbacks, and 83,168 validated rank/arm CUPTI samples. Both architectures use correctness tolerance atol=rtol=0.01. B300 measured-row runtime is **272.771914 s**, registered command **311.016003 s**, managed runtime **397.258994 s**, and submission-to-terminal physical turnaround **398.086380 s**. Result SHA256: `44240a844bd47389a393ace7529f76b3622f1070ecb1b1f5773641d34531d76c`. Benchmark and bounded receipt audits pass. Original registered-report SHA256: `5843c121e4f53591328fce9d512e8fdd6b64923cbf34de79d2dd350ff8c67bad`. All 12 new registered-run artifact hashes reconcile with the saved row and snapshot receipts; all eight rank-completion hashes also match. Full raw reports and CUPTI sidecars remain preserved under their original execution identity.

## Latest prepared-source versus official public API

Both comparisons use standalone source tree `f7d1b20d76cbb673957fb9fc76a68771261fce83` and the unchanged official f037 wheel identified below. On each architecture, four fresh processes run source/public/public/source for BF16 TP8 local/global M512/4096, K8192/N1280. Each process has three repeats, five untimed warmups and twenty cold-L2 CUPTI samples per repeat. Each row averages the two source maximum-rank medians and the two public maximum-rank medians. Public speedup is source/public; source speedup is the reciprocal.

| Architecture | Repeat | Source ms | Official public ms | Public speedup | Source speedup |
| --- | ---: | ---: | ---: | ---: | ---: |
| SM100 / B200 | 1 | 0.76273525 | 0.70929700 | 1.075340× | 0.929939× |
| SM100 / B200 | 2 | 0.77019950 | 0.80827375 | 0.952894× | 1.049434× |
| SM100 / B200 | 3 | 0.75148100 | 0.68580825 | 1.095760× | 0.912609× |
| SM103 / B300 | 1 | 0.40983050 | 0.30802500 | 1.330511× | 0.751591× |
| SM103 / B300 | 2 | 0.46655850 | 0.32058425 | 1.455338× | 0.687126× |
| SM103 / B300 | 3 | 0.55792450 | 0.30716875 | 1.816345× | 0.550556× |

B200 public-speedup GM is **1.039366×** (reciprocal **0.962125×**); its second repeat favors source. B300 public-speedup GM is **1.520758×** (reciprocal **0.657567×**), with public faster in all three repeats. This source/public comparison is separate from the seven-shape source/cuTile gate.

Each architecture passes 576 correctness checks, 256 source reusable-epoch assertions, 288 source-storage checks, 288 public retained-output checks, 32 clean rank completions, M256/M512 interleaving, matching workload/timing signatures, bit-exact cross-arm outputs, exact CUPTI routes and native isolation. Each has 1,920 rank timing samples. SM100 uses the CE peer-copy route without a fused helper; SM103 uses the fused-P32 route.

| Architecture | Maximum-rank workload sum s | Physical process sum s | Batch s | Managed s | Submission-to-terminal s |
| --- | ---: | ---: | ---: | ---: | ---: |
| SM100 / B200 | 149.244075 | 208.648238 | 232.704296 | 249.151044 | 250.150905 |
| SM103 / B300 | 249.803724 | 314.744196 | 358.434339 | 374.092103 | 375.209552 |

B200 result SHA256: `1d3d4c634bb9446e2c6c089cea988927a1f2aef65e1b9322f3e39e3e96bb454c`; original full-identity SHA256: `c9dc8696abd401d3c7c309b32437083ae342cf0ce537e108bb1d9e90d36c4de8`. B300 result SHA256: `e478d94e63b83eb90f9e1010716d4b268453177f86adf5699604b7c57f47508e`; original full-identity SHA256: `b5a0feaa4aebd11f2043f0e49da82a5c8d21b61b19d57d73882c17b93a61383a`. All 33 new B300 ABBA result-artifact hashes reconcile with the recorded receipts; the original raw logs remain preserved. These comparisons add no new sanitizer or serving execution claim.

## Earlier source projection versus cuTile: SM100 / eight B200s

Identical BF16 TP8 workloads, K8192/N2048, global M=8×local M, against cuTile from FlashInfer `c656c1196286e99d68656f14118a535dc5248c80`. Timing uses canonical cold-L2 CUPTI, paired ABBA and maximum-rank medians. Every comparative row must exceed 1.0×; geometric mean is a cross-shape summary.

| Local M | Source ms | cuTile ms | cuTile/source |
| ---: | ---: | ---: | ---: |
| 65536 | 25.8811250 | 30.9193570 | 1.194668× |
| 32768 | 12.9458285 | 15.9008315 | 1.228259× |
| 16384 | 6.0791230 | 8.0983430 | 1.332156× |
| 8192 | 3.1621890 | 4.9279950 | 1.558413× |
| 4096 | 1.5663510 | 2.5899545 | 1.653496× |
| 2048 | 0.8223545 | 0.9905480 | 1.204527× |
| 1024 | 0.6745915 | 1.0002715 | 1.482781× |

All seven rows pass; geometric mean **1.368661×**, minimum **1.194668×**. Ten correctness rows, complete routes with no external fallbacks, and eight rank completions passed on actual SM100 hardware. Measured-row runtime: **272.267169 s**; registered command: **378.448895 s**; physical turnaround: **1080.709207 s**.

## Earlier source projection versus cuTile: SM103 / eight B300s

The same shapes, pinned cuTile baseline, timing method and per-shape acceptance apply.

| Local M | Source ms | cuTile ms | cuTile/source |
| ---: | ---: | ---: | ---: |
| 65536 | 23.8101150 | 28.9214660 | 1.214671× |
| 32768 | 11.9789640 | 14.9336400 | 1.246655× |
| 16384 | 5.6753380 | 7.7276140 | 1.361613× |
| 8192 | 3.0889980 | 4.5455770 | 1.471538× |
| 4096 | 1.5660350 | 2.5286290 | 1.614670× |
| 2048 | 0.7973615 | 0.9637620 | 1.208689× |
| 1024 | 0.6134575 | 0.9047055 | 1.474765× |

All seven rows pass; geometric mean **1.362857×**, minimum **1.208689×**. Ten correctness rows, complete routes with no external fallbacks, and eight rank completions passed. Measured-row runtime: **205.790277 s**; registered command: **239.132412 s**; physical turnaround: **286.879898 s**.

Both architectures also passed correctness-only rows for FP16 M16384, BF16 non-power-of-two M19456 and packed QKV BF16 M512/K8192/N1280. The N2048 performance rows use grid y=1; the packed-QKV row does not establish a separate N1280 performance result.

## Public candidate and official package

Recorded SM103 public candidate validation passed 144 correctness checks, 144 retained-output checks, 16 reusable epochs per rank, M256/M512 interleaving, exact CUPTI routes and native isolation. Both separate sanitizer runs passed 144 checks and eight clean rank exits. Synccheck reported zero errors; racecheck reported zero hazards, errors and warnings. Sanitizers cover launched kernels except NCCL internal transport kernels and run without CUPTI; routes and isolation come from the separate correctness run.

| Original candidate-overlay evidence | Measured maximum-rank runtime s | Physical turnaround s |
| --- | ---: | ---: |
| Correctness / routes / isolation | 69.428493 | 186.298722 |
| Synccheck | 184.205730 | 248.461311 |
| Racecheck | 272.490861 | 363.788799 |

The official wheel build and complete installation verification passed for commit f037. The wheel is 36177235 bytes, SHA256 `bde34afb1ce3c3fc716ec0660f9a4e2de61077909f9a36d942908494d9841be0`, and its build metadata records the actual commit. Official build runtime was **1128.096168 s**, total build/install/verification runtime **1248.230369 s**, and physical turnaround **1309.323989 s**. Target-cluster installation verified **7532 runtime members** from this unchanged wheel: successful installation runtime **337.795135 s**, attempt turnaround **399.492244 s**, and first-resume submission through completion **2430.939085 s**. Building or installing the package does not itself add GPU measurements.

## Earlier source projection versus official public API: SM100

The official f037 wheel and the export-proven source projection completed a paired comparison on eight actual B200s: BF16 TP8, local/global M512/4096, K8192/N1280. Four fresh processes ran source/public/public/source, each with three repeats, five untimed warmups and twenty cold-L2 CUPTI samples per repeat. Each row averages the two source maximum-rank medians and the two public maximum-rank medians.

| Repeat | Source ms | Official public ms | Public speedup (source/public) | Source speedup (public/source) |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 0.85142550 | 0.71838525 | 1.185193× | 0.843744× |
| 2 | 0.82035275 | 0.67626625 | 1.213062× | 0.824360× |
| 3 | 0.92394575 | 0.76292250 | 1.211061× | 0.825722× |

The public API is faster in all three repeats: public-speedup GM **1.203038×**, reciprocal source-speedup GM **0.831229×**. This source/public comparison is separate from the source/cuTile per-shape gate.

Four verified pass seals and 32 clean rank completions establish **576 correctness checks**, **256 source reuse assertions**, **288 source storage observations** and **288 public retained-output checks**. M256/M512 interleaving, reusable epochs, exact CUPTI routes, native isolation and bit-exact outputs pass; workload and timing signatures match across all four processes. SM100 uses the CE peer-copy route with no fused helper or fused counters. The run contains **1920 rank timing samples**.

Maximum-rank workload runtime sum: **131.897628 s**; physical process sum: **195.762053 s**; batch runtime: **221.134788 s**; managed runtime: **254.153926 s**; actual submission-to-terminal physical turnaround: **258.928194 s**. The tested package is official commit `f037814544ab714be40ffc02fcd3e935b4ca6c6f`, tree `ff92f6abb73d12096010c63705e884642193f559`, wheel SHA256 `bde34afb1ce3c3fc716ec0660f9a4e2de61077909f9a36d942908494d9841be0`. Result SHA256: `af88b84fa1fa914228ee0787a3eaacc192f5b8b61f786d50e1321f31e9321f26`; full original identity SHA256: `5c1b869df4813b5e89f952e2f5560137c5c387ed1be772734a1f8ec206a23310`. These measurements retain their f037 execution identity and add no sanitizer claim.

## Earlier source projection versus official public API: SM103

The official f037 wheel and the export-proven source projection completed a fresh paired comparison on eight B300s: BF16 TP8, local/global M512/4096, K8192/N1280. Four fresh processes ran source/public/public/source, each with three repeats, five untimed warmups and twenty cold-L2 CUPTI samples per repeat. Each row averages the two source maximum-rank medians and the two public maximum-rank medians.

| Repeat | Source ms | Official public ms | Public speedup (source/public) |
| ---: | ---: | ---: | ---: |
| 1 | 0.69062525 | 0.63907325 | 1.080667× |
| 2 | 0.63772900 | 0.53622525 | 1.189293× |
| 3 | 0.66537700 | 0.64682550 | 1.028681× |

The official public API is faster in all three repeats, with a public-speedup geometric mean of **1.097540×**. The reciprocal source-speedup GM is **0.911128×**. This compares source and public implementations separately from the source/cuTile per-shape gate.

Four completed pass seals and 32 clean rank completions establish **576 correctness checks**, **256 source reuse assertions**, **288 source storage observations**, **288 public retained-output checks**, and **1504 source zero-counter checks**. M256/M512 interleaving, exact routes, native isolation and bit-exact outputs passed; fresh workload and timing signatures matched across all four processes. The run contains **1920 rank timing samples**.
Maximum-rank workload runtime sum: **186.744612 s**; physical process sum: **249.616150 s**; managed runtime: **323.759622 s**; actual submission-to-terminal physical turnaround: **324.549698 s**. The package binding uses the official f037 wheel SHA256 recorded above. This comparison adds no sanitizer or serving claim.

## Retained SM100 source/public sanitizer evidence

| Payload / tool | Correctness / clean ranks | Maximum-rank workload s | Physical submission-to-terminal s |
| --- | ---: | ---: | ---: |
| Source / synccheck | 144 / 8 | 152.446307 | 213.633912 |
| Official public API / synccheck | 144 / 8 | 169.487140 | 257.448675 |
| Source / racecheck | 144 / 8 | 239.891819 | 299.855235 |
| Official public API / racecheck | 144 / 8 | 248.137925 | 306.849004 |

Each pass covers 16 reusable epochs per rank and M256/M512 interleaving. The public runs each include 144 retained-output checks; each source sanitizer run includes 128 reuse assertions and 144 output-storage checks. Each has eight clean rank completions, zero process exit codes, and result/process/sanitizer-log hashes matching its seal. Every synccheck rank reports zero errors; every racecheck rank reports zero hazards, errors and warnings. Scope excludes NCCL internal transport kernels matching `ncclDev(Func|Kernel).*`; CUPTI is disabled. These sanitizer runs add no CUPTI route/isolation or performance claim; those checks come from the separate comparison above.

The public runs use the unchanged official f037 wheel recorded above. Public synccheck physical process runtime was **188.742848 s**, batch **220.751068 s**, managed **256.420841 s**, and actual submission-to-terminal turnaround **257.448675 s**. Result SHA256 `c84820fd5916de10d44b9d66ca6a80801919a476cf92f01f66f214c6fa1aade5`; full original identity SHA256 `dba3dd572b93df8f8e9e83d6266cf8a42de27bf01edb3c4bd5568fef7aaad66c`.

Source racecheck physical process was **257.969875 s**, batch **281.901288 s**, managed **298.919530 s**; actual submission-to-terminal physical turnaround **299.855235 s**. Result SHA256 `c6839f70f91700990fd35d3a6e47c2707003bee5cf0a2806a2276833472f454d`; original identity SHA256 `a9ae1476aed557f21f966eb841874f862051d31a09a016b5a4b22ad26f0b40d7`.

Public racecheck physical process was **266.040934 s**, batch **289.472853 s**, managed **305.892351 s**; actual submission-to-terminal physical turnaround **306.849004 s**. Result SHA256 `dd6becefc6792612a4c46c72b1c678f435dc5da519ace98cbfb6168b7be7601d`; original identity SHA256 `fd21ffe643ac37463fe5929f258e167e1c411bbd951d75916cb05fac7f7060e3`.

Source synccheck physical process was **169.728984 s**, batch **192.660966 s**, managed **212.652857 s**; actual submission-to-terminal physical turnaround **213.633912 s**. All eight sanitizer summaries report zero errors. Result SHA256 `eba2f236b298154db1c82d3b64d92bae69ca7e268c055ffda4ec40278442384b`; original identity SHA256 `f54c736b4cbbff4a058e1c26c76df377da7f3221b3e1184d89f1d4f07a8d15fd`. All five staged SM100 cells are complete: source/public ABBA and four separate sanitizer commands. These results retain their original source and f037 package identities.

## Integration and published-head CI evidence

| Evidence | Status and tested identity |
| --- | --- |
| Official-wheel SM100 source/public-API comparison | PASS: exact package identity, numerical correctness, reusable epochs, routes/isolation and comparative timings are recorded above. |
| SM100 separate source/public synccheck and racecheck | PASS: all four separate commands, each with 144 correctness checks and eight clean rank exits; zero synccheck errors and zero racecheck hazards/errors/warnings. |
| Earlier real Llama-3.1-70B-Instruct true sequence-parallel TP8 serving | Historical PASS on eight B200 and eight B300 GPUs using SGLang `6dc8c9445338c8fbd92a12162dd6a97673f50933` and this official wheel. Both architectures match all 96 candidate/native and 96 native/native token-ID requests; maximum candidate logprob deltas are 0.0003813989460468292 (B200) and 0.0003831770736724138 (B300), native delta 0. Exact eight-rank routes, 80 bindings/rank, 2560 QKV hits/rank/measurement, native isolation and synchronization disabled all pass. |
| Final published-head CI, review and merge | Lint and docs pass at `92b9e398676f7229883a21b59e306794e73dd93d`; PR Test attempt 2 passes all 14 jobs, including all 11 configured build/test matrix cells. Required review and merge remain pending. |

PR Test [run 34748467094, attempt 2](https://github.com/flashinfer-ai/flashinfer/actions/runs/34748467094/attempts/2) passed all 11 executed matrix cells: four CPU AOT build/import cells (x64/arm64, CUDA 12.9/13.0), five A10G JIT shards, T4 JIT, and H100 JIT. The run is associated with head `92b9e398676f7229883a21b59e306794e73dd93d`; the checked-out PR merge was `55887bc291c95c78903cdbe6c404c09e59365e6f` (head plus base `488ffbd9fe4455c3b4c3030cf668b5603c6698e4`). H100 reported 225,137 passed, 279,817 skipped, and zero failed; its test runtime was 7,546 s, and retry-to-completion turnaround was 7,616 s. These CI lanes do not provide SM100/SM103 TP8 GPU validation. The earlier runner-acquisition failure is superseded by this successful retry. The H100 lane passed 52 affected host tests and 10 dispatch tests; its two affected TP8 GPU E2E tests were skipped. SM100/SM103 correctness, sanitizer and timing evidence retains the separate hardware execution identities above.

## Current SGLang integration: true-SP TP8 serving on B200 and B300

[SGLang PR36766](https://github.com/sgl-project/sglang/pull/36766) now has real-model true sequence-parallel TP8 correctness evidence on eight actual B200 GPUs and eight actual B300 GPUs. Both execute clean SGLang commit `827dbfbf2883c1ab507b2309d0824d94f5ae57e1`, tree `7f36509440f9238f918dee650a385213871f4fc6`, with the official FlashInfer `f037814544ab714be40ffc02fcd3e935b4ca6c6f` wheel, tree `ff92f6abb73d12096010c63705e884642193f559`, wheel SHA256 `bde34afb1ce3c3fc716ec0660f9a4e2de61077909f9a36d942908494d9841be0`. The version/checksum checks stay enabled; the original runtime receipt verifies 7,532 package files. Published FlashInfer formatting head `92b9e398676f7229883a21b59e306794e73dd93d` retains its explicit AST/native-payload equivalence to the tested wheel; these runs are not relabeled as direct executions of 92b9.

The model is unquantized BF16 `meta-llama/Llama-3.1-70B-Instruct`, revision `1605565b47bb9346c5515c34102e054115b4f98b`, with all 30 verified shared shards read-only in place. Each architecture uses one server across native-A/candidate/native-B, each one warmup and three measurements of 32 requests × 4096 input IDs × 32 output tokens, concurrency one and temperature zero. True-SP TP8 uses global/local M4096/512 and packed-QKV K8192/N1280. Synchronization is off, `CUDA_LAUNCH_BLOCKING=0`, diagnostics off and per-call artifacts disabled. No serving synchronization was added.

Both architectures match **96/96 candidate/native-A** and **96/96 native-B/native-A** token sequences. Maximum candidate logprob delta is **0.0003813989460468292 on B200** and **0.0003831770736724138 on B300**, below 0.05; native stability delta is **0**. Every measurement verifies all eight ranks, **80 prepared bindings per rank**, **2560 prepared-QKV hits per rank**, 32 full-M4096 calls and 992 decode fallbacks, with zero candidate artifacts in native arms. B200 uses CE peer-copy, main grid 20×1×1, no fused helper and start-barrier → main ordering. B300 uses 80 native-bound fused launchers, main grid 20×4×1, helper 32×7×1 and start-barrier → fused-peer-copy → completion-barrier → main ordering. Both have seven peer routes and 34 barrier slots per binding/rank respectively.

| Architecture / repeat | Native-A tokens/s | Candidate tokens/s | Native-B tokens/s | Interpolated native tokens/s | Candidate/native |
| --- | ---: | ---: | ---: | ---: | ---: |
| B200 / 1 | 23.261132172 | 22.952848376 | 22.600646963 | 22.914018209 | 1.001694603129× |
| B200 / 2 | 23.040452260 | 23.045842843 | 22.518273869 | 22.766422549 | 1.012273350962× |
| B200 / 3 | 23.176225112 | 22.954360069 | 22.544051045 | 22.845061564 | 1.004784338387× |
| B300 / 1 | 22.712963228 | 22.429038915 | 22.394396630 | 22.547879035 | 0.994729432412× |
| B300 / 2 | 23.275056452 | 22.533593011 | 22.520824528 | 22.883326641 | 0.984716661380× |
| B300 / 3 | 23.267995862 | 22.503065927 | 23.383714663 | 23.328426423 | 0.964619967023× |

Geometric-mean candidate/native ratios are **1.006240975155× on B200** and **0.981275224746× on B300**. These serving throughput ratios are informational, with no minimum speedup gate. The strictly greater-than-1.0 requirement continues to apply to the seven kernel-comparison shapes above.

| Architecture / repeat | Native-A measured seconds | Candidate measured seconds | Native-B measured seconds |
| --- | ---: | ---: | ---: |
| B200 / 1 | 44.021932914 | 44.613199339 | 45.308437483 |
| B200 / 2 | 44.443572047 | 44.433176385 | 45.474178259 |
| B200 / 3 | 44.183209089 | 44.610261271 | 45.422182463 |
| B300 / 1 | 45.084385939 | 45.655099351 | 45.725724025 |
| B300 / 2 | 43.995596836 | 45.443263286 | 45.469027954 |
| B300 / 3 | 44.008947142 | 45.504910456 | 43.791160419 |

| Architecture | Nine measured serving phases s | Three warmups s | Server ready / lifetime s | Launcher s | Managed workload s | Workload submission → terminal s |
| --- | ---: | ---: | --- | ---: | ---: | ---: |
| B200 | 402.510149250 | 151.937193807 | 255 / 859 | 1159.235669136 | 1181.555971146 | 1182.519948959 |
| B300 | 404.678115408 | 154.850899250 | 529 / 1134 | 1213.902644396 | 1237.637359381 | 1238.854870796 |

The B300 workload completed all 12 serving phases and its parity/routes/throughput analyzers. Its original managed result remains `HARNESS_FAILED` because the finalizer rejected the correct scheduler Unix timestamp encoded as a string. A separate CPU finalizer copy adds only integer-epoch parsing and seals PASS in **3.235293865 s** physical, leaving every existing timestamp, source/package, original harness, raw measurement and acceptance check unchanged; no GPU phase was repeated. Workload submission-to-final-seal turnaround is **1637.690051556 s**. The full chain from the first B300 SG827 attempt to the final seal is **7202.305768728 s**, including prior interrupted attempts and recovery. Final seal time is **2026-09-14 00:36:22.889903 UTC**. This distinction preserves the original measured serving durations and the physical recovery cost.

The B300 x86_64 runtime records PyTorch `2.13.0a0+9186a08b2c.nv26.07`, CUDA 13.3, `sglang-kernel` 0.4.6.post1, Transformers 5.8.1 and container digest `356846f927ed8f2fee14ebafd28fe45eb4bd6529a98bf0e0a8719ebd6c6aafbf`. It reuses the completed model-input receipt; current mount/access/size verification took 0.093951941 s with zero new weight hashes or copies. All 55 new raw artifacts and referenced phase/rank/workload hashes match, with an independent token/logprob/routes/throughput audit taking 0.200715542 s.

| Artifact | SHA256 |
| --- | --- |
| B200 completion seal | `5bb10d26e1fd7d5fd1bcf3bca8c19492126734c594a83d39f3d7ff43f3117902` |
| B200 token/logprob and raw phase hashes | `dc04dd00ce542ab9c037d8deee1afbe83248c9a677aeef223907cf492b8503e9` |
| B200 eight-rank route evidence | `0cb827d9601976edeff6677aed72d44149b198b741e3ac4e6213bab96bcdae7a` |
| B200 per-repeat throughput | `cf4717efaed80b04333d87d90ca374714945ad8de085ed974576ac2855aee2b1` |
| B200 exact runtime | `01bd16c8652b86c401c72e13a6bed66a8040ce6b4edecd074aaa758ab8f56bc9` |
| B300 completion seal | `8a67dfd151dbddc289b5074136720807bbd60fe65b7c072dfb36b7a84c4b5a3d` |
| B300 token/logprob and raw phase hashes | `0553e45b1018c386f4a804728a53ac88ed6c58e547c6bb86e11a10c3eaee1c0e` |
| B300 eight-rank route evidence | `94b82de20f6ad835d7761aaf27a2daab07215531436e65e32ced0a1911a912f8` |
| B300 per-repeat throughput | `9667b25a9945eda19077c5b6e4bab789c647ea01b809e75af3422134d55e16a4` |
| B300 exact runtime | `d366c82c6272544b60f64e57c4966bda39bdd4f9c4043aa8627d64b3550fcc13` |
| B200 workload harness manifest | `b61af7389908a90b24cce139c72a213c8a5469e2ff7fd5715e83ea78ecadedf8` |
| B300 original workload harness manifest | `648448c800f443d62f817f9078c270790b551be0a316c9bec565c7f9b044faad` |
| B300 original finalizer in workload harness | `e244022bfb1eddc43f5dbda2aed77c50725ffb6df2639122219ae71dfea7efb7` |
| B300 separately repaired CPU finalizer | `df44b102c9903ef20200bebddeb0e62d69d203c995b643999b9040883eb2a750` |
| Shared request input IDs | `c290140af3c4eaab2c2f4d98d8d5e85e89ad7360165c987c2e0377ecf6388b60` |
| Weight LFS manifest | `438a360fe1b9c1f748fdd543757f11eb677c453cc522aa61100c4a5e6dce2c6f` |

Original per-phase token/logprob records, workload receipts, eight rank-route records and server logs remain under their execution identities. The SGLang PR body contains the complete serving evidence and recovery linkage.

## Earlier SGLang execution identities

For those SGLang `6dc8c9445338c8fbd92a12162dd6a97673f50933` executions, measured-phase runtimes are **414.401067 s (B200)** and **403.592879 s (B300)**; submission-command-to-terminal turnaround is **1262.836780 s (B200)** and **1264.615915 s (B300)**. Informational candidate/native throughput ratios are **0.963051/0.965179/1.009118** (B200, GM **0.978888**) and **0.991565/0.992482/0.992629** (B300, GM **0.992225**). The SGLang PR includes per-repeat native-A/candidate/native-B metrics and reproducibility hashes. These retained executions do not establish validation of a later SGLang integration head.

SGLang end-to-end acceptance is correctness only; throughput is reported without a minimum speedup requirement. Its integration is tracked by [SGLang PR36766](https://github.com/sgl-project/sglang/pull/36766). Kernel comparative acceptance remains strictly greater than 1.0× for every measured shape.

Earlier source/package measurements retain their original evidence identities. All five earlier SM100 validation cells retain their original completed-run seals; the latest prepared-source measurements above have their own execution identities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved packed-QKV all-gather matrix multiplication performance on supported Blackwell hardware.
  * Added optimized fused peer-copy processing for bfloat16 workloads with eight-way parallelism and 512 × 1280 dimensions.
  * Improved workload distribution and synchronization for more reliable execution.

* **Compatibility**
  * Expanded prepared packed-QKV support across SM100 and SM103 GPU architectures.
  * Added support for additional supported bfloat16 configurations, including four-way parallelism with 2560 columns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

