### PR TITLE
fix(moe): align the CUTLASS NVFP4 fc1 scale-row check with the kernel layout

### DIFF
--- a/csrc/fused_moe/cutlass_backend/flashinfer_cutlass_fused_moe_binding.cu
+++ b/csrc/fused_moe/cutlass_backend/flashinfer_cutlass_fused_moe_binding.cu
@@ -1402,8 +1402,7 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
             fc1_weight_block.size(0) == num_experts_on_rank &&
             fc1_weight_block.size(1) ==
                 TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
-                    inter_size, TmaWarpSpecializedGroupedGemmInput::MinKDimAlignmentNVFP4) *
-                    2 &&
+                    inter_size * 2, TmaWarpSpecializedGroupedGemmInput::MinNDimAlignmentNVFP4) &&
             fc1_weight_block.size(2) * FP8_PER_INT32 *
                     TmaWarpSpecializedGroupedGemmInput::NVFP4BlockScaleVectorSize ==
                 TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
@@ -1416,7 +1415,7 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
             fc1_weight_block.size(0) == num_experts_on_rank &&
             fc1_weight_block.size(1) ==
                 TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
-                    inter_size, TmaWarpSpecializedGroupedGemmInput::MinKDimAlignmentNVFP4) &&
+                    inter_size, TmaWarpSpecializedGroupedGemmInput::MinNDimAlignmentNVFP4) &&
             fc1_weight_block.size(2) * FP8_PER_INT32 *
                     TmaWarpSpecializedGroupedGemmInput::NVFP4BlockScaleVectorSize ==
                 TmaWarpSpecializedGroupedGemmInput::alignToSfDim(

--- a/tests/moe/test_unified_moe_cutlass.py
+++ b/tests/moe/test_unified_moe_cutlass.py
@@ -66,6 +66,7 @@ from flashinfer.utils import (
     is_sm121a_supported,
     is_sm12x_supported,
     is_sm90a_supported,
+    round_up,
 )
 
 
@@ -2202,11 +2203,13 @@ cutlass_nvfp4_required = pytest.mark.skipif(
 )
 
 
-def _make_nvfp4_case(num_tokens: int = 16, activation=None):
+def _make_nvfp4_case(
+    num_tokens: int = 16, activation=None, intermediate_size: int = 256
+):
     torch.manual_seed(44)
     device = torch.device("cuda", torch.cuda.current_device())
     num_experts, top_k = 4, 2
-    hidden_size, intermediate_size = 128, 256
+    hidden_size = 128
     activation = activation or SwiGLU()
     gemm1_rows = intermediate_size * (2 if activation.is_gated else 1)
     x = torch.randn(num_tokens, hidden_size, device=device, dtype=torch.bfloat16) / 2
@@ -2346,6 +2349,31 @@ def test_cutlass_nvfp4_moe_layer_matches_quantized_reference(activation):
     # needs to catch a wrong magnitude.
     ref_rtol = ref_atol = 3e-1 if isinstance(activation, Identity) else 2e-1
     _assert_numerically_close(actual, expected, rtol=ref_rtol, atol=ref_atol)
+
+
+@cutlass_nvfp4_required
+@pytest.mark.parametrize("activation", (ReLU2(), SwiGLU()))
+@pytest.mark.parametrize("intermediate_size", (96, 192))
+def test_cutlass_nvfp4_accepts_intermediate_size_not_multiple_of_128(
+    activation, intermediate_size
+):
+    # The fc1 block scale is padded to the 128-row swizzle tile and fc2's
+    # K-dimension scale groups to 64, so these shapes hand the binding scale
+    # tensors with more rows than inter_size (2 * inter_size when gated).
+    config, act, weights, view = _make_nvfp4_case(
+        activation=activation, intermediate_size=intermediate_size
+    )
+    expected_rows = intermediate_size * (2 if activation.is_gated else 1)
+    assert view["fc1_weight_block_scale"].shape[1] == round_up(expected_rows, 128)
+    layer = MoELayer(config)
+    _pin_fallback_winner(layer, act)
+
+    actual = layer(act, weights)
+    expected = _nvfp4_quantized_reference(act, view, activation)
+
+    assert layer.winner_backend == "cutlass_nvfp4"
+    assert torch.isfinite(actual).all(), "CUTLASS NVFP4 produced non-finite output"
+    _assert_numerically_close(actual, expected, rtol=2e-1, atol=2e-1)
 
 
 @cutlass_nvfp4_required


### PR DESCRIPTION
<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->
The CUTLASS NVFP4 fused MoE binding rejects `intermediate_size` values that are multiples of 64 but not of 128, for example 1856 (Nemotron-3.5-Lightning-30B-A3B), with `fc1 weight block size must be (num_experts_on_rank, inter_size, hidden_size // 4 // block_scale_vector_size)`.

As far as I can tell, the fc1 row term of that check aligns `inter_size` with `MinKDimAlignmentNVFP4` (64), while both producers of that tensor pad the rows to `MinNDimAlignmentNVFP4` (128): `getOffsetWeightSF` in the kernel and `prepare_cutlass_nvfp4_weights` / `CutlassNvfp4Runner.pack_inputs` on the Python side (`round_up(gemm1_rows, 128)`). The fc2 check in the same function already uses the row alignment for `hidden_size`. When I is a multiple of 128 the two constants agree, which is probably why the common shapes never hit this.

This PR aligns the full fc1 row count (`inter_size`, or `inter_size * 2` when gated) with `MinNDimAlignmentNVFP4` in both branches, and adds a test at intermediate sizes 96 and 192 for ReLU2 and SwiGLU so the padded-row shapes are exercised. The gated form aligns the doubled row count rather than doubling the aligned half, matching the kernel offset and the Python padding (for I=1856 gated the tensors carry 3712 rows, not 3840).

I might be missing a reason the stricter constant was intended. If NVFP4 is meant to require 128-multiples, the cleaner fix would be a Python-side rejection in `CutlassNvfp4Runner`, as the MXFP paths already do, and I am happy to switch to that instead.

## 🔍 Related Issues


## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

On an RTX PRO 6000 Blackwell (SM120), `pytest tests/moe/test_unified_moe_cutlass.py -k "nvfp4 or mxfp8"` gives 64 passed and 11 skipped (other architectures), including the new intermediate_size 96/192 x ReLU2/SwiGLU cases. The Nemotron shape (H=2688, I=1856, E=128, top_k=6, ReLU2, NVFP4 W4A4) also passes the `flashinfer_benchmark.py --refcheck` comparison at 1, 512 and 4096 tokens, with CUTLASS latencies of 59 / 566 / 957 us, in line with the numbers reported in #4646.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected NVFP4 shape validation for gated and non-gated mixture-of-experts models.
  * Improved handling of intermediate sizes and FC1 scale padding.
  * Ensured supported configurations execute successfully with finite, numerically accurate outputs.

* **Tests**
  * Added coverage for gated and non-gated activations using intermediate sizes of 96 and 192.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->