### PR TITLE
fix(sampling): remove CUDA 11.8 FlagHeads fallback

### DIFF
--- a/include/flashinfer/sampling.cuh
+++ b/include/flashinfer/sampling.cuh
@@ -109,10 +109,6 @@ constexpr BlockReduceAlgorithm REDUCE_ALGO = BLOCK_REDUCE_WARP_REDUCTIONS;
 #define FLASHINFER_SAMPLING_LAUNCH_BOUNDS(block_threads)
 #endif
 
-#if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120100)
-#define FLASHINFER_CUB_SUBTRACTLEFT_DEFINED
-#endif
-
 template <typename T>
 struct ValueCount {
   T value;
@@ -615,13 +611,8 @@ __device__ __forceinline__ void DeviceSamplingFromProb(
     }
 
     bool greater_than_u_diff[VEC_SIZE];
-#ifdef FLASHINFER_CUB_SUBTRACTLEFT_DEFINED
     BlockAdjacentDifference<bool, BLOCK_THREADS>(temp_storage->block_prim.adj_diff)
         .SubtractLeft<VEC_SIZE>(greater_than_u, greater_than_u_diff, BoolDiffOp());
-#else
-    BlockAdjacentDifference<bool, BLOCK_THREADS>(temp_storage->block_prim.adj_diff)
-        .template FlagHeads<VEC_SIZE>(greater_than_u_diff, greater_than_u, BoolDiffOp(), 0);
-#endif
     __syncthreads();
 
 #pragma unroll


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

The FlagHeads branch in DeviceSamplingFromProb was added in #265 to support CUDA 11.8, whose bundled CUB predates SubtractLeft. FlashInfer's minimum supported CUDA is now 12.9 and CI covers cu129/cu130 only, so the condition the fallback was written for can no longer occur.

The guard selecting it is also keyed on the wrong thing: __CUDACC_VER_MAJOR__/MINOR describes the compiler, but the availability of SubtractLeft vs FlagHeads is a property of the CUB headers on the include path. FlashInfer bundles its own CCCL and adds it with -I while the CUDA toolkit's own headers go in with -isystem (jit/cpp_ext.py:build_common_cflags), so the vendored copy deliberately takes precedence over the CTK-bundled one — and the compiler version therefore tells you nothing about which CUB you are compiling against. On nvcc < 12.1 the macro goes undefined and FlagHeads is emitted against bundled CCCL, where the public overloads were removed in CCCL 3.0, producing a compile failure that names neither the real cause nor the unsupported toolkit.

SubtractLeft is present in every CUB tested here, down to 2.0.1 -- well below the CCCL version shipped with CUDA 12.9, the minimum supported toolkit. Removing the fallback deletes code unreachable on every supported configuration and additionally lets nvcc 12.0 compile rather than fail.

### Verification

One source file (`probe.cu`, below), API branch selected explicitly via `-D`, only the CUB headers on the include path varied:

| nvcc | CUB / CCCL headers | Source | `FlagHeads` | `SubtractLeft` |
|---|---|---|---|---|
| 12.0.140 | CUB 2.0.1 | Ubuntu `libcub-dev`, `/usr/include` | pass (deprecated) | pass |
| 12.0.140 | CCCL 3.0.0 | `NVIDIA/cccl` tag `v3.0.0` | **fail** | pass |
| 12.0.140 | CCCL 3.0.3 | `NVIDIA/cccl` tag `v3.0.3` | **fail** | pass |
| 12.0.140 | CCCL 3.3.2 | wheel, `flashinfer-python` 0.6.18.post1 | **fail** | pass |
| 13.3.73 | CCCL 3.3.2 | wheel, `flashinfer-python` 0.6.18.post1 | **fail** | pass |
| 12.0.140 | CCCL 3.6.0 | `3rdparty/cccl` submodule at `main` | **fail** | pass |

`FlagHeads` is deprecated in CUB 2.0.1 and absent from CCCL 3.0.0 onward; `SubtractLeft` compiles across the entire range, including CUB 2.0.1 — older than anything reachable under the CUDA 12.9 floor. In CCCL 3.6.0 a `FlagHeads` symbol survives at `block_adjacent_difference.cuh:155`, but it is a private helper taking `int linear_tid` and is not the public overload this code calls, so the fallback cannot be repaired — only removed.

Error signature (nvcc 12.0.140, bundled CCCL 3.6.0, before this change):

```
include/flashinfer/sampling.cuh(623): error:
class "cub::_V_300600_SM_860::BlockAdjacentDifference<__nv_bool, 128, 1, 1>"
has no member "FlagHeads"
    detected during instantiation of
    "void flashinfer::sampling::DeviceSamplingFromProb<...>"
```

After this change, `sampling.cuh` compiles under both nvcc 12.0.140 and 13.3.73 against bundled CCCL 3.6.0.

<details>
<summary><code>probe.cu</code> — minimal reproduction</summary>

```cuda
#include <cub/cub.cuh>

struct BoolDiffOp {
  __device__ __forceinline__ bool operator()(const bool &a, const bool &b) const {
    return a != b;
  }
};

constexpr int BLOCK_THREADS = 128;
constexpr int VEC_SIZE = 4;

__global__ void probe(bool *out) {
  using BAD = cub::BlockAdjacentDifference<bool, BLOCK_THREADS>;
  __shared__ typename BAD::TempStorage tmp;
  bool in[VEC_SIZE] = {true, false, true, false};
  bool diff[VEC_SIZE];
#ifdef USE_SUBTRACTLEFT
  BAD(tmp).SubtractLeft<VEC_SIZE>(in, diff, BoolDiffOp());
#else
  BAD(tmp).template FlagHeads<VEC_SIZE>(diff, in, BoolDiffOp(), 0);
#endif
  out[threadIdx.x] = diff[0];
}
```

Compile with and without `-DUSE_SUBTRACTLEFT`, varying `-I` to select the header set:

```bash
nvcc -ccbin g++-12 -arch=sm_86 $INC -c probe.cu -o /dev/null
nvcc -ccbin g++-12 -arch=sm_86 $INC -c probe.cu -o /dev/null -DUSE_SUBTRACTLEFT
```

</details>

## 🔍 Related Issues

<!-- Link any related issues here -->

- #265 introduced the `FlagHeads` fallback in May 2024 to support CUDA 11.8,   closing #261 (the same `has no member` compile failure, in the opposite   direction: `SubtractLeft` missing on CUB 1.x). #410 was a follow-up cu118 CUB fix.
- #4763 reports the same failure and fixes it by preferring system CUB/Thrust   over the bundled CCCL in `env.py`. This PR fixes the version predicate instead,   so the two are alternatives rather than complements — deferring to maintainers   on which is preferable. I raised the root cause there before opening this.

One clarification for anyone comparing the two reports: #4763's description  says "bundled CCCL 3.0.3", but the pasted error names `cub::_V_300302_SM_890`.  Per the `MMMmmmpp` encoding documented in `cub/version.cuh`, `300302` decodes  as 3.3.2 — the same version reported here, not 3.0.3. (For contrast,  `_V_300003` in the table above really is 3.0.3.)

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

This is a compile-time change; no new unit test would be meaningful. Existing `tests/test_sampling.py` coverage exercises the affected code path unchanged. CI runs cu129/cu130 only, so no tested configuration takes the removed branch — a green run confirms no regression on supported versions.

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->

If a version guard is preferred over removal, the correct predicate is `CUB_VERSION` / `CCCL_VERSION` rather than `__CUDACC_VER_*` — but since every CUB reachable under the 12.9 floor has `SubtractLeft`, any such guard would be unconditionally true. Happy to switch approach if maintainers prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized sampling behavior by consistently using the same adjacent-difference operation across supported CUDA environments.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->