### PR TITLE
test(cake_comm): initialize NVSHMEM for BF16 rank-major GPU regression

### DIFF
--- a/docs/design_docs/moe_ep_bf16_rank_major_gpu_tests.md
+++ b/docs/design_docs/moe_ep_bf16_rank_major_gpu_tests.md
@@ -12,8 +12,12 @@ the GPUs. The fixed configuration is eight ranks, capacity 128 tokens per
 rank, hidden size 7168, intermediate size 2048, 256 experts (32 per rank),
 top-k 8, and BF16 weights/activations. All ranks use the same active-token
 count in the supported range 1–128. Use a CUDA-enabled PyTorch installation
-with symmetric-memory support, `cuda-bindings`, and CUDA 12.8+ `nvcc` on
+with NVSHMEM symmetric-memory support, `cuda-bindings`, and CUDA 12.8+ `nvcc` on
 `PATH` (or under `CUDA_HOME`/`CUDA_PATH`).
+
+The fixture selects PyTorch's NVSHMEM symmetric-memory backend before allocating
+the peer workspace. The independent reference disables TF32, including a forced
+`TORCH_ALLOW_TF32_CUBLAS_OVERRIDE` inherited from the environment.
 
 From the repository root:
 

--- a/tests/moe_ep/test_moe_ep_bf16_rank_major_cuda_multirank.py
+++ b/tests/moe_ep/test_moe_ep_bf16_rank_major_cuda_multirank.py
@@ -19,6 +19,7 @@ from datetime import timedelta
 import pytest
 import torch
 import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
 import torch.nn.functional as F
 
 from flashinfer.moe_ep import (
@@ -63,12 +64,15 @@ def problem():
     assert int(os.environ["LOCAL_WORLD_SIZE"]) == _WORLD
     assert rank == local_rank, "this test requires a single node"
     torch.cuda.set_device(local_rank)
+    # Use the validated peer-memory transport for this eight-rank backend.
+    symm_mem.set_backend("NVSHMEM")
     if not dist.is_initialized():
         dist.init_process_group("nccl", timeout=timedelta(minutes=10))
     assert dist.get_world_size() == _WORLD
     assert dist.get_rank() == rank
 
     # The independent reference must use FP32 accumulation, not TF32 products.
+    old_tf32_override = os.environ.pop("TORCH_ALLOW_TF32_CUBLAS_OVERRIDE", None)
     old_tf32 = torch.backends.cuda.matmul.allow_tf32
     torch.backends.cuda.matmul.allow_tf32 = False
     generator = torch.Generator(device="cuda").manual_seed(20260910 + rank)
@@ -117,6 +121,8 @@ def problem():
     finally:
         layer.destroy()
         torch.backends.cuda.matmul.allow_tf32 = old_tf32
+        if old_tf32_override is not None:
+            os.environ["TORCH_ALLOW_TF32_CUBLAS_OVERRIDE"] = old_tf32_override
         # The shared conftest destroys the process group once per session.
 
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The eight-rank BF16 rank-major GPU regression crashed in the default PyTorch symmetric-memory rendezvous on the validation environment. Select the existing NVSHMEM transport in the test fixture and remove a forced TF32 override so its independent reference uses FP32 GEMMs. The change touches only the test and its dependency documentation.

## 🔍 Related Issues

Follow-up to #4810.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

Validated source commit: `5f870b7dbd3cdf99f3d726ed82b1f47f852d96c0`.

Published commit: `11d21d8248e2cba46d868f3e9ef69bcee324d7dd`, a cherry-pick of
the same two-file repair onto #4810's merge commit
`dc8148ba9d620b01ce6f952510497145d590258d`. The GPU results below were collected
at the validated source commit, not rerun at the published commit. Git comparison
confirms identical regression test, public runner, test instructions, shared
conftest, mega backend subtree, bundled CUDA source/manifest, and MNNVL helper.

On one x86_64 node with eight B200 GPUs, each of ranks 0–7 passed all 16 tests
with zero skips: token boundaries T=1/63/64/65/127/128, repeated calls and output
ownership, and CUDA Graph capture/replay with changed inputs at T=1/127/128.
Independent reference tolerance: BF16 atol=rtol=0.01; max absolute error 0.00390625.
Ruff check and format passed.

Public entrypoint: `bash tests/moe_ep/run_tests.sh bf16-rank-major`.
Public command wall time: 51.332810 s; full payload: 219.612739 s;
step submission-to-completion: 259.669751 s. These include test/setup overhead,
not isolated kernel timings. Eight separate JUnit receipts are retained.
Allocation request-to-result, including queue and diagnosis/retries: 1941.302833 s.

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

The numerical oracle, tolerances, 16-case coverage, public layer calls, backend implementation, and source manifest remain unchanged. NVSHMEM setup matches the established validated execution path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved BF16 multi-GPU regression test reliability by selecting the validated peer-memory transport before distributed initialization.
  * Ensured TF32-related environment settings are isolated during reference calculations and restored afterward.

* **Documentation**
  * Updated testing guidance with requirements for NVSHMEM symmetric-memory support and clarified backend and TF32 configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->