### PR TITLE
perf(moe): feed cuTile BF16 GEMM2 from an expert-sorted buffer at large M

### DIFF
--- a/flashinfer/fused_moe/cutile/moe.py
+++ b/flashinfer/fused_moe/cutile/moe.py
@@ -146,20 +146,27 @@ def allocate_workspace(
     allocate_activation_output: bool = True,
     allocate_gemm1_output: bool | None = None,
     gemm1_output_rows: int | None = None,
+    sorted_io: bool = False,
 ) -> Workspace:
-    """Allocate graph-stable buffers for one exact token shape and tactic set."""
+    """Allocate graph-stable buffers for one exact token shape and tactic set.
+
+    With ``sorted_io`` the GEMM1 output and activation buffers are sized for the
+    padded, expert-sorted row space so ``run_moe(sorted_io=True)`` can write
+    GEMM1 tiles contiguously and feed GEMM2 through TMA loads.
+    """
     if not block_sizes or any(block_size <= 0 for block_size in block_sizes):
         raise ValueError("block_sizes must contain positive integers.")
     num_assignments = num_tokens * top_k
-    if allocate_gemm1_output is None:
-        allocate_gemm1_output = is_gated
-    if gemm1_output_rows is None:
-        gemm1_output_rows = num_assignments
-    if allocate_gemm1_output and gemm1_output_rows < num_assignments:
-        raise ValueError("gemm1_output_rows must cover every routed assignment.")
     max_em = max(
         num_assignments + num_experts * (block_size - 1) for block_size in block_sizes
     )
+    if allocate_gemm1_output is None:
+        allocate_gemm1_output = is_gated
+    if gemm1_output_rows is None:
+        gemm1_output_rows = max_em if sorted_io else num_assignments
+    if allocate_gemm1_output and gemm1_output_rows < num_assignments:
+        raise ValueError("gemm1_output_rows must cover every routed assignment.")
+    activation_output_rows = max_em if sorted_io else num_assignments
     max_blocks = max(
         (num_assignments + num_experts * (block_size - 1) + block_size - 1)
         // block_size
@@ -192,7 +199,11 @@ def allocate_workspace(
             device=device,
         ),
         activation_out=torch.empty(
-            ((num_assignments, intermediate_size) if allocate_activation_output else 0),
+            (
+                (activation_output_rows, intermediate_size)
+                if allocate_activation_output
+                else 0
+            ),
             dtype=bf16,
             device=device,
         ),
@@ -492,6 +503,7 @@ def _permute_small(
 @ct.function
 def _grouped_gemm_bf16_impl(
     X,
+    X_SORTED,
     W,
     SORTED_SLOTS,
     BLOCK_EXPERT,
@@ -507,6 +519,8 @@ def _grouped_gemm_bf16_impl(
     ACTIVATION_PARAM1: ConstFloat,
     ACTIVATION_PARAM2: ConstFloat,
     ACTIVATION_PARAM3: ConstFloat,
+    INPUT_SORTED: ConstBool,
+    OUTPUT_SORTED: ConstBool,
     USE_INT64: ConstBool,
 ):
     initial_m_block = ct.bid(0)
@@ -534,17 +548,29 @@ def _grouped_gemm_bf16_impl(
                 rows = ct.astype(rows, ct.int64)
             accumulator = ct.zeros((TILE_M, TILE_N), dtype=ct.float32)
             for k_tile in range(num_k_tiles):
-                a_indices = ct.reshape(rows, (TILE_M, 1)) * K_IN + ct.reshape(
-                    k_tile * TILE_K + k_offsets, (1, TILE_K)
-                )
-                # Padded routing slots carry a one-past-the-end row sentinel.
-                a = ct.gather(
-                    X,
-                    (a_indices,),
-                    padding_value=0,
-                    check_bounds=True,
-                    latency=3,
-                )
+                if INPUT_SORTED:
+                    # Rows of the padded sorted space map 1:1 onto this block,
+                    # so the A tile is a plain contiguous load.
+                    a = ct.load(
+                        X_SORTED,
+                        index=(m_block, k_tile),
+                        shape=(TILE_M, TILE_K),
+                        allow_tma=True,
+                        latency=3,
+                        padding_mode=ct.PaddingMode.ZERO,
+                    )
+                else:
+                    a_indices = ct.reshape(rows, (TILE_M, 1)) * K_IN + ct.reshape(
+                        k_tile * TILE_K + k_offsets, (1, TILE_K)
+                    )
+                    # Padded routing slots carry a one-past-the-end row sentinel.
+                    a = ct.gather(
+                        X,
+                        (a_indices,),
+                        padding_value=0,
+                        check_bounds=True,
+                        latency=3,
+                    )
                 b = ct.reshape(
                     ct.load(
                         W,
@@ -569,10 +595,14 @@ def _grouped_gemm_bf16_impl(
                     ACTIVATION_PARAM2,
                     ACTIVATION_PARAM3,
                 )
+            # A TMA ``ct.store`` of the sorted tile measured 13-18% slower than
+            # this scatter on SM120, so the sorted layout keeps the scatter and
+            # only swaps the row indices.
+            output_rows = m_offsets if OUTPUT_SORTED else slots
             ct.scatter(
                 OUT,
                 (
-                    ct.reshape(slots, (TILE_M, 1)),
+                    ct.reshape(output_rows, (TILE_M, 1)),
                     ct.reshape(n_offsets, (1, TILE_N)),
                 ),
                 ct.astype(values, OUT.dtype),
@@ -583,6 +613,7 @@ def _grouped_gemm_bf16_impl(
 @ct.kernel
 def _grouped_gemm_bf16(
     X,
+    X_SORTED,
     W,
     SORTED_SLOTS,
     BLOCK_EXPERT,
@@ -598,9 +629,12 @@ def _grouped_gemm_bf16(
     ACTIVATION_PARAM1: ConstFloat,
     ACTIVATION_PARAM2: ConstFloat,
     ACTIVATION_PARAM3: ConstFloat,
+    INPUT_SORTED: ConstBool,
+    OUTPUT_SORTED: ConstBool,
 ):
     _grouped_gemm_bf16_impl(
         X,
+        X_SORTED,
         W,
         SORTED_SLOTS,
         BLOCK_EXPERT,
@@ -616,6 +650,8 @@ def _grouped_gemm_bf16(
         ACTIVATION_PARAM1,
         ACTIVATION_PARAM2,
         ACTIVATION_PARAM3,
+        INPUT_SORTED,
+        OUTPUT_SORTED,
         False,
     )
 
@@ -623,6 +659,7 @@ def _grouped_gemm_bf16(
 @ct.kernel
 def _grouped_gemm_bf16_i64(
     X: ct.IndexedWithInt64,
+    X_SORTED: ct.IndexedWithInt64,
     W: ct.IndexedWithInt64,
     SORTED_SLOTS,
     BLOCK_EXPERT,
@@ -638,9 +675,12 @@ def _grouped_gemm_bf16_i64(
     ACTIVATION_PARAM1: ConstFloat,
     ACTIVATION_PARAM2: ConstFloat,
     ACTIVATION_PARAM3: ConstFloat,
+    INPUT_SORTED: ConstBool,
+    OUTPUT_SORTED: ConstBool,
 ):
     _grouped_gemm_bf16_impl(
         X,
+        X_SORTED,
         W,
         SORTED_SLOTS,
         BLOCK_EXPERT,
@@ -656,6 +696,8 @@ def _grouped_gemm_bf16_i64(
         ACTIVATION_PARAM1,
         ACTIVATION_PARAM2,
         ACTIVATION_PARAM3,
+        INPUT_SORTED,
+        OUTPUT_SORTED,
         True,
     )
 
@@ -878,13 +920,26 @@ def _grouped_gemm(
     block_size: int,
     config: GemmConfig,
     activation: ActivationConfig | None = None,
+    num_assignments: int | None = None,
+    input_sorted: bool = False,
+    output_sorted: bool = False,
 ) -> None:
     if activation is not None:
         activation = _validate_activation(activation)
-    num_assignment_rows = output.shape[0]
+    if num_assignments is None:
+        num_assignments = output.shape[0]
     n = output.shape[1]
     m_blocks = (sorted_slots.shape[0] + block_size - 1) // block_size
-    grid_m = max(1, min(m_blocks, num_assignment_rows))
+    # Live blocks never reach past num_post_pad <= len(sorted_slots), so the
+    # sorted buffers only need to cover the padded routing space itself.
+    padded_rows = sorted_slots.shape[0]
+    if (input_sorted and x.shape[0] < padded_rows) or (
+        output_sorted and output.shape[0] < padded_rows
+    ):
+        raise ValueError(
+            "sorted grouped GEMM buffers must cover the padded routing space."
+        )
+    grid_m = max(1, min(m_blocks, num_assignments))
     base_kernel = (
         _grouped_gemm_bf16_i64
         if needs_int64_indexing(x, weights, output)
@@ -897,6 +952,7 @@ def _grouped_gemm(
         kernel,
         (
             x.reshape(-1),
+            x,
             weights,
             sorted_slots,
             block_expert,
@@ -913,6 +969,8 @@ def _grouped_gemm(
                 if activation is None
                 else _activation_kernel_args(activation)
             ),
+            input_sorted,
+            output_sorted,
         ),
     )
 
@@ -930,8 +988,16 @@ def run_moe(
     block_size: int,
     gemm1_config: GemmConfig,
     gemm2_config: GemmConfig,
+    sorted_io: bool = False,
 ) -> torch.Tensor:
-    """Run the complete pre-routed BF16 MoE pipeline."""
+    """Run the complete pre-routed BF16 MoE pipeline.
+
+    With ``sorted_io`` GEMM1 stores its tiles in the padded expert-sorted row
+    space instead of scattering them back to assignment order, so the
+    activation runs on contiguous rows and GEMM2 loads its A operand with TMA
+    instead of a per-row gather. Padded rows only ever feed rows that the
+    GEMM2 epilogue drops, so their contents are irrelevant.
+    """
     num_tokens, hidden_size = hidden_states.shape
     top_k = topk_ids.shape[1]
     num_assignments = num_tokens * top_k
@@ -940,10 +1006,21 @@ def run_moe(
     sorted_slots, block_expert, num_post_pad = _permute(
         topk_ids, w1.shape[0], block_size, workspace
     )
-    activation_out = workspace.activation_out[:num_assignments]
+    stage_rows = sorted_slots.shape[0] if sorted_io else num_assignments
+    if workspace.activation_out.shape[0] < stage_rows:
+        raise ValueError(
+            "workspace.activation_out is too small for this launch; allocate it "
+            "with sorted_io=True to run the sorted pipeline."
+        )
+    activation_out = workspace.activation_out[:stage_rows]
     activation = _validate_activation(activation)
     if activation.is_gated:
-        gemm1_out = workspace.gemm1_out[:num_assignments]
+        if workspace.gemm1_out.shape[0] < stage_rows:
+            raise ValueError(
+                "workspace.gemm1_out is too small for this launch; allocate it "
+                "with sorted_io=True to run the sorted pipeline."
+            )
+        gemm1_out = workspace.gemm1_out[:stage_rows]
         _grouped_gemm(
             hidden_states,
             w1,
@@ -954,6 +1031,8 @@ def run_moe(
             top_k=top_k,
             block_size=block_size,
             config=gemm1_config,
+            num_assignments=num_assignments,
+            output_sorted=sorted_io,
         )
         launch_activation(gemm1_out, activation_out, activation)
     else:
@@ -968,6 +1047,8 @@ def run_moe(
             block_size=block_size,
             config=gemm1_config,
             activation=activation,
+            num_assignments=num_assignments,
+            output_sorted=sorted_io,
         )
     gemm2_out = workspace.gemm2_out[:num_assignments]
     _grouped_gemm(
@@ -980,6 +1061,8 @@ def run_moe(
         top_k=1,
         block_size=block_size,
         config=gemm2_config,
+        num_assignments=num_assignments,
+        input_sorted=sorted_io,
     )
     tile_h = _combine_tile_h(num_tokens, hidden_size)
     ct.launch(

--- a/flashinfer/fused_moe/runners.py
+++ b/flashinfer/fused_moe/runners.py
@@ -2704,6 +2704,12 @@ _CUTILE_BF16_DEFAULT_GEMM_CONFIGS = {
     120: (128, 32, 4),
     121: (128, 32, 4),
 }
+# The sorted GEMM2 input only pays off when GEMM2's K (the intermediate size) is
+# long enough for TMA tiles to beat the per-row gather and the routing batch is
+# large enough for the tuner to land on narrow-K tiles: on SM120 it won 19% at
+# K=1856 with 49k assignments, was neutral at 25k, and lost 6% at K=512.
+_CUTILE_BF16_SORTED_IO_MIN_ASSIGNMENTS = 32768
+_CUTILE_BF16_SORTED_IO_MIN_INTERMEDIATE = 1024
 _CUTILE_BF16_GEMM_CONFIGS = (
     (128, 32, 4),
     (128, 64, 1),
@@ -3000,9 +3006,20 @@ class CuTileBf16Runner(MoERunner):
                 is_gated=self.config.activation.is_gated,
                 block_sizes=self._block_sizes,
                 device=self.device,
+                **self._workspace_kwargs(capacity * self.config.routing.top_k),
             )
             self._workspace_cache[key] = workspace
         self._workspace = workspace
+
+    def _use_sorted_io(self, num_assignments: int) -> bool:
+        return (
+            num_assignments >= _CUTILE_BF16_SORTED_IO_MIN_ASSIGNMENTS
+            and self.config.experts.intermediate_size
+            >= _CUTILE_BF16_SORTED_IO_MIN_INTERMEDIATE
+        )
+
+    def _workspace_kwargs(self, max_num_assignments: int) -> dict[str, Any]:
+        return {"sorted_io": self._use_sorted_io(max_num_assignments)}
 
     def _validate_inputs(self, act: MoEActivationPack) -> tuple[torch.Tensor, int, int]:
         self._require_built()
@@ -3277,6 +3294,7 @@ class CuTileBf16Runner(MoERunner):
             block_size=block_size,
             gemm1_config=gemm1_config,
             gemm2_config=gemm2_config,
+            sorted_io=self._use_sorted_io(inputs[2].numel()),
         )
 
     def _cache_key_extras(self) -> tuple:
@@ -3364,6 +3382,10 @@ class CuTileNvfp4Runner(CuTileBf16Runner):
         from .cutile import fp4
 
         self._kernel_module = fp4
+
+    def _workspace_kwargs(self, max_num_assignments: int) -> dict[str, Any]:
+        del max_num_assignments
+        return {}
 
     def _candidate_block_sizes(self, num_assignments: int) -> tuple[int, ...]:
         num_experts = self.config.routing.num_experts

--- a/tests/moe/test_unified_moe_cutile.py
+++ b/tests/moe/test_unified_moe_cutile.py
@@ -514,6 +514,96 @@ def test_cutile_bf16_runner_matches_reference(
 
 @cutile_bf16_required
 @pytest.mark.parametrize("activation", (SwiGLU(), ReLU2()))
+def test_cutile_bf16_sorted_io_matches_unsorted(activation, monkeypatch):
+    from flashinfer.fused_moe import runners as runners_module
+
+    device = torch.device("cuda")
+    # 192 and 96 leave partial tiles on every GEMM edge, and 64 tokens x top_k 2
+    # over 4 experts fill several routing blocks per expert.
+    num_tokens, hidden_size, intermediate_size, num_experts, top_k = 64, 192, 96, 4, 2
+    torch.manual_seed(1)
+    hidden_states = torch.randn(
+        num_tokens, hidden_size, dtype=torch.bfloat16, device=device
+    )
+    w1 = (
+        torch.randn(
+            num_experts,
+            intermediate_size * (2 if activation.is_gated else 1),
+            hidden_size,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        / hidden_size**0.5
+    )
+    w2 = (
+        torch.randn(
+            num_experts,
+            hidden_size,
+            intermediate_size,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        / intermediate_size**0.5
+    )
+    ids = torch.stack(
+        [torch.randperm(num_experts, device=device)[:top_k] for _ in range(num_tokens)]
+    ).to(torch.int32)
+    routing_weights = torch.softmax(
+        torch.randn(num_tokens, top_k, device=device), dim=-1
+    )
+    weights = MoEWeightPack()
+    weights.prepare_for(
+        "cutile_bf16",
+        CuTileBf16Config.prepare_weights(
+            w1,
+            w2,
+            num_local_experts=num_experts,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            activation=activation,
+        ),
+    )
+    act = MoEActivationPack(hidden_states, None, ids, routing_weights)
+
+    def run(min_assignments: int) -> torch.Tensor:
+        monkeypatch.setattr(
+            runners_module, "_CUTILE_BF16_SORTED_IO_MIN_ASSIGNMENTS", min_assignments
+        )
+        monkeypatch.setattr(
+            runners_module, "_CUTILE_BF16_SORTED_IO_MIN_INTERMEDIATE", 0
+        )
+        config = _config(
+            num_experts=num_experts,
+            top_k=top_k,
+            intermediate_size=intermediate_size,
+            tune_max_num_tokens=num_tokens,
+            activation=activation,
+        )
+        runner = CuTileBf16Runner(config, device)
+        runner.check_support()
+        runner.build()
+        inputs = runner.pack_inputs(act, weights)
+        tactic = runner._fallback_tactic(inputs)
+        out = runner.forward(inputs, tactic=tactic).clone()
+        assert runner._use_sorted_io(num_tokens * top_k) is (min_assignments == 0)
+        assert runner._workspace.activation_out.shape[0] >= (
+            num_tokens * top_k
+            + (
+                num_experts * (max(runner._block_sizes) - 1)
+                if min_assignments == 0
+                else 0
+            )
+        )
+        return out
+
+    unsorted = run(1 << 30)
+    sorted_io = run(0)
+    assert torch.isfinite(sorted_io).all()
+    torch.testing.assert_close(sorted_io, unsorted, rtol=0, atol=0)
+
+
+@cutile_bf16_required
+@pytest.mark.parametrize("activation", (SwiGLU(), ReLU2()))
 def test_cutile_bf16_int64_specialization_matches_int32(activation, monkeypatch):
     device = torch.device("cuda")
     num_tokens, hidden_size, intermediate_size = 3, 64, 64


### PR DESCRIPTION
## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->
Adds an expert-sorted intermediate layout to the cuTile BF16 fused MoE (`flashinfer/fused_moe/cutile/moe.py`) and enables it from the runner for large routing batches.

While profiling the #4646 testlist on an RTX PRO 6000 (SM120) for #4857, GEMM2 was the slow kernel at 8192 tokens: it reached 176-204 TFLOPS against 282-288 for GEMM1 (cuBLAS bf16 on that card is about 409). GEMM2's A operand is one activation row per assignment, read through `ct.gather` with no reuse, and the tactics the tuner picks at large M use tile_k=32, so each gathered row segment is only 64 bytes. GEMM1's token rows are shared across top_k assignments and hit L2, which is why it did not show the same problem. The W4A4 path already avoids this with its sorted-IO buffers; the BF16 path did not have an equivalent.

With `sorted_io=True`, GEMM1 scatters its output tiles into the padded expert-sorted row space (the same scatter as before, only with sorted row indices), the activation runs on that buffer, and GEMM2 loads its A tiles with `ct.load(..., allow_tma=True)`. The GEMM2 epilogue still scatters to assignment order, so `combine` is untouched and the two paths produce bitwise-identical outputs (covered by a new test). Padded rows only feed GEMM2 rows that the epilogue drops. The workspace grows the GEMM1/activation buffers to the padded row space only when the runner asks for the sorted path.

`CuTileBf16Runner` turns it on for `num_assignments >= 32768` and `intermediate_size >= 1024`; both constants live in `runners.py`. Below that the gather is fine and the padded buffers would only add traffic. In my measurements a TMA `ct.store` for the sorted GEMM1 tile was 13-18% slower than the scatter it would replace, so the sorted output keeps the scatter; I left a comment in the kernel about that since it is not obvious.

Measured on an RTX PRO 6000 Blackwell (SM120), cuTile BF16, Nemotron-3.5-Lightning shape (H=2688, I=1856, E=128, top_k=6, ReLU2), CUDA graph timing, both autotuned:

| Tokens | before (us) | after (us) | GEMM2 kernel, fixed tactic (us) |
|---:|---:|---:|---|
| 2048 | 1905 | 1920 | 904 -> 917 (path off) |
| 4096 | 2709 | 2703 | 1519 -> 1513 (path off) |
| 8192 | 4375 | **4140** | 2789 -> **2256** |

Qwen3.6-35B-A3B (I=512) stays on the gather path; with the sorted path forced on it lost about 3% there, which is what the intermediate-size condition is for. I might be missing a shape family where the threshold should differ, so happy to adjust either constant.

## 🔍 Related Issues

<!-- Link any related issues here -->
#4857 (cuTile MoE performance on SM120). Baseline numbers and the per-kernel breakdown are from the #4646 testlist.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

New `test_cutile_bf16_sorted_io_matches_unsorted` runs SwiGLU and ReLU2 on a shape with partial tiles on every GEMM edge (H=192, I=96, 64 tokens x top_k 2 over 4 experts) with the sorted path forced on and off and asserts bitwise equality. `pytest tests/moe/test_unified_moe_cutile.py` passes on the RTX PRO 6000 (81 passed). The benchmark reference check passes for the Nemotron shape at 2048/4096/8192 tokens with the path on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional sorted-I/O execution for BF16 Mixture-of-Experts workloads.
  * Automatically enables the optimized mode for sufficiently large workloads while retaining standard processing for smaller inputs.
  * Added support for configuring sorted-I/O behavior when allocating workspace and running MoE operations.

* **Bug Fixes**
  * Verified that sorted-I/O and standard execution produce matching, finite results across supported activation functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->