### PR TITLE
fix(trtllm): convert float2 to e4m3 directly in vendored packed cast

### DIFF
--- a/csrc/nv_internal/tensorrt_llm/common/cudaTypeUtils.cuh
+++ b/csrc/nv_internal/tensorrt_llm/common/cudaTypeUtils.cuh
@@ -592,7 +592,11 @@ __device__ inline half2 cuda_cast<half2, __nv_fp8x2_e4m3>(__nv_fp8x2_e4m3 val) {
 
 template <>
 __device__ inline __nv_fp8x2_e4m3 cuda_cast<__nv_fp8x2_e4m3, float2>(float2 val) {
-  return __nv_fp8x2_e4m3(bf1622float2(float22bf162(val)));
+  // Direct conversion: an intermediate bf16 step drops mantissa bits that a
+  // small quantization scale then amplifies past e4m3 bucket boundaries.
+  __nv_fp8x2_e4m3 out;
+  out.__x = __nv_cvt_float2_to_fp8x2(val, __NV_SATFINITE, __NV_E4M3);
+  return out;
 }
 
 template <>


### PR DESCRIPTION
## 📌 Description

The vendored TRT-LLM copy of `cudaTypeUtils.cuh` still converts `float2` to `__nv_fp8x2_e4m3` through an intermediate bf16.

```cpp
return __nv_fp8x2_e4m3(bf1622float2(float22bf162(val)));
```

The bf16 step drops mantissa bits that a small quantization scale then amplifies past e4m3 rounding boundaries. #4160 caught this failure mode in the header-only twin under `include/flashinfer/trtllm/`, and #4167 fixed it there, but the fix never reached the vendored copy imported by #1113. This PR applies the same change, with the same comment, so the specialization is byte-identical to the twin's. After this patch, diffing the two files leaves only the include prefixes and the two e5m2 specializations that exist only in the twin.

The vendored fp8 chain is currently dormant, since `invokePerTokenQuantization` has no callers and the trtllm-gen MoE launcher accepts only MxFp8 and DeepSeekFp8 for fp8 (measured impact and full call chain in #5128). The change therefore carries no behavior risk today, and any future wiring of the vendored fp8 per-token path no longer inherits the double rounding.

## 🔍 Related Issues

Fixes #5128.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

- Pre-commit was run as `pre-commit run --files csrc/nv_internal/tensorrt_llm/common/cudaTypeUtils.cuh` (the only file this PR touches), and all matching hooks pass, including clang-format v19.1.1. `--all-files` was not run from this environment because the mypy and ruff hooks target the `flashinfer/` python tree and would report import errors without the full package dependencies installed.
- No test is added because no shipped path reaches this vendored cast; #5128 documents the call chain and its dormant status, so there is no existing test surface for this file. The reachable twin of this cast was fixed by #4167 together with `tests/utils/test_norm.py`.
- The probe from #5128 was rerun on A100-PCIE-40GB (sm_80, CUDA 12.8) against this branch. The boundary scan of all 252 e4m3 rounding midpoints ±8 f32-ulps converts differently on 2016 of 4284 points with the unpatched tree and on 0 of 4284 with this patch, and 0 of 504 bucket-interior control points differ in both cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved conversion accuracy when converting paired floating-point values to FP8 e4m3 format.
  - Prevented unnecessary precision loss caused by an intermediate conversion step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->