### PR TITLE
build: raise the nvidia-cudnn-frontend floor to 1.28.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ nccl-extensions>=0.1.0
 nccl4py>=0.4.1
 ninja
 numpy
-nvidia-cudnn-frontend>=1.25.0
+nvidia-cudnn-frontend>=1.28.0
 nvidia-cutlass-dsl>=4.6.2a0
 nvidia-ml-py
 packaging>=24.2


### PR DESCRIPTION
## Summary

Raises the `nvidia-cudnn-frontend` floor from `>=1.25.0` to `>=1.28.0`. One line, no code changes.

## Motivation

The declared floor is below what shipped code already requires, so an environment can satisfy `requirements.txt` and still silently lose a cuDNN path.

`flashinfer/cudnn/prefill.py:44-56` gates its FP8 / mixed-dtype prefill on frontend `(1, 27)`:

```python
if mixed or (dtype in (torch.float8_e4m3fn, torch.float8_e5m2)):
    min_backend, min_frontend = 92500, (1, 27)
elif dtype in (torch.float16, torch.bfloat16):
    min_backend, min_frontend = 92400, (1, 25)
...
major, minor = map(int, cudnn.__version__.split(".")[:2])
return (major, minor) >= min_frontend
```

while `requirements.txt` asks only for `>=1.25.0`.

On a resolved 1.25 or 1.26, `_cudnn_supports_direct_seqlens` returns `False` and the token-unit direct path is skipped — **no error and no warning**, just a quieter fallback. That check is deliberately a package-version compare rather than a feature probe, as its own comment explains:

> this is a pure version compare against the runtime backend and the FE package version (the practical proxy for the FE's compiled-against cuDNN). The FE exposes no compiled/effective-version query, so a feature-probe with NOT_SUPPORTED fallback is left as a follow-up.

Since the frontend offers no capability query, the declared floor is the only place that information can live — which makes the current understatement load-bearing rather than cosmetic.

## Why 1.28 and not 1.27

To be precise: the **strictly demonstrated** in-tree requirement today is **1.27**. This picks 1.28.0 because it is the current release on PyPI, so the floor costs nothing to satisfy and avoids a second bump shortly after. Newer frontend APIs (the DSA indexer / top-K family) also live there, but nothing in this PR depends on them.

Happy to retarget this at `>=1.27.0` instead if maintainers prefer the floor to track only what is provably required.

## Compatibility

- `1.28.0` is the latest `nvidia-cudnn-frontend` release on PyPI, so the floor is satisfiable today.
- No behaviour change for anyone already resolving 1.28.
- Anyone previously resolving 1.25–1.27 now gets the FP8 prefill path they were silently missing.

## Test plan

No code touched. Verified locally that a clean environment resolving `nvidia-cudnn-frontend==1.28.0` imports FlashInfer and reports the expected versions:

```
torch 2.11.0+cu128   cuda 12.8
cudnn FE 1.28.0      backend 91900
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum supported version of the NVIDIA cuDNN frontend dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->