### PR TITLE
feat(cake_diffusion): add SM100a support to MiniMax-H3 BF16 pre-attention

### DIFF
--- a/csrc/cake_minimax_h3_bf16_pre_attention_sm103a.cu
+++ b/csrc/cake_minimax_h3_bf16_pre_attention_sm103a.cu
@@ -26,6 +26,7 @@ static_assert(alignof(FlashInferTensorMap) == 128, "tensor-map ABI alignment mis
 static_assert(sizeof(CUtensorMap) == 128, "CUDA tensor-map ABI size mismatch");
 static_assert(alignof(CUtensorMap) >= 64,
               "CUDA tensor-map ABI requires at least 64-byte alignment");
+#include <cuda_fp8.h>
 
 #define MINIMAX_H3_INF CUDART_INF_F
 #define TMEM_NCOLS 512
@@ -97,6 +98,10 @@ __device__ __forceinline__ void mbarrier_init(int mbar_addr, int count) {
   asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;" ::"r"(mbar_addr), "r"(count) : "memory");
 }
 
+__device__ __forceinline__ void mbarrier_init_generic(void* mbar_addr, int count) {
+  asm volatile("mbarrier.init.b64 [%0], %1;" ::"l"(mbar_addr), "r"(count));
+}
+
 __device__ __forceinline__ uint32_t mbarrier_try_wait(int mbar_addr, int phase) {
   uint32_t token;
   asm volatile(
@@ -127,37 +132,106 @@ __device__ __forceinline__ uint32_t mbarrier_try_wait_cluster(int mbar_addr, int
   return token;
 }
 
-// CTA-local pipelines have short, resident producer/consumer edges.  Omitting
-// suspendTimeHint keeps a miss on the lightweight TRYWAIT retry path; the
-// explicit loop still makes this helper blocking until acquire succeeds.
+// Match CUTLASS ClusterBarrier::wait: a large suspendTimeHint lets the hardware
+// take the blocking phase-check slowpath instead of spinning on TRYWAIT misses.
 __device__ __forceinline__ void mbarrier_wait(int mbar_addr, int phase) {
+  uint32_t ticks = 0x989680;
   asm volatile(
       "{\n\t"
       ".reg .pred P1;\n\t"
       "LAB_WAIT:\n\t"
       "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64"
-      " P1, [%0], %1;\n\t"
+      " P1, [%0], %1, %2;\n\t"
       "@P1 bra.uni DONE;\n\t"
       "bra.uni LAB_WAIT;\n\t"
       "DONE:\n\t"
       "}\n" ::"r"(mbar_addr),
-      "r"(phase)
+      "r"(phase), "r"(ticks)
+      : "memory");
+}
+
+// Exact source ports may request the PTX suspendTimeHint operand explicitly.
+// The hint is expressed in nanoseconds and is kept separate from the canonical
+// no-hint CTA helper so unrelated schedules retain their existing retry path.
+__device__ __forceinline__ void mbarrier_wait_suspend(int mbar_addr, int phase,
+                                                      uint32_t suspend_time_hint) {
+  asm volatile(
+      "{\n\t"
+      ".reg .pred P1;\n\t"
+      "LAB_WAIT_SUSPEND:\n\t"
+      "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64"
+      " P1, [%0], %1, %2;\n\t"
+      "@P1 bra.uni DONE_SUSPEND;\n\t"
+      "bra.uni LAB_WAIT_SUSPEND;\n\t"
+      "DONE_SUSPEND:\n\t"
+      "}\n" ::"r"(mbar_addr),
+      "r"(phase), "r"(suspend_time_hint)
       : "memory");
 }
 
 __device__ __forceinline__ void mbarrier_wait_cluster(int mbar_addr, int phase) {
-  uint32_t ticks = 0x989680;
   asm volatile(
       "{\n\t"
       ".reg .pred P1;\n\t"
       "LAB_WAIT_CLUSTER:\n\t"
       "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64"
-      " P1, [%0], %1, %2;\n\t"
+      " P1, [%0], %1;\n\t"
       "@P1 bra.uni DONE_CLUSTER;\n\t"
       "bra.uni LAB_WAIT_CLUSTER;\n\t"
       "DONE_CLUSTER:\n\t"
       "}\n" ::"r"(mbar_addr),
-      "r"(phase), "r"(ticks)
+      "r"(phase)
+      : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_wait_hint(int mbar_addr, int phase,
+                                                   uint32_t suspend_time_hint) {
+  asm volatile(
+      "{\n\t"
+      ".reg .pred P1;\n\t"
+      ".reg .u32 WAIT_ADDR;\n\t"
+      "mov.u32 WAIT_ADDR, %0;\n\t"
+      "LAB_WAIT_HINT:\n\t"
+      "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64"
+      " P1, [WAIT_ADDR], %1, %2;\n\t"
+      "@P1 bra.uni DONE_HINT;\n\t"
+      "bra.uni LAB_WAIT_HINT;\n\t"
+      "DONE_HINT:\n\t"
+      "}\n" ::"r"(mbar_addr),
+      "r"(phase), "r"(suspend_time_hint)
+      : "memory");
+}
+
+// Exact unqualified CTA wait used by source schedules whose PTX intentionally
+// omits the acquire qualifier while retaining a typed suspendTimeHint operand.
+__device__ __forceinline__ void mbarrier_wait_relaxed_hint(int mbar_addr, int phase,
+                                                           uint32_t suspend_time_hint) {
+  asm volatile(
+      "{\n\t"
+      ".reg .pred P1;\n\t"
+      "LAB_WAIT_RELAXED_HINT:\n\t"
+      "mbarrier.try_wait.parity.shared::cta.b64"
+      " P1, [%0], %1, %2;\n\t"
+      "@P1 bra DONE_RELAXED_HINT;\n\t"
+      "bra LAB_WAIT_RELAXED_HINT;\n\t"
+      "DONE_RELAXED_HINT:\n\t"
+      "}\n" ::"r"(mbar_addr),
+      "r"(phase), "r"(suspend_time_hint));
+}
+
+__device__ __forceinline__ void mbarrier_wait_cluster_hint(int mbar_addr, int phase,
+                                                           uint32_t suspend_time_hint) {
+  asm volatile(
+      "{\n\t"
+      ".reg .pred P1;\n\t"
+      "LAB_WAIT_CLUSTER_HINT:\n\t"
+      "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64"
+      " P1, [%0], %1, %2;\n\t"
+      "@P1 bra.uni DONE_CLUSTER_HINT;\n\t"
+      "bra.uni LAB_WAIT_CLUSTER_HINT;\n\t"
+      "DONE_CLUSTER_HINT:\n\t"
+      "}\n" ::"r"(mbar_addr),
+      "r"(phase), "r"(suspend_time_hint)
       : "memory");
 }
 
@@ -167,10 +241,33 @@ __device__ __forceinline__ void mbarrier_wait_token(int mbar_addr, int phase, ui
   }
 }
 
+__device__ __forceinline__ void mbarrier_wait_token_suspend(int mbar_addr, int phase,
+                                                            uint32_t token,
+                                                            uint32_t suspend_time_hint) {
+  if (token == 0) {
+    mbarrier_wait_suspend(mbar_addr, phase, suspend_time_hint);
+  }
+}
+
 __device__ __forceinline__ void mbarrier_wait_token_cluster(int mbar_addr, int phase,
                                                             uint32_t token) {
   if (token == 0) {
     mbarrier_wait_cluster(mbar_addr, phase);
+  }
+}
+
+__device__ __forceinline__ void mbarrier_wait_token_hint(int mbar_addr, int phase, uint32_t token,
+                                                         uint32_t suspend_time_hint) {
+  if (token == 0) {
+    mbarrier_wait_hint(mbar_addr, phase, suspend_time_hint);
+  }
+}
+
+__device__ __forceinline__ void mbarrier_wait_token_cluster_hint(int mbar_addr, int phase,
+                                                                 uint32_t token,
+                                                                 uint32_t suspend_time_hint) {
+  if (token == 0) {
+    mbarrier_wait_cluster_hint(mbar_addr, phase, suspend_time_hint);
   }
 }
 
@@ -278,12 +375,14 @@ __launch_bounds__(640, 1) void kernel_minimax_h3_bf16_pre_attention_destination_
     __nv_bfloat16* __restrict__ out, const __grid_constant__ CUtensorMap qkv_weight, int M, int P,
     float eps) {
   const int tid = threadIdx.x;
-  const int warp = make_warp_uniform(tid / 32);
-  const int lane = tid % 32;
+  const uint32_t warp = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+  uint32_t lane;
+  asm("mov.u32 %0, %%laneid;" : "=r"(lane));
 
   extern __shared__ __align__(1024) char smem_raw[];
   int smem;
   smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
   const int mbar_base = smem;
 #define a_full_addr (mbar_base + 0)
 #define b_full_addr (mbar_base + 16)
@@ -292,6 +391,7 @@ __launch_bounds__(640, 1) void kernel_minimax_h3_bf16_pre_attention_destination_
 
   const int bid = blockIdx.x;
   const int num_bids = gridDim.x;
+  volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 56);
 
   // Kernel setup ops
   __nv_bfloat16* smem_a = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
@@ -311,7 +411,7 @@ __launch_bounds__(640, 1) void kernel_minimax_h3_bf16_pre_attention_destination_
   float* smem_norm_partials = reinterpret_cast<float*>(smem_raw + 165888);
   const int smem_norm_partials_addr = smem + 165888;
 
-  // Mbarrier init (4 groups, 7 barriers)
+  // Mbarrier init (4 pipeline groups, 0 ordered-sequence groups, 7 barriers)
   // Mbarriers at smem_raw[0..56)
 
   if (warp == 0) {
@@ -336,7 +436,6 @@ __launch_bounds__(640, 1) void kernel_minimax_h3_bf16_pre_attention_destination_
   __syncwarp();
 
   // TMEM alloc (512 columns, 512 used)
-  volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 56);
   if (warp == 0) {
     int _tmem_hold = smem + 56;
     asm volatile(
@@ -376,7 +475,7 @@ __launch_bounds__(640, 1) void kernel_minimax_h3_bf16_pre_attention_destination_
       for (int row_group = 0; row_group < BLOCK_M / 4; row_group++) {
         int row_slot = warp / 4;
         int warp_in_row = warp % 4;
-        int thread_in_row = warp_in_row * 32 + lane;
+        int thread_in_row = (unsigned int)(warp_in_row * 32) + lane;
         int local_row = row_group * 4 + row_slot;
         int global_row = off_m + local_row;
         float sum_sq = 0.0f;
@@ -650,7 +749,7 @@ __launch_bounds__(640, 1) void kernel_minimax_h3_bf16_pre_attention_destination_
       int off_n_4 = group_n_2 * GROUP_N * BLOCK_N;
       int warp_in_wg = warp % 4;
       int row_addr = warp_in_wg * 32 << 16;
-      int local_row_2 = warp_in_wg * 32 + lane;
+      int local_row_2 = (unsigned int)(warp_in_wg * 32) + lane;
       int global_row_2 = off_m_3 + local_row_2;
       int safe_global_row = ((global_row_2 < M) ? global_row_2 : M - 1);
       int heads_per_destination = NUM_HEADS / P;
@@ -1227,8 +1326,9 @@ void ConfigureKernel() {
   status = cudaGetDeviceProperties(&properties, device);
   TVM_FFI_CHECK(status == cudaSuccess, RuntimeError)
       << "failed to query CUDA device properties: " << cudaGetErrorString(status);
-  TVM_FFI_CHECK(properties.major == 10 && properties.minor == 3, RuntimeError)
-      << "MiniMax-H3 BF16 pre-attention requires compute capability 10.3";
+  TVM_FFI_CHECK(properties.major == 10 && (properties.minor == 0 || properties.minor == 3),
+                RuntimeError)
+      << "MiniMax-H3 BF16 pre-attention requires compute capability 10.0 or 10.3";
   status = cudaFuncSetAttribute(kernel_minimax_h3_bf16_pre_attention_destination_major_005f_v1,
                                 cudaFuncAttributeMaxDynamicSharedMemorySize, kDynamicSmemBytes);
   TVM_FFI_CHECK(status == cudaSuccess, RuntimeError)

--- a/flashinfer/diffusion_ops/minimax_h3.py
+++ b/flashinfer/diffusion_ops/minimax_h3.py
@@ -168,15 +168,15 @@ def _validate_input_contract(
 def _check_runtime_support(device: torch.device) -> None:
     if device.type != "cuda":
         raise ValueError("MiniMax-H3 BF16 pre-attention requires CUDA tensors")
-    if get_compute_capability(device) != (10, 3):
+    if get_compute_capability(device) not in {(10, 0), (10, 3)}:
         raise RuntimeError(
-            "MiniMax-H3 BF16 pre-attention requires compute capability 10.3"
+            "MiniMax-H3 BF16 pre-attention requires compute capability 10.0 or 10.3"
         )
     if not is_cuda_version_at_least("12.9"):
         raise RuntimeError("MiniMax-H3 BF16 pre-attention requires CUDA 12.9 or newer")
 
 
-@supported_compute_capability([103])
+@supported_compute_capability([100, 103])
 @flashinfer_api(trace=minimax_h3_bf16_pre_attention_trace)
 def minimax_h3_bf16_pre_attention(
     x: torch.Tensor,
@@ -243,8 +243,9 @@ def minimax_h3_bf16_pre_attention(
     MiniMax-H3 checkpoint semantics without a synchronizing host reduction.
 
     This is a direct kernel entry point for all supported destination counts.
-    The measured performance promotion range is ``P in {2, 4, 8}``; callers
-    that dispatch by ``P`` should retain their segmented fallback for ``P=1``.
+    On SM103a, the measured performance promotion range is ``P in {2, 4, 8}``.
+    Callers that dispatch by ``P`` should retain their segmented fallback for
+    ``P=1``.
     """
     _validate_input_contract(
         x,

--- a/flashinfer/jit/cake_minimax_h3_bf16_pre_attention.py
+++ b/flashinfer/jit/cake_minimax_h3_bf16_pre_attention.py
@@ -17,7 +17,7 @@ limitations under the License.
 from pathlib import Path
 
 from . import env as jit_env
-from .core import JitSpec, gen_jit_spec, sm103a_nvcc_flags
+from .core import JitSpec, gen_jit_spec, sm100a_nvcc_flags, sm103a_nvcc_flags
 from .cpp_ext import is_cuda_version_at_least
 
 
@@ -62,15 +62,16 @@ def _minimax_h3_include_dir() -> Path:
 
 
 def gen_minimax_h3_bf16_pre_attention_module() -> JitSpec:
-    """Return the SM103a-only JIT spec for fused BF16 pre-attention."""
+    """Return the SM100a/SM103a fatbin JIT spec for fused BF16 pre-attention."""
 
     if not is_cuda_version_at_least("12.9"):
-        raise RuntimeError("SM103a compilation requires CUDA 12.9 or newer")
+        raise RuntimeError("SM100a/SM103a compilation requires CUDA 12.9 or newer")
     source = _minimax_h3_cuda_source()
     return gen_jit_spec(
-        "minimax_h3_bf16_pre_attention_sm103a_v1",
+        "minimax_h3_bf16_pre_attention_sm100a_sm103a_v1",
         [source],
-        extra_cuda_cflags=sm103a_nvcc_flags + _PRECISE_MATH_FLAGS,
+        extra_cuda_cflags=list(dict.fromkeys(sm100a_nvcc_flags + sm103a_nvcc_flags))
+        + _PRECISE_MATH_FLAGS,
         extra_include_paths=[_minimax_h3_include_dir()],
     )
 

--- a/tests/diffusion_ops/test_minimax_h3_bf16_pre_attention.py
+++ b/tests/diffusion_ops/test_minimax_h3_bf16_pre_attention.py
@@ -99,10 +99,10 @@ _SOURCE = (
     / "cake_minimax_h3_bf16_pre_attention_sm103a.cu"
 )
 _CUDA_DEVICE = torch.device("cuda")
-_HAS_SM103A_RUNTIME = (
+_HAS_BLACKWELL_RUNTIME = (
     _SOURCE.is_file()
     and torch.cuda.is_available()
-    and get_compute_capability(_CUDA_DEVICE) == (10, 3)
+    and get_compute_capability(_CUDA_DEVICE) in {(10, 0), (10, 3)}
     and is_sm100f_supported(_CUDA_DEVICE)
 )
 _RUN_FULL = os.environ.get("FLASHINFER_RUN_FULL_MINIMAX_H3_TESTS", "0") == "1"
@@ -394,19 +394,19 @@ def _run_correctness_shape(m: int, p: int, profile: str):
 
 
 @pytest.mark.skipif(
-    not _HAS_SM103A_RUNTIME,
-    reason="requires the frozen SM103a CUDA source and an SM103a GPU",
+    not _HAS_BLACKWELL_RUNTIME,
+    reason="requires the frozen CUDA source and an SM100a or SM103a GPU",
 )
 @pytest.mark.parametrize("m,p,profile", SMOKE_SHAPES)
-def test_sm103a_smoke_correctness(m, p, profile):
+def test_blackwell_smoke_correctness(m, p, profile):
     _run_correctness_shape(m, p, profile)
 
 
 @pytest.mark.skipif(
-    not _HAS_SM103A_RUNTIME,
-    reason="requires the frozen SM103a CUDA source and an SM103a GPU",
+    not _HAS_BLACKWELL_RUNTIME,
+    reason="requires the frozen CUDA source and an SM100a or SM103a GPU",
 )
-def test_sm103a_invalid_adaln_indices_produce_zero_rows():
+def test_blackwell_invalid_adaln_indices_produce_zero_rows():
     case = _make_cuda_case(6, 8, "all_same")
     case["adaln_index"] = torch.tensor(
         [0, -1, 8, 9, -(2**31), 2**31 - 1], dtype=torch.int32, device="cuda"
@@ -418,10 +418,10 @@ def test_sm103a_invalid_adaln_indices_produce_zero_rows():
 
 
 @pytest.mark.skipif(
-    not _HAS_SM103A_RUNTIME,
-    reason="requires the frozen SM103a CUDA source and an SM103a GPU",
+    not _HAS_BLACKWELL_RUNTIME,
+    reason="requires the frozen CUDA source and an SM100a or SM103a GPU",
 )
-def test_sm103a_cuda_graph_capture():
+def test_blackwell_cuda_graph_capture():
     case = _make_cuda_case(128, 8, "production_segments")
     expected = _reference(case)
     minimax_h3_bf16_pre_attention(**case)
@@ -435,9 +435,9 @@ def test_sm103a_cuda_graph_capture():
 
 
 @pytest.mark.skipif(
-    not (_HAS_SM103A_RUNTIME and _RUN_FULL),
+    not (_HAS_BLACKWELL_RUNTIME and _RUN_FULL),
     reason="set FLASHINFER_RUN_FULL_MINIMAX_H3_TESTS=1 to run the 44-shape suite",
 )
 @pytest.mark.parametrize("m,p,profile", FULL_CORRECTNESS_SHAPES)
-def test_sm103a_full_correctness(m, p, profile):
+def test_blackwell_full_correctness(m, p, profile):
     _run_correctness_shape(m, p, profile)


### PR DESCRIPTION
Add SM100a support to the MiniMax-H3 BF16 pre-attention implementation merged in #4690, while retaining SM103a support. The runtime accepts compute capability 10.0 or 10.3, and the cached JIT module contains both native targets with the existing precise-math flags. CUDA 12.9 remains the minimum.

### Measured speedup vs baseline

These CUPTI/cold-L2 measurements compare the exported fused operator with the segmented BF16 baseline, including input RMSNorm, indexed AdaLN, three BF16 projections, Q/K RMSNorm, partial NeoX RoPE, packing, and the final D2D copy. Speedup is **baseline latency / exported latency**; host setup and weight packing are outside timing.

| GPU | Scope | Baseline (ms) | Exported fused operator (ms) | Speedup vs baseline |
|---|---|---:|---:|---:|
| B200 / SM100 | Primary M4824/P8 | 2.905457 | 2.332705 | **1.245531×** |
| GB300 / SM103 | Primary M4824/P8 | 2.641840 | 2.129152 | **1.240794×** |
| B200 / SM100 | All 24 production centers: geometric mean | 11.276954 | 10.747696 | **1.049244×** |
| GB300 / SM103 | All 24 production centers: geometric mean | 10.168333 | 9.892297 | **1.027904×** |

All 24 centers are included: SM100 has 17 faster / 7 slower shapes; SM103 has 13 faster / 11 slower shapes. Minimum speedups are 0.910050× and 0.886623× respectively. Full per-shape baseline/source/export timings, source/export parity, hardware provenance and measurement durations remain below.

The public API, output layout, BF16 round points, and authored kernel schedule are preserved. Regenerated CUDA uses updated warp/lane lowering and a CTA barrier-wait suspend hint. Current SM103 correctness and performance measurements below cover this generated code; previous performance results are not reused as new evidence.

### Correctness and integration validation

All completed public full-suite runs execute 67 tests, including the complete 44-shape inventory, at BF16 atol=rtol=0.01. Exact public source and every setup/call/teardown phase were checked.

| GPU / CUDA | Passed / skipped | JUnit tests (s) | Validation payload (s) | Separate source staging (s) | Physical turnaround (s) |
|---|---:|---:|---:|---:|---:|
| B200 / 12.9 | 67 / 0 | 12.259 | 256.949 | 57.872 | 448.904 |
| B200 / 13.0 | 67 / 0 | 6.956 | 191.337 | reused validated staging | 589.914 |
| GB300 / 12.9 | 67 / 0 | 33.155 | 100.490 | included in payload | 299.490 |
| GB300 / 13.0 | 67 / 0 | 34.350 | 90.880 | included in payload | 263.450 |

Both B200 runs used Python 3.10.21 and driver 580.82.07 on the same GPU. CUDA 12.9 used NVCC 12.9.41, PyTorch 2.13.0+cu129 and image `flashinfer/flashinfer-ci-cu129@sha256:b0181ed5707140c87a06834ca07676f20e1c212c2c63e58712a8cf6dfdf312c6`; CUDA 13.0 used NVCC 13.0.88, PyTorch 2.13.0+cu130 and image `flashinfer/flashinfer-ci-cu130@sha256:0b9fd0713b0b92e36ad8fe4654f702710724e851ce30d91c07dde2f81dcad415`. Their pytest subprocesses took 17.223 and 10.596 seconds. CUDA 13.0 physical turnaround includes time queued behind the comparative benchmark. The GB300 public runs used NVCC 12.9.41 and 13.0.88 with corresponding PyTorch 2.13.0 builds. These are suite and orchestration durations, not kernel timing.

Source, exported implementation, and explicit segmented baseline each passed all 44 shapes on both GPUs with no failed or skipped shapes and atol=rtol=0.01; source/export outputs matched on every row.

| Source/export correctness | Rows per arm | Correctness subprocess (s) | Setup/validation payload (s) | Physical turnaround (s) |
|---|---:|---:|---:|---:|
| SM100 | 44 / 44 / 44 | 52.835 | 655.402 | 887.620 |
| SM103 | 44 / 44 / 44 | 41.000 | 49.630 | 212.790 |

Generated-export checks passed: 39 tests, zero skips; both native targets compiled with NVRTC; canonical freeze/replay and Python lint/format checks passed. The check payload took 38.30 seconds, with 864.30 seconds of physical turnaround. Exact-head CPU/API validation also passed 17 tests, collecting all 67 tests and 44 shapes; its 50 GPU skips are superseded by the hardware runs above.

Current-head [PR Test CI](https://github.com/flashinfer-ai/flashinfer/actions/runs/34595426448) passed all 14 jobs: seven JIT test jobs, four AOT Build Import jobs across x64/arm64 and CUDA 12.9/13.0, plus Permission Check, Setup, and Test Results Summary. Each JIT/AOT job ran its test step successfully. Workflow turnaround was 3h 33m 19s. This CI matrix itself does not execute SM100. Current-head pre-commit and documentation checks also passed.

### Registered regression and bounded sanitizers

| Gate | SM100 | SM103 |
|---|---|---|
| Registered GPU e2e | PASS: one pytest case, eight shapes; 3.481 s testcase / 9.193 s JUnit suite | PASS: one pytest case, eight shapes; 3.479 s JUnit |
| Registered CUPTI benchmark | PASS: 2.3245 ms against 2.55728 ms ceiling; 30.989 s subprocess | PASS: 2.1529 ms against 3.1000 ms ceiling; 28.20 s subprocess |
| NVIDIA synccheck | PASS: 0 errors, 0 warnings; one command, 10 launches, 15.459 s | PASS: 0 errors, 0 warnings, 10 launches, 13.53 s |
| NVIDIA racecheck | PASS: 0 errors, 0 warnings; 10 launch positions checked across 10 commands, 16.185–16.676 s each | PASS: 0 errors, 0 warnings, 10 launches, 18.52 s |

The registered SM100 e2e retry passed after private pytest 9.1.1 dependency setup. Its one case invokes the unchanged eight-shape registration, spanning all P routes, the active center, tails, and small rows; zero failures or skips. Testcase time was 3.481 seconds, JUnit suite time 9.193 seconds, pytest subprocess 10.993 seconds, dependency setup/test payload 21.688 seconds, and physical turnaround 102.832 seconds.

SM100 synccheck uses one command covering the full ten-launch worker. SM100 racecheck uses ten separate commands. Every racecheck command executes the unchanged registered worker: the same ten candidate calls, in the same order, over M128/P8 and M129/P8, each with valid inputs followed by AdaLN index sentinels -1, 9, -2147483648, and 2147483647.

Command `i` retains the candidate kernel-name filter and adds `--launch-skip i --launch-count 1` for `i=0..9`. NVIDIA documents that these counters advance only for launches matching the kernel filters. [Compute Sanitizer command-line options](https://docs.nvidia.com/compute-sanitizer/ComputeSanitizer/index.html). The batch therefore executes **100 candidate calls in total and instruments 10**, covering each of the ten required launch positions once. Each command preserves the 19-second TERM timeout plus one-second kill grace; registry preparation and report processing occur outside that cap.

All ten racecheck commands completed with zero errors and zero warnings. Their combined command time was 163.657 seconds; the batch used 228.708 seconds payload and 301.177 seconds physical turnaround. The completed SM103 registered e2e/benchmark batch used 76.09 seconds payload and 149.65 seconds physical turnaround; its separate successful sanitizer batch used 43.44 seconds payload and 115.40 seconds physical turnaround.

The initial registered batch used 79.026 seconds payload and 687.239 seconds physical turnaround, including its queue behind other validation. Its e2e command stopped before testing because pytest was missing, and its unsplit racecheck command reached the 19-second cutoff. Those incomplete results are superseded by the successful e2e retry and the complete racecheck coverage across ten bounded commands above. The successful initial benchmark and synccheck results are retained.

The initial registered SM100 CUPTI measurement was 2.3248 ms (30.482 s subprocess). It established the existing 110% latency ceiling at 2.55728 ms. The subsequent registered check passed at 2.3245 ms with `backend_actual=cupti`; the CLI displays the ceiling rounded to 2.5573 ms. Confirmation took 30.989 seconds for the benchmark subprocess, 32.407 seconds for the payload, and 115.041 seconds of physical turnaround. This confirms the newly established ceiling and is not an improvement claim against a preexisting SM100 baseline.

### Measured hardware and software

Each architecture's source/export comparison used one visible GPU. GPU identity came from the measured process, and both arms used the same device.

| Field | SM100 | SM103 |
|---|---|---|
| GPU | NVIDIA B200 | NVIDIA GB300 |
| Host | `nsc-svg-slurm-1-gpu-62` | `nvl72d232-T18` |
| GPU UUID | `GPU-9a6fd126-b31c-8fd5-5694-dac2b52e7e60` | `GPU-ec223e3c-a093-cba2-b83d-7eb979f080ed` |
| Compute capability / CPU | 10.0 / x86_64 | 10.3 / aarch64 |
| Driver | 580.82.07 | 580.159.03 |
| Framework CUDA / NVCC | 13.3 / 13.3.33 | 13.3 / 13.3.33 |
| Python / PyTorch | 3.12.3 / 2.13.0a0+8145d630e8.nv26.06 | 3.12.3 / 2.13.0a0+8145d630e8.nv26.06 |
| CUPTI Python | 13.0.1 | 13.0.1 |
| Container reference | `nvcr.io/nvidia/pytorch:26.06-py3` | `nvcr.io/nvidia/pytorch:26.06-py3` |
| Public generated-source revision | `f617403f534c0bf9f2a2076c81fa94a6fa18e594` | `f617403f534c0bf9f2a2076c81fa94a6fa18e594` |

The recorded compiler identity is NVCC; separate NVRTC/ptxas versions and the benchmark container digest were not retained in these summaries. Both runs used the recorded clock policy with no imposed minimum SM frequency and no steady-state-clock requirement. BF16 reduced-precision matmul reduction and TF32 framework flags were enabled for the reference. The measurements establish current behavior on each GPU; cross-GPU latency differences are not an optimization claim.

### Comparative CUPTI/cold-L2 evidence

These are whole-operator GPU timings: the fused source/export kernel versus the explicit segmented reference chain. They are not serving latency. Hidden width is 5376, with 56 heads of dimension 128 and partial 96-channel split-half NeoX RoPE. Inputs and outputs are BF16; output is caller-owned and destination-major. The baseline includes input RMSNorm, indexed AdaLN, three separate BF16 projections, Q/K RMSNorm, RoPE, packing and the final D2D copy. Host setup and weight packing are outside timing.

All 24 production centers use shared inputs and interleaved forward/reverse baseline/source/export ordering. The independent export-parity comparison uses three adjacent closed ABBA/BAAB groups on the same GPU and process, one CUPTI session per reportable group. Warmup is 100 ms and measurement is 500 ms with cold L2; the recorded GPU activity scope includes kernels and D2D copies. Baseline comparison and export parity are separate experiments. No production row is excluded; the other 20 shapes are correctness-only.

Geometric-mean latencies and ratios use the same complete row set and unrounded per-row measurements. `ΔB−S` and `ΔB−E` mean baseline minus source/export latency; a positive delta saves time. B/S and B/E below use the three-arm group.

| Architecture | Rows | Baseline geomean ms | Source geomean ms | Export geomean ms | B/S geomean | B/E geomean | Minimum B/E | Export faster / slower |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| SM100 | 24 | 11.276954 | 10.717868 | 10.747696 | 1.052164× | 1.049244× | 0.910050× | 17 / 7 |
| SM103 | 24 | 10.168333 | 9.853035 | 9.892297 | 1.032000× | 1.027904× | 0.886623× | 13 / 11 |

At the primary M4824/P8 center, SM100 baseline/source/export are **2.905457 / 2.319617 / 2.332705 ms**, giving **1.245531×** baseline/export speedup. SM103 is **2.641840 / 2.122128 / 2.129152 ms**, giving **1.240794×**. The worst B/E shape on both GPUs is M48768/P1: **0.910050×** on SM100 and **0.886623×** on SM103. These slower shapes remain visible in the full tables.

<details>
<summary>SM100: all 24 production-center measurements (milliseconds)</summary>

| M | P | Baseline ms | Source ms | Export ms | ΔB−S ms | ΔB−E ms | B/S | B/E | S/E paired |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 33472 | 1 | 17.535125 | 18.877477 | 18.789269 | -1.342351 | -1.254144 | 0.928891× | 0.933252× | 1.004919× |
| 16736 | 2 | 9.646046 | 9.304622 | 9.401678 | +0.341424 | +0.244368 | 1.036694× | 1.025992× | 0.990011× |
| 8368 | 4 | 4.917423 | 4.222208 | 4.205136 | +0.695215 | +0.712288 | 1.164657× | 1.169385× | 1.004856× |
| 4184 | 8 | 2.545408 | 2.086225 | 2.090576 | +0.459184 | +0.454832 | 1.220103× | 1.217563× | 0.996370× |
| 38592 | 1 | 20.184677 | 21.747893 | 21.671413 | -1.563216 | -1.486736 | 0.928121× | 0.931396× | 1.003495× |
| 19296 | 2 | 11.135155 | 10.839668 | 10.956019 | +0.295488 | +0.179137 | 1.027260× | 1.016351× | 0.989551× |
| 9648 | 4 | 5.648274 | 5.069185 | 5.039362 | +0.579089 | +0.608912 | 1.114237× | 1.120831× | 1.004044× |
| 4824 | 8 | 2.905457 | 2.319617 | 2.332705 | +0.585840 | +0.572752 | 1.252559× | 1.245531× | 0.996150× |
| 48768 | 1 | 25.563467 | 27.638379 | 28.090187 | -2.074912 | -2.526720 | 0.924926× | 0.910050× | 0.983925× |
| 24384 | 2 | 14.080998 | 13.812662 | 13.743669 | +0.268337 | +0.337329 | 1.019427× | 1.024544× | 1.005030× |
| 12192 | 4 | 7.088963 | 6.496595 | 6.474147 | +0.592368 | +0.614816 | 1.091181× | 1.094965× | 1.004360× |
| 6096 | 8 | 3.621010 | 2.980338 | 3.002945 | +0.640672 | +0.618065 | 1.214966× | 1.205820× | 0.992756× |
| 58944 | 1 | 31.273039 | 33.236783 | 33.119104 | -1.963744 | -1.846065 | 0.940917× | 0.944260× | 1.004196× |
| 29472 | 2 | 16.972664 | 16.762648 | 16.662199 | +0.210016 | +0.310465 | 1.012529× | 1.018633× | 1.006652× |
| 14736 | 4 | 8.519892 | 8.040532 | 8.006403 | +0.479361 | +0.513489 | 1.059618× | 1.064135× | 1.005031× |
| 7368 | 8 | 4.319714 | 3.717106 | 3.696130 | +0.602608 | +0.623585 | 1.162118× | 1.168713× | 1.003843× |
| 74240 | 1 | 39.172706 | 41.917043 | 42.614900 | -2.744338 | -3.442194 | 0.934529× | 0.919226× | 0.983804× |
| 37120 | 2 | 21.354713 | 21.067401 | 21.411657 | +0.287312 | -0.056944 | 1.013638× | 0.997341× | 0.984040× |
| 18560 | 4 | 10.722389 | 10.516453 | 10.665989 | +0.205936 | +0.056400 | 1.019582× | 1.005288× | 0.985339× |
| 9280 | 8 | 5.419939 | 4.747906 | 4.732499 | +0.672033 | +0.687441 | 1.141543× | 1.145260× | 1.004780× |
| 109952 | 1 | 64.599660 | 62.539851 | 63.501707 | +2.059809 | +1.097953 | 1.032936× | 1.017290× | 0.983548× |
| 54976 | 2 | 31.963918 | 31.152366 | 31.020350 | +0.811552 | +0.943568 | 1.026051× | 1.030418× | 1.004349× |
| 27488 | 4 | 15.835446 | 15.677047 | 15.837270 | +0.158399 | -0.001824 | 1.010104× | 0.999885× | 0.990130× |
| 13744 | 8 | 7.984419 | 7.426659 | 7.393219 | +0.557760 | +0.591200 | 1.075102× | 1.079965× | 1.004789× |

</details>

<details>
<summary>SM103: all 24 production-center measurements (milliseconds)</summary>

`ΔB−S` and `ΔB−E` are baseline minus source/export latency; positive values save time. B/S and B/E use the three-arm measurement group. S/E paired comes from the independent three-group parity experiment.

| M | P | Baseline ms | Source ms | Export ms | ΔB−S ms | ΔB−E ms | B/S | B/E | S/E paired |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 33472 | 1 | 15.818704 | 17.377280 | 17.359104 | -1.558576 | -1.540400 | 0.910310× | 0.911263× | 1.001078× |
| 16736 | 2 | 8.755232 | 8.563264 | 8.618576 | +0.191968 | +0.136656 | 1.022418× | 1.015856× | 0.993659× |
| 8368 | 4 | 4.485312 | 3.866032 | 3.860384 | +0.619280 | +0.624928 | 1.160185× | 1.161882× | 1.000949× |
| 4184 | 8 | 2.357600 | 1.947616 | 1.951536 | +0.409984 | +0.406064 | 1.210506× | 1.208074× | 0.997560× |
| 38592 | 1 | 18.184224 | 20.010400 | 19.991696 | -1.826176 | -1.807472 | 0.908739× | 0.909589× | 1.000738× |
| 19296 | 2 | 10.044096 | 10.017408 | 10.095744 | +0.026688 | -0.051648 | 1.002664× | 0.994884× | 0.992396× |
| 9648 | 4 | 5.109200 | 4.495184 | 4.488960 | +0.614016 | +0.620240 | 1.136594× | 1.138170× | 1.001152× |
| 4824 | 8 | 2.641840 | 2.122128 | 2.129152 | +0.519712 | +0.512688 | 1.244901× | 1.240794× | 0.996380× |
| 48768 | 1 | 22.944111 | 25.455952 | 25.878096 | -2.511841 | -2.933985 | 0.901326× | 0.886623× | 0.983811× |
| 24384 | 2 | 12.684752 | 12.652752 | 12.632144 | +0.032000 | +0.052608 | 1.002529× | 1.004165× | 1.001458× |
| 12192 | 4 | 6.429568 | 5.999984 | 5.992000 | +0.429584 | +0.437568 | 1.071598× | 1.073025× | 1.001535× |
| 6096 | 8 | 3.291536 | 2.787984 | 2.801648 | +0.503552 | +0.489888 | 1.180615× | 1.174857× | 0.996001× |
| 58944 | 1 | 27.779600 | 30.587968 | 30.568928 | -2.808368 | -2.789328 | 0.908187× | 0.908753× | 1.000538× |
| 29472 | 2 | 15.266752 | 15.482512 | 15.449472 | -0.215760 | -0.182720 | 0.986064× | 0.988173× | 1.002299× |
| 14736 | 4 | 7.731024 | 7.348640 | 7.340048 | +0.382384 | +0.390976 | 1.052035× | 1.053266× | 1.001659× |
| 7368 | 8 | 3.942400 | 3.475168 | 3.472256 | +0.467232 | +0.470144 | 1.134449× | 1.135400× | 1.001207× |
| 74240 | 1 | 34.880720 | 38.677264 | 39.311344 | -3.796544 | -4.430624 | 0.901840× | 0.887294× | 0.983831× |
| 37120 | 2 | 19.246944 | 19.438160 | 19.754640 | -0.191216 | -0.507696 | 0.990163× | 0.974300× | 0.983844× |
| 18560 | 4 | 9.660528 | 9.637408 | 9.770336 | +0.023120 | -0.109808 | 1.002399× | 0.988761× | 0.986275× |
| 9280 | 8 | 4.926128 | 4.369984 | 4.365456 | +0.556144 | +0.560672 | 1.127265× | 1.128434× | 1.001213× |
| 109952 | 1 | 55.166416 | 57.228320 | 58.174464 | -2.061904 | -3.008048 | 0.963971× | 0.948293× | 0.983680× |
| 54976 | 2 | 28.518991 | 28.473712 | 28.437648 | +0.045279 | +0.081343 | 1.001590× | 1.002860× | 1.001077× |
| 27488 | 4 | 14.329072 | 14.395680 | 14.509088 | -0.066608 | -0.180016 | 0.995373× | 0.987593× | 0.992220× |
| 13744 | 8 | 7.210127 | 6.759776 | 6.753519 | +0.450352 | +0.456608 | 1.066622× | 1.067610× | 1.001550× |

</details>

### Separate exported-artifact parity

The loaded generated entrypoint is `kernel_minimax_h3_bf16_pre_attention_destination_major_005f_v1`, from the public dual-target implementation at `f617403f534c0bf9f2a2076c81fa94a6fa18e594`. All 24 source/export pairs on each GPU have matching activity signatures and pass the existing export/source band [1/1.03, 1.03].

These source/export absolute latencies come from the separate paired experiment. S/E means source divided by export. Source-first and export-first ratios preserve the two ordering directions. The source/export drift columns are the per-arm median endpoint drifts across the three closed groups, as percentages. PASS is the immediate existing-band result; it does not compare against the segmented baseline.

| Architecture | Rows | Paired source geomean ms | Paired export geomean ms | Paired S/E geomean | Existing-band passes | Exclusions |
|---|---:|---:|---:|---:|---:|---|
| SM100 | 24 | 10.707443 | 10.736484 | 0.997295× | 24 / 24 | none |
| SM103 | 24 | 9.853649 | 9.892576 | 0.996065× | 24 / 24 | none |

<details>
<summary>SM100: separate source/export parity, all 24 centers</summary>

| M | P | Source ms | Export ms | S/E | Source-first S/E | Export-first S/E | Source drift % | Export drift % | Verdict |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|
| 33472 | 1 | 18.873262 | 18.780880 | 1.004919× | 1.004824× | 1.004766× | 0.041125 | 0.031444 | PASS |
| 16736 | 2 | 9.303708 | 9.397581 | 0.990011× | 0.989991× | 0.990112× | 0.007212 | 0.006811 | PASS |
| 8368 | 4 | 4.214767 | 4.194399 | 1.004856× | 1.005117× | 1.005134× | 0.014431 | 0.043468 | PASS |
| 4184 | 8 | 2.081856 | 2.089440 | 0.996370× | 0.996423× | 0.996523× | 0.046120 | 0.021391 | PASS |
| 38592 | 1 | 21.746804 | 21.671059 | 1.003495× | 1.003694× | 1.003635× | 0.074798 | 0.017567 | PASS |
| 19296 | 2 | 10.833588 | 10.947987 | 0.989551× | 0.989548× | 0.989552× | 0.012993 | 0.011246 | PASS |
| 9648 | 4 | 5.061506 | 5.041121 | 1.004044× | 1.004040× | 1.003912× | 0.012666 | 0.017135 | PASS |
| 4824 | 8 | 2.318161 | 2.327122 | 0.996150× | 0.996343× | 0.995886× | 0.044174 | 0.054995 | PASS |
| 48768 | 1 | 27.626795 | 28.078138 | 0.983925× | 0.983907× | 0.983903× | 0.023112 | 0.009059 | PASS |
| 24384 | 2 | 13.811077 | 13.741958 | 1.005030× | 1.005194× | 1.005060× | 0.021537 | 0.003027 | PASS |
| 12192 | 4 | 6.498499 | 6.470291 | 1.004360× | 1.004425× | 1.004461× | 0.072416 | 0.086091 | PASS |
| 6096 | 8 | 2.973346 | 2.995041 | 0.992756× | 0.992829× | 0.992716× | 0.061359 | 0.019236 | PASS |
| 58944 | 1 | 33.204736 | 33.065984 | 1.004196× | 1.004283× | 1.004043× | 0.017918 | 0.013845 | PASS |
| 29472 | 2 | 16.762040 | 16.651272 | 1.006652× | 1.006520× | 1.006474× | 0.027091 | 0.032467 | PASS |
| 14736 | 4 | 8.038324 | 7.998084 | 1.005031× | 1.005123× | 1.004959× | 0.040012 | 0.032999 | PASS |
| 7368 | 8 | 3.710962 | 3.696754 | 1.003843× | 1.003940× | 1.003614× | 0.015534 | 0.039401 | PASS |
| 74240 | 1 | 41.903542 | 42.593366 | 0.983804× | 0.983744× | 0.983872× | 0.013591 | 0.011193 | PASS |
| 37120 | 2 | 21.061498 | 21.403082 | 0.984040× | 0.983922× | 0.984085× | 0.012160 | 0.009564 | PASS |
| 18560 | 4 | 10.511173 | 10.667573 | 0.985339× | 0.985292× | 0.985326× | 0.009732 | 0.016520 | PASS |
| 9280 | 8 | 4.748562 | 4.725970 | 1.004780× | 1.004755× | 1.004647× | 0.014152 | 0.006750 | PASS |
| 109952 | 1 | 62.023280 | 63.060734 | 0.983548× | 0.983541× | 0.983587× | 0.005677 | 0.012382 | PASS |
| 54976 | 2 | 31.122685 | 30.987933 | 1.004349× | 1.004307× | 1.004322× | 0.029101 | 0.022406 | PASS |
| 27488 | 4 | 15.674999 | 15.831255 | 0.990130× | 0.990127× | 0.990108× | 0.006842 | 0.030516 | PASS |
| 13744 | 8 | 7.422531 | 7.387156 | 1.004789× | 1.004964× | 1.004628× | 0.040090 | 0.063712 | PASS |

</details>

<details>
<summary>SM103: separate source/export parity, all 24 centers</summary>

| M | P | Source ms | Export ms | S/E | Source-first S/E | Export-first S/E | Source drift % | Export drift % | Verdict |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|
| 33472 | 1 | 17.376209 | 17.357489 | 1.001078× | 1.000995× | 1.001071× | 0.011416 | 0.051611 | PASS |
| 16736 | 2 | 8.562864 | 8.617504 | 0.993659× | 0.993653× | 0.993648× | 0.015130 | 0.010775 | PASS |
| 8368 | 4 | 3.864400 | 3.860736 | 1.000949× | 1.001019× | 1.001310× | 0.024026 | 0.089113 | PASS |
| 4184 | 8 | 1.949088 | 1.953856 | 0.997560× | 0.997491× | 0.997459× | 0.284396 | 0.269769 | PASS |
| 38592 | 1 | 20.010368 | 19.995617 | 1.000738× | 1.000728× | 1.000671× | 0.019670 | 0.006321 | PASS |
| 19296 | 2 | 10.018336 | 10.095104 | 0.992396× | 0.992344× | 0.992400× | 0.013413 | 0.029794 | PASS |
| 9648 | 4 | 4.493200 | 4.488032 | 1.001152× | 1.001096× | 1.001610× | 0.046269 | 0.020671 | PASS |
| 4824 | 8 | 2.122752 | 2.130464 | 0.996380× | 0.996368× | 0.996430× | 0.194113 | 0.100534 | PASS |
| 48768 | 1 | 25.457328 | 25.876239 | 0.983811× | 0.983860× | 0.983780× | 0.001259 | 0.035485 | PASS |
| 24384 | 2 | 12.652912 | 12.634495 | 1.001458× | 1.001461× | 1.001370× | 0.017831 | 0.012410 | PASS |
| 12192 | 4 | 6.001072 | 5.991872 | 1.001535× | 1.001482× | 1.001402× | 0.012265 | 0.018159 | PASS |
| 6096 | 8 | 2.789792 | 2.800992 | 0.996001× | 0.996086× | 0.995970× | 0.016058 | 0.034264 | PASS |
| 58944 | 1 | 30.586655 | 30.570223 | 1.000538× | 1.000631× | 1.000617× | 0.004813 | 0.008165 | PASS |
| 29472 | 2 | 15.483904 | 15.448384 | 1.002299× | 1.002145× | 1.002292× | 0.020043 | 0.054873 | PASS |
| 14736 | 4 | 7.351120 | 7.338944 | 1.001659× | 1.001574× | 1.001657× | 0.040060 | 0.010465 | PASS |
| 7368 | 8 | 3.476048 | 3.471856 | 1.001207× | 1.001357× | 1.001326× | 0.004602 | 0.019360 | PASS |
| 74240 | 1 | 38.675904 | 39.311536 | 0.983831× | 0.983874× | 0.983850× | 0.005626 | 0.005456 | PASS |
| 37120 | 2 | 19.436992 | 19.756176 | 0.983844× | 0.983829× | 0.983899× | 0.007820 | 0.009070 | PASS |
| 18560 | 4 | 9.634976 | 9.769056 | 0.986275× | 0.986231× | 0.986373× | 0.014447 | 0.029648 | PASS |
| 9280 | 8 | 4.370864 | 4.365568 | 1.001213× | 1.001507× | 1.001195× | 0.006224 | 0.016124 | PASS |
| 109952 | 1 | 57.227008 | 58.176447 | 0.983680× | 0.983634× | 0.983686× | 0.003243 | 0.014135 | PASS |
| 54976 | 2 | 28.471041 | 28.440416 | 1.001077× | 1.001058× | 1.001062× | 0.013261 | 0.029371 | PASS |
| 27488 | 4 | 14.395824 | 14.508704 | 0.992220× | 0.992210× | 0.992254× | 0.011559 | 0.012138 | PASS |
| 13744 | 8 | 6.760096 | 6.749632 | 1.001550× | 1.001571× | 1.001419× | 0.026962 | 0.069687 | PASS |

</details>

| Benchmark duration | SM100 (s) | SM103 (s) |
|---|---:|---:|
| Measured GPU samples | 147.082 | 144.837 |
| Benchmark payload | 299.892 | 303.365 |
| End-to-end physical turnaround | 372.353 | 376.583 |

Cache flushing, preparation, and orchestration account for the difference between measured GPU time, payload time, and physical turnaround.

### Complete existing shape denominator

The existing 44-row inventory is preserved: 24 production centers measured for performance on both GPUs, eight aligned neighbors, eight tail neighbors, and four smoke shapes. Every row passed source/export/reference correctness at BF16 atol=rtol=0.01 on both architectures. The table gives every M/P coordinate; head count, head dimension, dtype, layout, and operator semantics are as defined above.

<details>
<summary>All 44 shapes and their coverage</summary>

| Shape | M | P | Coverage |
|---|---:|---:|---|
| center_p1_4s_m33472 | 33472 | 1 | correctness + performance |
| center_p2_4s_m16736 | 16736 | 2 | correctness + performance |
| center_p4_4s_m8368 | 8368 | 4 | correctness + performance |
| center_p8_4s_m4184 | 4184 | 8 | correctness + performance |
| center_p1_5s_m38592 | 38592 | 1 | correctness + performance |
| center_p2_5s_m19296 | 19296 | 2 | correctness + performance |
| center_p4_5s_m9648 | 9648 | 4 | correctness + performance |
| center_p8_5s_m4824 | 4824 | 8 | correctness + performance |
| center_p1_6s_m48768 | 48768 | 1 | correctness + performance |
| center_p2_6s_m24384 | 24384 | 2 | correctness + performance |
| center_p4_6s_m12192 | 12192 | 4 | correctness + performance |
| center_p8_6s_m6096 | 6096 | 8 | correctness + performance |
| center_p1_8s_m58944 | 58944 | 1 | correctness + performance |
| center_p2_8s_m29472 | 29472 | 2 | correctness + performance |
| center_p4_8s_m14736 | 14736 | 4 | correctness + performance |
| center_p8_8s_m7368 | 7368 | 8 | correctness + performance |
| center_p1_10s_m74240 | 74240 | 1 | correctness + performance |
| center_p2_10s_m37120 | 37120 | 2 | correctness + performance |
| center_p4_10s_m18560 | 18560 | 4 | correctness + performance |
| center_p8_10s_m9280 | 9280 | 8 | correctness + performance |
| center_p1_15s_m109952 | 109952 | 1 | correctness + performance |
| center_p2_15s_m54976 | 54976 | 2 | correctness + performance |
| center_p4_15s_m27488 | 27488 | 4 | correctness + performance |
| center_p8_15s_m13744 | 13744 | 8 | correctness + performance |
| aligned_p1_5s_minus64_m38528 | 38528 | 1 | correctness |
| aligned_p1_5s_plus64_m38656 | 38656 | 1 | correctness |
| aligned_p2_5s_minus32_m19264 | 19264 | 2 | correctness |
| aligned_p2_5s_plus32_m19328 | 19328 | 2 | correctness |
| aligned_p4_5s_minus16_m9632 | 9632 | 4 | correctness |
| aligned_p4_5s_plus16_m9664 | 9664 | 4 | correctness |
| aligned_p8_5s_minus8_m4816 | 4816 | 8 | correctness |
| aligned_p8_5s_plus8_m4832 | 4832 | 8 | correctness |
| tail_p1_5s_minus1_m38591 | 38591 | 1 | correctness |
| tail_p1_5s_plus1_m38593 | 38593 | 1 | correctness |
| tail_p2_5s_minus1_m19295 | 19295 | 2 | correctness |
| tail_p2_5s_plus1_m19297 | 19297 | 2 | correctness |
| tail_p4_5s_minus1_m9647 | 9647 | 4 | correctness |
| tail_p4_5s_plus1_m9649 | 9649 | 4 | correctness |
| tail_p8_5s_minus1_m4823 | 4823 | 8 | correctness |
| tail_p8_5s_plus1_m4825 | 4825 | 8 | correctness |
| smoke_p8_m1 | 1 | 8 | correctness |
| smoke_p8_m127 | 127 | 8 | correctness |
| smoke_p8_m128 | 128 | 8 | correctness |
| smoke_p8_m129 | 129 | 8 | correctness |

</details>

### Reproduction

```bash
FLASHINFER_RUN_FULL_MINIMAX_H3_TESTS=1 python -m pytest tests/diffusion_ops/test_minimax_h3_bf16_pre_attention.py
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for CUDA compute capabilities 10.0 and 10.3.
  * Enabled JIT compilation for both SM100a and SM103a architectures.
  * Improved barrier synchronization behavior for supported hardware.

* **Bug Fixes**
  * Expanded runtime compatibility and validation for Blackwell GPUs.
  * Updated correctness checks, CUDA graph capture, and invalid-index handling across supported architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->