### PR TITLE
BF16 cutedsl prune [2] + cache bf16 cutedsl kernels

### DIFF
--- a/docs/design_docs/cute_dsl_kernel_cache.md
+++ b/docs/design_docs/cute_dsl_kernel_cache.md
@@ -49,7 +49,7 @@ Callers depend on the interface, not the implementation: `gen_jit_spec()` and th
 
 The on-disk conventions also match the nvcc cache: the same two-level scheme (in-process `functools.cache` + on-disk artifact), the same `cached_ops/` root with one directory per op family, invalidation at the same module granularity as ninja rebuilds. It diverges only where the DSL toolchain forces it — artifacts are single-arch object files rather than multi-arch fatbin `.so`s.
 
-One contract nuance: `try_load()` returns the cached artifact only when it is present *and known-valid*, and may conservatively return `None` even when artifacts exist. `JitSpecCuteDsl` decides validity itself (`.o` present + `meta.json` match); `JitSpecNvcc` returns only the AOT artifact, routing the JIT path through `build()` where ninja's dependency scan owns freshness. On a miss, `JitSpecCuteDsl.build()` keeps the freshly compiled kernel in memory and `load()` returns it directly — a build is never followed by a redundant JITLink reload from disk.
+One contract nuance: `try_load()` returns the cached artifact only when it is present *and known-valid*, and may conservatively return `None` even when artifacts exist. `JitSpecCuteDsl` decides validity itself (`.o` present + `meta.json` match); `JitSpecNvcc` returns only the AOT artifact, routing the JIT path through `build()` where ninja's dependency scan owns freshness. On a miss, `JitSpecCuteDsl.build()` compiles and exports the kernel. `load()` prefers the exported artifact so fresh builds and cache hits use the same loaded form and unsupported targets fail before invocation. If no artifact was produced, it falls back to the in-process compiled kernel.
 
 ### 2.1 Internal interface for kernel authors
 
@@ -70,8 +70,9 @@ def _get_compiled_kernel(...):
 ```
 
 On a **hit**, the kernel is JITLinked from the cached `.o` (milliseconds).
-On a **miss**, `compile_fn` runs, the result is exported to the module
-directory, and the in-process compiled function is returned directly.
+On a **miss**, `compile_fn` runs and the result is exported to the module
+directory. The exported artifact is then loaded; if export produced no
+artifact, the in-process compiled function is used instead.
 
 ### 2.2 Cache on disk layout
 
@@ -224,6 +225,25 @@ The initial implementation was a free function that duplicated the lock/double-c
 The benchmark command
 `flashinfer_benchmark.py --routine nvfp4_quantize ... --backends cuda cute-dsl`
 compiles on the first run and is compile-free on every subsequent run.
+
+### BF16 dense GEMM
+
+The `mm_bf16(backend="cute-dsl")` Direct, cluster Split-K, and warp Split-K
+kernels use the same disk-cache helper. Their names encode all static shape,
+layout, dtype, tactic, bias, and PDL fields that affect code generation.
+Cluster Split-K retains dynamic matrix extents, so its artifacts can be reused
+across shapes with the same layout and tactic. Device indices distinguish
+in-process loaded functions; disk artifacts are shared by matching architecture.
+
+The kernels use TVM-FFI's environment stream, preserving the caller's current
+PyTorch CUDA stream. Only compiled kernels are persisted here; autotune winners
+are a separate cache and need not be saved.
+
+Keeping `~/.cache/flashinfer` across server restarts is sufficient for reuse.
+For replaceable containers, preserve that directory or set
+`FLASHINFER_WORKSPACE_BASE` to a persistent mount before importing FlashInfer.
+The first use of a missing specialization still compiles it; this integration
+does not precompile or package kernels in a wheel.
 
 ## 5. Limitations and future work
 

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -739,6 +739,8 @@ def mm_bf16(
         kernels on the M <= 32 buckets and the cuBLASLt fallback on the larger
         ones, so a single large-M warm-up tunes both ranges; with bias the
         direct kernel is excluded.
+        Compiled CuTe DSL kernels are cached on disk and reused across processes
+        when the source, compiler stack, architecture, and configuration match.
         ``"auto"`` allows selecting the best tactic from all available backends when autotune is enabled.
 
     Returns
@@ -2035,7 +2037,6 @@ def get_mm_bf16_cublaslt_module():
     )
 
 
-_CUTE_DSL_BF16_AUTOTUNE_VERSION = 12
 # M bound of the CuTe-DSL low-M kernels; larger M runs the cuBLASLt fallback.
 _CUTE_DSL_BF16_MAX_M = 32
 
@@ -2193,7 +2194,6 @@ class _CuteDSLBf16Runner(TunableRunner):
             bias is not None,
             bool(pdl),
             self.compute_capability,
-            _CUTE_DSL_BF16_AUTOTUNE_VERSION,
         )
 
 

--- a/flashinfer/gemm/kernels/dense_bf16_gemm_direct.py
+++ b/flashinfer/gemm/kernels/dense_bf16_gemm_direct.py
@@ -22,6 +22,8 @@ from cutlass import const_expr
 from cutlass.cute import experimental as cute_ext
 from cutlass.cute.runtime import from_dlpack
 
+from ...jit.cute_dsl_core import build_and_load_cute_dsl_kernel
+
 
 _VECTOR_WIDTH = 8
 _SUPPORTED_BLOCK_SIZES = (32, 64, 96, 128, 192, 256, 384)
@@ -301,6 +303,7 @@ def _make_compile_repr_tensors(dtype, m: int, n: int, k: int):
 
 @functools.cache
 def _get_compiled_direct_kernel(
+    device_index: int,
     dtype,
     m: int,
     n: int,
@@ -310,16 +313,30 @@ def _get_compiled_direct_kernel(
 ):
     if dtype != _torch.bfloat16:
         raise ValueError(f"direct GEMM supports BF16; got {dtype}")
-    kernel = DirectDenseGemmKernel(
-        element_type=cutlass.BFloat16,
-        num_rows=m,
-        k_extent=k,
-        tactic=tactic,
-        use_pdl=use_pdl,
-    )
-    tensors = _make_compile_repr_tensors(dtype, m, n, k)
-    stream = _cuda.CUstream(_torch.cuda.current_stream().cuda_stream)
-    return cute_ext.compile(kernel, *tensors, stream, options=_COMPILE_OPTIONS)
+
+    def compile_kernel():
+        return cute_ext.compile(
+            DirectDenseGemmKernel(
+                element_type=cutlass.BFloat16,
+                num_rows=m,
+                k_extent=k,
+                tactic=tactic,
+                use_pdl=use_pdl,
+            ),
+            *_make_compile_repr_tensors(dtype, m, n, k),
+            cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+            options=_COMPILE_OPTIONS + " --enable-tvm-ffi",
+        )
+
+    with _torch.cuda.device(device_index):
+        return build_and_load_cute_dsl_kernel(
+            "dense_bf16_gemm_direct",
+            f"bf16_m{m}_n{n}_k{k}_block{tactic.block_size}"
+            f"_out{tactic.outputs_per_block}_rows{tactic.rows_per_block}"
+            f"_pdl{int(use_pdl)}",
+            compile_kernel,
+            extra_key_files=(__file__,),
+        )
 
 
 def _validate_runtime_tensors(a, b, out, tactic: DirectTactic):
@@ -351,10 +368,11 @@ def _validate_runtime_tensors(a, b, out, tactic: DirectTactic):
 def run_direct_dense(a, b, out, pdl: bool, tactic: DirectTactic):
     """Run direct ``A[M,K] @ B[K,N]`` with the ``mm_bf16`` layouts."""
     m, n, k = _validate_runtime_tensors(a, b, out, tactic)
-    compiled = _get_compiled_direct_kernel(a.dtype, m, n, k, tactic, pdl)
-    tensors = tuple(_from_dlpack_static(tensor) for tensor in (a, b.T, out))
-    stream = _cuda.CUstream(_torch.cuda.current_stream(a.device).cuda_stream)
-    compiled(*tensors, stream)
+    with _torch.cuda.device(a.device):
+        compiled = _get_compiled_direct_kernel(
+            a.get_device(), a.dtype, m, n, k, tactic, pdl
+        )
+        compiled(a, b.T, out)
     return out
 
 

--- a/flashinfer/gemm/kernels/dense_bf16_gemm_sm100_splitk.py
+++ b/flashinfer/gemm/kernels/dense_bf16_gemm_sm100_splitk.py
@@ -24,6 +24,8 @@ from cutlass.cute.nvgpu import tcgen05
 from cutlass.cute.runtime import from_dlpack
 from cutlass.cutlass_dsl import T, dsl_user_op
 
+from ...jit.cute_dsl_core import build_and_load_cute_dsl_kernel
+
 
 #: Per-CTA SMEM capacity reported by CuTeDSL on SM100/SM103.
 _SMEM_CAPACITY_BYTES = utils.get_smem_capacity_in_bytes("sm_100")
@@ -185,15 +187,17 @@ def autotune_tactics(
                     continue
                 max_stages = _max_ab_stages_for(base, smem_capacity)
                 # Short K favors shallow pipelines; long K stays near the cap.
+                if k <= 4 * _CTA_K:
+                    max_stages = min(max_stages, 6)
+                else:
+                    min_stages = min(max(5, max_stages - 2), max_stages)
+                # Retain a non-wrapping power-of-two ring for cheap stage indexing.
+                stage_limit = 1 << (k // _CTA_K // split_k).bit_length()
                 tactics.extend(
                     dataclasses.replace(base, ab_stages=ab_stages)
-                    for ab_stages in (
-                        range(min_stages, min(max_stages, 6) + 1)
-                        if k <= 4 * _CTA_K
-                        else range(
-                            min(max(5, max_stages - 2), max_stages),
-                            max_stages + 1,
-                        )
+                    for ab_stages in range(
+                        min(min_stages, stage_limit),
+                        min(max_stages, stage_limit) + 1,
                     )
                 )
     return tactics
@@ -909,36 +913,24 @@ def _make_compile_repr_tensors(
     )
 
 
-def _to_cute_swap(a, b, out, bias):
-    a_swap = b.unsqueeze(0).transpose(-2, -1)
-    b_swap = a.unsqueeze(0).transpose(-2, -1)
-    c_swap = out.unsqueeze(0).transpose(-2, -1)
-    leading_dims = tuple(
-        _detect_leading_dim(tensor) for tensor in (a_swap, b_swap, c_swap)
+def _make_swapped_tensors(a, b, out, bias):
+    tensors = (
+        b.unsqueeze(0).transpose(-2, -1),
+        a.unsqueeze(0).transpose(-2, -1),
+        out.unsqueeze(0).transpose(-2, -1),
     )
-    cute_tensors = tuple(
-        _from_dlpack_dynamic(tensor, leading_dim)
-        for tensor, leading_dim in zip(
-            (a_swap, b_swap, c_swap), leading_dims, strict=True
-        )
-    )
-    if bias is None:
-        return (*cute_tensors, None, leading_dims)
     return (
-        *cute_tensors,
-        _from_dlpack_dynamic(
-            bias.as_strided(
-                size=(1, c_swap.shape[1], c_swap.shape[2]), stride=(0, 1, 0)
-            ),
-            1,
-            2,
-        ),
-        leading_dims,
+        *tensors,
+        bias.as_strided(size=tensors[2].shape, stride=(0, 1, 0))
+        if bias is not None
+        else None,
+        tuple(_detect_leading_dim(tensor) for tensor in tensors),
     )
 
 
 @functools.cache
 def _get_compiled_splitk_kernel(
+    device_index: int,
     dtype,
     tactic: SplitKTactic,
     use_pdl: bool,
@@ -950,18 +942,26 @@ def _get_compiled_splitk_kernel(
             f"split-K dense GEMM supports {_SUPPORTED_TORCH_DTYPES}; got {dtype}"
         )
 
-    kernel = SplitKDenseGemmKernel(
-        tactic=tactic,
-        use_pdl=use_pdl,
-        has_bias=has_bias,
-    )
-    compile_tensors = _make_compile_repr_tensors(dtype, has_bias, *leading_dims)
-    stream = _cuda.CUstream(_torch.cuda.current_stream().cuda_stream)
-    if has_bias:
-        compiled = cute_ext.compile(_bmm_bias, kernel, *compile_tensors, stream)
-    else:
-        compiled = cute_ext.compile(_bmm_no_bias, kernel, *compile_tensors[:3], stream)
-    return compiled
+    def compile_kernel():
+        compile_tensors = _make_compile_repr_tensors(dtype, has_bias, *leading_dims)
+        return cute_ext.compile(
+            _bmm_bias if has_bias else _bmm_no_bias,
+            SplitKDenseGemmKernel(tactic=tactic, use_pdl=use_pdl, has_bias=has_bias),
+            *(compile_tensors if has_bias else compile_tensors[:3]),
+            cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+            options="--enable-tvm-ffi",
+        )
+
+    with _torch.cuda.device(device_index):
+        return build_and_load_cute_dsl_kernel(
+            "dense_bf16_gemm_sm100_splitk",
+            f"{str(dtype).removeprefix('torch.')}_m{tactic.mma_m}_n{tactic.mma_n}"
+            f"_split{tactic.split_k}_stages{tactic.ab_stages}"
+            f"_la{leading_dims[0]}_lb{leading_dims[1]}_lc{leading_dims[2]}"
+            f"_pdl{int(use_pdl)}_bias{int(has_bias)}",
+            compile_kernel,
+            extra_key_files=(__file__,),
+        )
 
 
 def _validate_runtime_tensors(a, b, bias, out) -> tuple[int, int, int]:
@@ -1016,17 +1016,15 @@ def run_splitk_dense(
     """Run ``A[M,K] @ B[K,N]`` with the ``mm_bf16`` layouts."""
     validate_tactic(tactic, *_validate_runtime_tensors(a, b, bias, out))
     has_bias = bias is not None
-    cute_tensors = _to_cute_swap(a, b, out, bias)
-    compiled = _get_compiled_splitk_kernel(
-        dtype=a.dtype,
-        tactic=tactic,
-        use_pdl=pdl,
-        has_bias=has_bias,
-        leading_dims=cute_tensors[4],
-    )
-    stream = _cuda.CUstream(_torch.cuda.current_stream(a.device).cuda_stream)
-    if has_bias:
-        compiled(*cute_tensors[:4], stream)
-    else:
-        compiled(*cute_tensors[:3], stream)
+    tensors = _make_swapped_tensors(a, b, out, bias)
+    with _torch.cuda.device(a.device):
+        compiled = _get_compiled_splitk_kernel(
+            device_index=a.get_device(),
+            dtype=a.dtype,
+            tactic=tactic,
+            use_pdl=pdl,
+            has_bias=has_bias,
+            leading_dims=tensors[4],
+        )
+        compiled(*(tensors[:4] if has_bias else tensors[:3]))
     return out

--- a/flashinfer/gemm/kernels/dense_bf16_gemm_warp_splitk.py
+++ b/flashinfer/gemm/kernels/dense_bf16_gemm_warp_splitk.py
@@ -20,6 +20,8 @@ from cutlass.cute import experimental as cute_ext
 from cutlass.cute.nvgpu import warp
 from cutlass.cute.runtime import from_dlpack
 
+from ...jit.cute_dsl_core import build_and_load_cute_dsl_kernel
+
 
 _MMA_SHAPE = (16, 8, 16)
 _COMPUTE_WARPS = 4
@@ -791,20 +793,32 @@ def _compile(
     use_pdl: bool,
     has_bias: bool,
 ):
-    device = _torch.device("cuda", device_index)
-    with _torch.cuda.device(device):
-        kernel = CpAsyncWarpSplitKKernel(tactic, use_pdl, has_bias)
-        tensors = tuple(
-            _from_dlpack(tensor)
-            for tensor in (
-                _torch.empty((n, k), device=device, dtype=dtype),
-                _torch.empty((m, k), device=device, dtype=dtype),
-                _torch.empty((n,), device=device, dtype=dtype),
-                _torch.empty((m, n), device=device, dtype=dtype),
-            )
+    def compile_kernel():
+        return cute_ext.compile(
+            CpAsyncWarpSplitKKernel(tactic, use_pdl, has_bias),
+            *(
+                _from_dlpack(tensor)
+                for tensor in (
+                    _torch.empty((n, k), device="cuda", dtype=dtype),
+                    _torch.empty((m, k), device="cuda", dtype=dtype),
+                    _torch.empty((n,), device="cuda", dtype=dtype),
+                    _torch.empty((m, n), device="cuda", dtype=dtype),
+                )
+            ),
+            cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+            options="--enable-tvm-ffi",
         )
-        stream = _cuda.CUstream(_torch.cuda.current_stream(device).cuda_stream)
-        return cute_ext.compile(kernel, *tensors, stream)
+
+    with _torch.cuda.device(device_index):
+        return build_and_load_cute_dsl_kernel(
+            "dense_bf16_gemm_warp_splitk",
+            f"{str(dtype).removeprefix('torch.')}_m{m}_n{n}_k{k}"
+            f"_out{tactic.output_tile}_token{tactic.token_tile}_kt{tactic.k_tile}"
+            f"_stages{tactic.stages}_bl{tactic.b_loader_warps}"
+            f"_pdl{int(use_pdl)}_bias{int(has_bias)}",
+            compile_kernel,
+            extra_key_files=(__file__,),
+        )
 
 
 def run_warp_splitk_dense(a, b, out, pdl: bool, tactic: WarpSplitKTactic, bias=None):
@@ -816,15 +830,13 @@ def run_warp_splitk_dense(a, b, out, pdl: bool, tactic: WarpSplitKTactic, bias=N
         compiled = _compile(
             device_index, a.dtype, m, n, k, tactic, pdl, bias is not None
         )
-        stream = _cuda.CUstream(_torch.cuda.current_stream(a.device).cuda_stream)
         # Without bias the kernel never reads its bias argument; pass a row of
         # ``out`` so the launch signature stays fixed.
         compiled(
-            _from_dlpack(b.T),
-            _from_dlpack(a),
-            _from_dlpack(bias if bias is not None else out[0]),
-            _from_dlpack(out),
-            stream,
+            b.T,
+            a,
+            bias if bias is not None else out[0],
+            out,
         )
     return out
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Follow-up to https://github.com/flashinfer-ai/flashinfer/pull/5089.

Add persistent compiled-kernel caching for `mm_bf16(backend="cute-dsl")` and conservatively prune cluster Split-K stages.

- Reuse `build_and_load_cute_dsl_kernel()` for Direct, cluster Split-K, and warp Split-K. Preserve specialization fields, device selection, and the current PyTorch stream through TVM-FFI.
- Cap cluster stage candidates at a non-wrapping power-of-two ring derived from each CTA's K-tile count. Kernel mainloops, default tactics, and Direct/warp candidate sets are unchanged.
- Remove the manually bumped BF16 autotune cache-version field; retain dtype, output dtype, bias, PDL, and architecture extras.

### Measurements

B300 SXM6 AC, Torch 2.13.0+cu130, CuTeDSL 4.7.0; BF16 input/output, no bias, PDL enabled; default M buckets 1/2/4/8/16/32.

The disk-cache experiment below fully retuned in **separate processes**, without persisting autotune winners. Common binding setup is excluded. These cache measurements preceded the additional stage pruning.

| N | K | Empty disk cache: JIT + export + autotune | New process: disk load + autotune | CuTe compilations on reload |
|---:|---:|---:|---:|---:|
| 4608 | 8192 | 563.784 s | 8.021 s | 0 |
| 8192 | 2048 | 351.925 s | 6.930 s | 0 |

First use still pays JIT/export costs; this is **not** an offline-precompiled package or a claim of faster first-ever compilation.

Cluster candidates per M bucket:

| K | Before | After |
|---:|---:|---:|
| 128 | 35 | 12 |
| 256 | 58 | 24 |
| 512 | 85 | 53 |
| 1024 | 41 | 29 |
| 2048 | 41 | 37 |
| 8192 | 41 | 41 |

Hot/cold CUPTI candidate-set comparisons covered all 32 shapes in #4266 affected by this pruning; no performance regression was observed. The other 32 shapes retain identical candidate sets. This measures the best available candidate latency, not a guarantee about a noisy production autotuner's selection.

<details>
<summary>Reproduce cache reuse</summary>

Run this program twice in independent Python processes with the same `FLASHINFER_WORKSPACE_BASE`, initially using an empty task-specific cache directory. Change `n,k` for the second matrix family. Do not save/load an autotune winner cache.

```python
import time
import torch
import flashinfer
from flashinfer.gemm import gemm_base as gb

n, k = 4608, 8192
a = torch.randn((32, k), device="cuda", dtype=torch.bfloat16)
b = torch.randn((n, k), device="cuda", dtype=torch.bfloat16).T
out = torch.empty((32, n), device="cuda", dtype=torch.bfloat16)
workspace = gb._get_cache_buf("mm_bf16_workspace", gb.DEFAULT_WORKSPACE_SIZE, a.device)
gb._cute_dsl_bf16_runners([a, b, None, True, out, workspace])
torch.cuda.synchronize()
start = time.perf_counter()
with flashinfer.autotune(True):
    flashinfer.mm_bf16(a, b, out=out, pdl=True, backend="cute-dsl")
torch.cuda.synchronize()
print(time.perf_counter() - start)
```

Only compiled artifacts are persisted by this change; each process still performs autotuning.

</details>

## 🔍 Related Issues

Related: #4266, #5089.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

No test files are added or modified; existing accuracy tests are reused.

- Post-rebase B300: `pytest -q tests/gemm/test_mm_bf16.py -k 'cute and not cutile'` — **10 passed** on CuTeDSL 4.7.0 and **10 passed** on 4.6.2.
- Fresh-process cache reload verified with CuTe compilation forbidden; eager, custom-stream, CUDA Graph, bias, BF16/FP16, and cache-disabled paths checked locally.
- Additional local numerical checks: 178 cache-path cases, 256 stage-boundary cases, and actual M=1..32 after autotuning both matrix families.
- Cache integration: 19 matched-tactic cases across hot/cold L2, maximum observed slowdown 0.55%. Stage pruning: broader 54-cell check within a 1% near-tie band; the final 20-shape/40-cell #4266 follow-up measured changes of -0.24% to 0%.
- `pre-commit run --all-files` passed on the final rebased revision.

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

The diff is limited to the three existing kernel modules and the BF16 interface documentation/cache extras. Local benchmarks, result files, and logs are not included.

Dynamic M, offline wheel generation, and the rejected B-loader pruning experiment are out of scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added disk caching for compiled BF16 GEMM kernels, enabling reuse across processes and application runs.
  * Improved cache reuse across compatible GEMM shapes and configurations.
  * Preserved the caller’s PyTorch CUDA stream during kernel execution.
  * Added deployment guidance for retaining or configuring the kernel cache location.

* **Documentation**
  * Documented BF16 GEMM disk-cache behavior and deployment considerations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->