### PR TITLE
fix(comm): accept MNNVL fabric UUIDs with leading zero bytes

### DIFF
--- a/flashinfer/comm/mnnvl.py
+++ b/flashinfer/comm/mnnvl.py
@@ -600,8 +600,8 @@ def is_mnnvl_fabric_supported(device_idx: int) -> bool:
         pynvml.nvmlDeviceGetGpuFabricInfoV(handle, ctypes.byref(fabric_info))
         return (
             fabric_info.state >= pynvml.NVML_GPU_FABRIC_STATE_COMPLETED
-            and fabric_info.clusterUuid
-            and fabric_info.clusterUuid[0] != 0
+            # A binary UUID may start with zero; only an all-zero UUID is absent.
+            and any(fabric_info.clusterUuid)
         )
     finally:
         pynvml.nvmlShutdown()

--- a/tests/comm/test_mnnvl_fabric_support.py
+++ b/tests/comm/test_mnnvl_fabric_support.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2024 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest.mock import patch
+
+import pytest
+
+from flashinfer.comm import mnnvl
+
+
+@pytest.mark.parametrize(
+    "fabric_uuid,state,supported,expected",
+    [
+        ("00112233445566778899aabbccddeeff", 3, 1, True),
+        ("112233445566778899aabbccddeeff00", 3, 1, True),
+        ("00000000000000000000000000000001", 3, 1, True),
+        ("00000000000000000000000000000000", 3, 1, False),
+        ("00112233445566778899aabbccddeeff", 2, 1, False),
+        ("00112233445566778899aabbccddeeff", 3, 0, False),
+    ],
+)
+def test_is_mnnvl_fabric_supported(fabric_uuid, state, supported, expected):
+    fabric_info = mnnvl.pynvml.c_nvmlGpuFabricInfoV_t()
+    fabric_info.state = state
+    fabric_info.clusterUuid[:] = bytes.fromhex(fabric_uuid)
+    with (
+        patch.object(
+            mnnvl.cuda,
+            "cuDeviceGetAttribute",
+            return_value=(mnnvl.cuda.CUresult.CUDA_SUCCESS, supported),
+        ),
+        patch.object(mnnvl.pynvml, "nvmlInit") as init,
+        patch.object(mnnvl.pynvml, "nvmlShutdown") as shutdown,
+        patch.object(mnnvl.pynvml, "nvmlDeviceGetHandleByIndex"),
+        patch.object(mnnvl.pynvml, "c_nvmlGpuFabricInfoV_t", return_value=fabric_info),
+        patch.object(mnnvl.pynvml, "nvmlDeviceGetGpuFabricInfoV"),
+    ):
+        assert mnnvl.is_mnnvl_fabric_supported(0) is expected
+        if supported:
+            init.assert_called_once()
+            shutdown.assert_called_once()
+        else:
+            init.assert_not_called()
+            shutdown.assert_not_called()


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

`is_mnnvl_fabric_supported()` rejects a healthy MNNVL fabric when the first byte of its binary cluster UUID is zero. For example, `00112233-4455-6677-8899-aabbccddeeff` is nonzero, but `clusterUuid[0] != 0` returns false. Consumers can then reject MNNVL or select the wrong handle type despite CUDA reporting FABRIC support and NVML reporting a completed fabric.

Check `any(fabric_info.clusterUuid)` instead. This accepts UUIDs with leading zero bytes while continuing to reject the all-zero UUID. The CUDA capability check, fabric-state check, and NVML cleanup are unchanged.

The affected predicate is present in both v0.6.17 and v0.6.18, and in current main.

## 🔍 Related Issues

No existing issue. Found while investigating a multi-node serving startup failure on GB300.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

Changed-file hooks were run with `pre-commit run --files flashinfer/comm/mnnvl.py tests/comm/test_mnnvl_fabric_support.py`; the repository-wide hook run is not claimed.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Focused regression suite:

```bash
python -m pytest tests/comm/test_mnnvl_fabric_support.py -q
```

- Before the fix: **2 failed, 4 passed**. Both failures are nonzero UUIDs whose first byte is zero.
- After the fix: **6 passed**. Cases cover leading-zero UUIDs, a UUID with only its final byte nonzero, an ordinary UUID, an all-zero UUID, incomplete fabric state, and unsupported FABRIC handles. CUDA/NVML calls are mocked, so these tests require no GPU allocation.
- Prior live driver/NVML validation on GB300: on four GPUs in a healthy fabric with a zero-leading UUID, the original probe returned **False** and the corrected probe returned **True**. Four GPUs on a fabric with a nonzero first UUID byte returned **True** with both probes. A downstream serving run using the same predicate correction successfully allocated MNNVL memory and served requests on the affected fabric.

The full GPU test suite has not been run for this upstream checkout.

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

This is a support-detection fix; it changes no kernels or public signatures. AI-assisted implementation and test preparation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of supported GPU fabrics when cluster UUIDs begin with a zero byte.
  * Fabric support checks now handle binary UUID values more accurately.

* **Tests**
  * Added coverage for fabric states, UUID values, and expected support results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->