### PR TITLE
refactor(prefill): normalize cudnn wrapper qo_indptr to token units

### DIFF
--- a/benchmarks/routines/attention.py
+++ b/benchmarks/routines/attention.py
@@ -1674,7 +1674,7 @@ def testBatchPrefillWithPagedKVCacheWrapper(args):
         )
         .long()
         .to(device)
-    )  # For cuDNN
+    )  # Element-unit offsets, for the low-level cudnn-native call only
     qo_indptr = (
         torch.cat(
             [
@@ -1875,7 +1875,7 @@ def testBatchPrefillWithPagedKVCacheWrapper(args):
                 )
             )
             backend_wrappers["cudnn"].plan(
-                q_indptr,
+                qo_indptr,
                 kv_indptr,
                 kv_indices,
                 kv_last_page_len,
@@ -2612,7 +2612,7 @@ def testBatchPrefillWithRaggedKVCacheWrapper(args):
         )
         .long()
         .to(device)
-    )  # For cuDNN
+    )  # Element-unit offsets, for the low-level cudnn-native call only
 
     k_indptr = torch.cat(
         [
@@ -2728,8 +2728,8 @@ def testBatchPrefillWithRaggedKVCacheWrapper(args):
                 )
             )
             backend_wrappers[backend].plan(
-                qo_indptr=q_indptr,
-                kv_indptr=k_indptr,
+                qo_indptr=qo_indptr,
+                kv_indptr=kv_indptr,
                 num_qo_heads=num_qo_heads,
                 num_kv_heads=num_kv_heads,
                 head_dim_qk=head_dim_qk,
@@ -2743,8 +2743,6 @@ def testBatchPrefillWithRaggedKVCacheWrapper(args):
                 seq_lens_q=actual_seq_lens_q_device,
                 max_token_per_sequence=s_qo,
                 max_sequence_kv=s_kv,
-                v_indptr=v_indptr,
-                o_indptr=o_indptr,
             )
 
     q_scale, k_scale, v_scale = None, None, None

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -2254,8 +2254,8 @@ class BatchPrefillWithPagedKVCacheWrapper:
         ----------
         qo_indptr : torch.Tensor
             The indptr of the query/output tensor, shape: ``[batch_size + 1]``.
-            For the ``cudnn`` backend this is interpreted in **element units**
-            (``cumsum(seq_lens_q) * num_qo_heads * head_dim_qk``), not token units.
+            Token units for every backend, including ``cudnn`` (it previously took
+            element-unit offsets; that contract has been normalized).
         paged_kv_indptr : torch.Tensor
             The indptr of the paged kv-cache, shape: ``[batch_size + 1]``.
         paged_kv_indices : torch.Tensor
@@ -2948,11 +2948,17 @@ class BatchPrefillWithPagedKVCacheWrapper:
         )
         # Validate q shape matches qo_indptr (using value cached in plan() to avoid GPU sync)
         if self._backend == "cudnn":
-            if q.numel() != self._qo_indptr_last:
+            if q.size(0) != self._qo_indptr_last:
+                hint = ""
+                if q.numel() == self._qo_indptr_last:
+                    hint = (
+                        " qo_indptr looks like element-unit offsets "
+                        "(total_tokens * num_heads * head_dim); the cudnn backend now "
+                        "takes token-unit qo_indptr, like every other backend."
+                    )
                 raise ValueError(
-                    f"q.numel() ({q.numel()}) does not match qo_indptr[-1] ({self._qo_indptr_last}). "
-                    f"For cudnn paged prefill, qo_indptr uses element offsets "
-                    f"(total_tokens * num_heads * head_dim)."
+                    f"q.shape[0] ({q.size(0)}) does not match qo_indptr[-1] ({self._qo_indptr_last})."
+                    + hint
                 )
         else:
             if q.size(0) != self._qo_indptr_last:
@@ -3168,17 +3174,10 @@ class BatchPrefillWithPagedKVCacheWrapper:
             if self._seq_lens_kv is not None and self._seq_lens_kv.dim() == 1:
                 self._seq_lens_kv = self._seq_lens_kv.reshape(self._batch_size, 1, 1, 1)
 
-            # qo_indptr is element-unit (tokens * num_qo_heads * head_dim_qk). The O
-            # ragged offset is strided by head_dim_vo, so when head_dim_qk !=
-            # head_dim_vo the Q offset cannot be reused for O -- rescale it (only in
-            # that case, so the common head_dim_qk == head_dim_vo path is unchanged).
-            head_dim_qk = q.shape[-1]
-            head_dim_vo = out.shape[-1]
-            if head_dim_qk == head_dim_vo:
-                o_indptr = self._qo_indptr_buf
-            else:
-                o_indptr = self._qo_indptr_buf // head_dim_qk * head_dim_vo
-
+            # qo_indptr is token-unit (like every other backend). The low level
+            # consumes it directly as cu_seq_len_q / the Q and O ragged offsets,
+            # applying the per-tensor (num_heads * head_dim) multipliers itself, so
+            # head_dim_qk != head_dim_vo is handled without any offset rescaling.
             cudnn_batch_prefill_with_kv_cache(
                 q,
                 k_cache,  # Need to be changed
@@ -3196,7 +3195,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 k_scale=k_scale,
                 v_scale=v_scale,
                 batch_offsets_q=self._qo_indptr_buf,
-                batch_offsets_o=o_indptr,
+                batch_offsets_units="tokens",
                 out=out,
                 lse=lse,
                 o_data_type=out_dtype,
@@ -3722,10 +3721,9 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         ----------
         qo_indptr : torch.Tensor
             The indptr of the query/output tensor, shape: ``[batch_size + 1]``.
-            For the ``cudnn`` backend the ``qo_indptr`` and ``kv_indptr`` are
-            interpreted in **element units** (``cumsum(seq_lens) * num_heads *
-            head_dim_qk``), not token units. The ``cudnn`` backend also requires
-            ``kv_layout="NHD"``.
+            Token units for every backend, including ``cudnn`` (it previously took
+            element-unit offsets; that contract has been normalized). The ``cudnn``
+            backend also requires ``kv_layout="NHD"``.
         kv_indptr : torch.Tensor
             The indptr of the key/value tensor, shape: ``[batch_size + 1]``.
         num_qo_heads : int
@@ -3823,9 +3821,11 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         max_sequence_kv: Optional[int],
             Required for cudnn backend. This is the scalar max sequence length of each sequence in kv cache.
         v_indptr: Optional[torch.Tensor]
-            Required for cudnn backend. This is the indptr of the value tensor.
+            Only used by the cudnn backend. Token-unit indptr of the value tensor;
+            defaults to ``kv_indptr``.
         o_indptr: Optional[torch.Tensor]
-            Required for cudnn backend. This is the indptr of the output tensor.
+            Only used by the cudnn backend. Token-unit indptr of the output tensor;
+            defaults to ``qo_indptr``.
         Note
         ----
         The :meth:`plan` method should be called before any :meth:`run` or
@@ -4415,11 +4415,17 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         )
         # Validate q shape matches qo_indptr (using value cached in plan() to avoid GPU sync)
         if self._backend == "cudnn":
-            if q.numel() != self._qo_indptr_last:
+            if q.size(0) != self._qo_indptr_last:
+                hint = ""
+                if q.numel() == self._qo_indptr_last:
+                    hint = (
+                        " qo_indptr looks like element-unit offsets "
+                        "(total_tokens * num_heads * head_dim); the cudnn backend now "
+                        "takes token-unit qo_indptr, like every other backend."
+                    )
                 raise ValueError(
-                    f"q.numel() ({q.numel()}) does not match qo_indptr[-1] ({self._qo_indptr_last}). "
-                    f"For cudnn ragged prefill, qo_indptr uses element offsets "
-                    f"(total_tokens * num_heads * head_dim)."
+                    f"q.shape[0] ({q.size(0)}) does not match qo_indptr[-1] ({self._qo_indptr_last})."
+                    + hint
                 )
         else:
             if q.size(0) != self._qo_indptr_last:
@@ -4701,6 +4707,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 batch_offsets_k=self._kv_indptr_buf,
                 batch_offsets_v=self._v_indptr_buf,
                 batch_offsets_o=self._o_indptr_buf,
+                batch_offsets_units="tokens",
                 is_cuda_graph_compatible=self._use_cuda_graph,
                 out=out,
                 lse=lse,

--- a/tests/attention/test_cudnn_prefill.py
+++ b/tests/attention/test_cudnn_prefill.py
@@ -51,7 +51,7 @@ def test_cudnn_prefill(
     q_indptr = torch.cat(
         [
             torch.tensor([0], device=device),
-            torch.cumsum(actual_seq_lens_q.view(-1), dim=0) * head_dim * num_qo_heads,
+            torch.cumsum(actual_seq_lens_q.view(-1), dim=0),
         ]
     ).int()
 
@@ -248,7 +248,7 @@ def test_cudnn_prefill_fp8(
     q_indptr = torch.cat(
         [
             torch.tensor([0], device=device),
-            torch.cumsum(actual_seq_lens_q.view(-1), dim=0) * head_dim * num_qo_heads,
+            torch.cumsum(actual_seq_lens_q.view(-1), dim=0),
         ]
     ).int()
 

--- a/tests/attention/test_cudnn_prefill_deepseek.py
+++ b/tests/attention/test_cudnn_prefill_deepseek.py
@@ -44,36 +44,28 @@ def test_cudnn_prefill_deepseek(
     q_indptr = torch.cat(
         [
             torch.tensor([0], device=device),
-            torch.cumsum(actual_seq_lens_q.view(-1), dim=0)
-            * head_dim_qk
-            * num_qo_heads,
+            torch.cumsum(actual_seq_lens_q.view(-1), dim=0),
         ]
     ).int()
 
     k_indptr = torch.cat(
         [
             torch.tensor([0], device=device),
-            torch.cumsum(actual_seq_lens_kv.view(-1), dim=0)
-            * head_dim_qk
-            * num_kv_heads,
+            torch.cumsum(actual_seq_lens_kv.view(-1), dim=0),
         ]
     ).int()
 
     v_indptr = torch.cat(
         [
             torch.tensor([0], device=device),
-            torch.cumsum(actual_seq_lens_kv.view(-1), dim=0)
-            * head_dim_vo
-            * num_kv_heads,
+            torch.cumsum(actual_seq_lens_kv.view(-1), dim=0),
         ]
     ).int()
 
     o_indptr = torch.cat(
         [
             torch.tensor([0], device=device),
-            torch.cumsum(actual_seq_lens_q.view(-1), dim=0)
-            * head_dim_vo
-            * num_qo_heads,
+            torch.cumsum(actual_seq_lens_q.view(-1), dim=0),
         ]
     ).int()
 

--- a/tests/attention/test_cudnn_prefill_token_indptr.py
+++ b/tests/attention/test_cudnn_prefill_token_indptr.py
@@ -4,6 +4,7 @@ Token-unit indptrs must produce the same results as the historical
 element-unit offsets, both on the direct path (cuDNN consumes the indptrs
 via cu_seq_len + ragged-offset multipliers, no conversion pre-pass) and on
 the conversion path (FlashInfer scales them to element units internally).
+The backend="cudnn" wrappers forward token-unit indptrs to this path.
 """
 
 import pytest
@@ -260,3 +261,107 @@ def test_cudnn_prefill_lse_is_base2(num_kv_heads):
 
     lse_cudnn = lse[0, :s_q, :].transpose(0, 1)  # [h_qo, s_q]
     torch.testing.assert_close(lse_cudnn, lse_ref, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("head_dim_qk,head_dim_vo", [(128, 128), (192, 128)])
+def test_cudnn_wrapper_token_indptr(head_dim_qk, head_dim_vo):
+    """backend="cudnn" wrappers take token-unit qo_indptr/kv_indptr like every
+    other backend, and reject the historical element-unit offsets with a
+    migration hint."""
+    if not cudnn_prefill.CUDNN_AVAILABLE:
+        pytest.skip("cudnn-frontend python package not available")
+
+    import flashinfer
+
+    torch.manual_seed(0)
+    device = "cuda:0"
+    batch_size, s_qo, s_kv = 4, 87, 512
+    num_qo_heads, num_kv_heads = 8, 4
+    scale = float(head_dim_qk**-0.5)
+
+    actual_seq_lens_q = torch.randint(
+        1, s_qo + 1, (batch_size,), dtype=torch.int32, device=device
+    )
+    actual_seq_lens_kv = torch.randint(
+        s_qo, s_kv + 1, (batch_size,), dtype=torch.int32, device=device
+    )
+    zero = torch.zeros(1, dtype=torch.int32, device=device)
+    qo_indptr = torch.cat([zero, torch.cumsum(actual_seq_lens_q, 0)]).int()
+    kv_indptr = torch.cat([zero, torch.cumsum(actual_seq_lens_kv, 0)]).int()
+
+    q = torch.randn(
+        int(actual_seq_lens_q.sum()),
+        num_qo_heads,
+        head_dim_qk,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    k = torch.randn(
+        int(actual_seq_lens_kv.sum()),
+        num_kv_heads,
+        head_dim_qk,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    v = torch.randn(
+        int(actual_seq_lens_kv.sum()),
+        num_kv_heads,
+        head_dim_vo,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+
+    def plan(wrapper, qo, kv):
+        wrapper.plan(
+            qo_indptr=qo,
+            kv_indptr=kv,
+            num_qo_heads=num_qo_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim_qk=head_dim_qk,
+            head_dim_vo=head_dim_vo,
+            causal=True,
+            sm_scale=scale,
+            q_data_type=torch.bfloat16,
+            kv_data_type=torch.bfloat16,
+            o_data_type=torch.bfloat16,
+            seq_lens=actual_seq_lens_kv.view(batch_size, 1, 1, 1),
+            seq_lens_q=actual_seq_lens_q.view(batch_size, 1, 1, 1),
+            max_token_per_sequence=s_qo,
+            max_sequence_kv=s_kv,
+        )
+
+    workspace = torch.empty(512 * 1024 * 1024, dtype=torch.int8, device=device)
+    cudnn_wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+        workspace, "NHD", backend="cudnn"
+    )
+
+    # Same token-unit indptrs as the fa2 reference wrapper.
+    plan(cudnn_wrapper, qo_indptr, kv_indptr)
+    out = cudnn_wrapper.run(q, k, v)
+
+    ref_wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+        torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=device), "NHD"
+    )
+    ref_wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim_qk,
+        head_dim_vo=head_dim_vo,
+        causal=True,
+        sm_scale=scale,
+        q_data_type=torch.bfloat16,
+        kv_data_type=torch.bfloat16,
+    )
+    out_ref = ref_wrapper.run(q, k, v)
+    torch.testing.assert_close(out, out_ref, atol=1e-2, rtol=1e-2)
+
+    # Legacy element-unit offsets are rejected with a migration hint.
+    plan(
+        cudnn_wrapper,
+        qo_indptr * (num_qo_heads * head_dim_qk),
+        kv_indptr * (num_kv_heads * head_dim_qk),
+    )
+    with pytest.raises(ValueError, match="element-unit"):
+        cudnn_wrapper.run(q, k, v)


### PR DESCRIPTION
Prerequisite for letting `backend="auto"` pick cuDNN. #5133 excludes cuDNN from `auto` because the `backend="cudnn"` prefill wrappers were the only backend taking **element-unit** `qo_indptr` (`cumsum(seq_lens) * num_heads * head_dim`); every other backend takes token units. That deviation made a units mismatch an `auto` footgun, so this PR removes it.

## Change
- `BatchPrefillWithPagedKVCacheWrapper` / `BatchPrefillWithRaggedKVCacheWrapper` with `backend="cudnn"` now take **token-unit** `qo_indptr` (and `kv_indptr`, `v_indptr`, `o_indptr`) like every other backend.
- The wrappers pass `batch_offsets_units="tokens"` to `cudnn_batch_prefill_with_kv_cache`, which consumes the indptrs directly as `cu_seq_len` plus ragged offsets with per-tensor `num_heads * head_dim` multipliers (the direct path from #4222). No conversion kernel is added.
- The paged `head_dim_qk != head_dim_vo` O-offset rescale from #4663 is gone: the O multiplier handles it.
- Passing the old element-unit `qo_indptr` to a cudnn wrapper raises `ValueError` with a migration hint (detected when `q.numel() == qo_indptr[-1]`).
- `plan()`'s `total_num_rows` / `_max_q_len` bookkeeping, previously inflated by the element factor for cudnn, is now correct.

## Compatibility
- The **low-level** `cudnn_batch_prefill_with_kv_cache` is unchanged and still defaults to `batch_offsets_units="elements"`. vLLM and SGLang call the low-level function directly with element offsets and are unaffected; neither uses the `backend="cudnn"` wrappers.
- `benchmarks/routines/attention.py` now feeds token-unit indptrs to the cudnn wrappers and keeps element-unit offsets only for the low-level `cudnn-native` path.

## Testing
On H100 (sm90): `test_cudnn_prefill` **288**, `test_cudnn_prefill_deepseek` **96**, `test_cudnn_prefill_token_indptr` **135** (new `test_cudnn_wrapper_token_indptr`: token-unit cudnn wrapper matches the fa2 wrapper for `d_qk == d_vo` and `192/128`, and element-unit indptrs raise the migration error). Benchmark harness `--refcheck` passes for both Paged and Ragged routines with `fa2 cudnn cudnn-native`.

Follow-up (not in this PR): wrapper `return_lse` for cudnn allocates a 2D `lse` while the low level needs `(batch, max_q_len, heads)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized cuDNN prefill offset handling to use token-based indexing.
  - Added validation to reject legacy element-based offsets with a clear migration error.
  - Corrected paged and ragged prefill execution and validation across supported configurations.

- **Tests**
  - Added coverage for token-based offsets and reference-backend consistency.
  - Updated existing attention tests to use token-based sequence offsets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->