### PR TITLE
feat(moe): wire dynamic FP8 FC2 quantization for per-channel MoE

### DIFF
--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -1492,8 +1492,8 @@ class FusedMoeLauncher {
   void prepare_moe_runner(int64_t& moe_tactic) {
     using RunnerType = tensorrt_llm::kernels::trtllmgen_moe::MoE::Runner;
     bool usePerTokenScalingGemm1 = per_token_scales.has_value() || args->mUseRoutingScalesOnInput;
-    // FIXME(siyuan): currently only nvfp4 x nvfp4 uses per-token scaling in both FC1 and FC2
-    bool usePerTokenScalingGemm2 = per_token_scales.has_value() && mDtypeAct == btg::Dtype::E2m1;
+    bool usePerTokenScalingGemm2 = per_token_scales.has_value() &&
+                                   (mDtypeAct == btg::Dtype::E2m1 || use_per_channel_scaling_gemm2);
     // For FP8 block-scale (E4m3 activations, E4m3 weights) with DeepSeek FP8 and no
     // gemm1 bias, use the weights-only Runner constructor to match the original kernel
     // path and numerics. DSFp8 + biasMn routes through the unified constructor below
@@ -2443,24 +2443,27 @@ class Fp8PerChannelLauncher : public FusedMoeLauncher {
   void prepare_moe(int64_t& moe_tactic) override {
     FusedMoeLauncher::prepare_moe_common(moe_tactic);
 
-    int32_t max_num_padded_tokens_gemm1 = workspace.total_max_padded_tokens + args->num_experts;
+    int32_t max_num_padded_tokens_gemm1 =
+        tensorrt_llm::kernels::trtllmgen_moe::Routing::maybeGetMinTokenCount(
+            workspace.total_max_padded_tokens, args->intermediate_size,
+            btg::dtypeGetNumBits(btg::Dtype::Bfloat16));
     int32_t max_num_padded_tokens_gemm2 = workspace.total_max_padded_tokens;
 
-    gemm1_output = alloc_tensor(
-        {max_num_padded_tokens_gemm1, intermediate_size_factor * args->intermediate_size}, dl_uint8,
-        hidden_states.device());
-    gemm1_output_scale = alloc_tensor(
-        {intermediate_size_factor * args->intermediate_size / 128, max_num_padded_tokens_gemm1},
-        dl_float32, hidden_states.device());
+    gemm1_output = alloc_tensor({max_num_padded_tokens_gemm1, args->intermediate_size}, dl_bfloat16,
+                                hidden_states.device());
+    activation_output = alloc_tensor({max_num_padded_tokens_gemm1, args->intermediate_size},
+                                     dl_uint8, hidden_states.device());
+    activation_output_scale =
+        alloc_tensor({max_num_padded_tokens_gemm1}, dl_float32, hidden_states.device());
 
     gemm2_output = alloc_tensor({max_num_padded_tokens_gemm2, args->hidden_size}, dl_bfloat16,
                                 hidden_states.device());
 
     workspace.hidden_states_scale_linear = nullptr;
     workspace.gemm1_output = gemm1_output.data_ptr();
-    workspace.gemm1_output_scale = static_cast<float*>(gemm1_output_scale.data_ptr());
-    workspace.activation_output = nullptr;
-    workspace.activation_output_scale = nullptr;
+    workspace.gemm1_output_scale = nullptr;
+    workspace.activation_output = activation_output.data_ptr();
+    workspace.activation_output_scale = static_cast<float*>(activation_output_scale.data_ptr());
     workspace.gemm2_output = gemm2_output.data_ptr();
     workspace.gemm2_output_scale = nullptr;
 
@@ -2489,7 +2492,7 @@ class Fp8PerChannelLauncher : public FusedMoeLauncher {
   TensorView gemm2_per_channel_weight_scale_;
   TensorView expert_indices_;
   TensorView expert_weights_;
-  Tensor gemm1_output_scale;
+  Tensor activation_output_scale;
 
  public:
   static Array<Array<int64_t>> getValidConfigs(int64_t top_k, int64_t hidden_size,
@@ -2513,7 +2516,7 @@ class Fp8PerChannelLauncher : public FusedMoeLauncher {
           static_cast<batchedGemm::gemm::MatrixLayout>(weight_layout),
           /*gemm1BiasType*/ batchedGemm::gemm::BiasType::None,
           /*usePerTokenScalingGemm1*/ true,
-          /*usePerTokenScalingGemm2*/ false,
+          /*usePerTokenScalingGemm2*/ true,
           /*usePerChannelScalingGemm1*/ true,
           /*usePerChannelScalingGemm2*/ true);
 

--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -2304,15 +2304,11 @@ class Fp8PerChannelLauncher : public FusedMoeLauncher {
     args->mUseRoutingScalesOnInput = use_routing_scales_on_input;
 
     auto dtype = hidden_states.dtype();
-    if (dtype == dl_float16) {
-      mDtypeAct = btg::Dtype::Fp16;
-    } else if (dtype == dl_bfloat16) {
-      mDtypeAct = btg::Dtype::Bfloat16;
-    } else if (dtype == dl_float8_e4m3fn) {
+    if (dtype == dl_float8_e4m3fn) {
       mDtypeAct = btg::Dtype::E4m3;
     } else {
       TVM_FFI_LOG_AND_THROW(NotImplementedError)
-          << "Unsupported input dtype for FP8 per-channel MoE.";
+          << "FP8 per-channel MoE requires float8_e4m3fn hidden_states.";
     }
     mDtypeWeights = btg::Dtype::E4m3;
 
@@ -2431,9 +2427,8 @@ class Fp8PerChannelLauncher : public FusedMoeLauncher {
     TVM_FFI_ICHECK_EQ(gemm2_per_channel_weight_scale_.size(1), args->hidden_size)
         << "gemm2_per_channel_weight_scale dim 1 must match hidden_size.";
 
-    TVM_FFI_ICHECK(hidden_states.dtype() == dl_float8_e4m3fn ||
-                   hidden_states.dtype() == dl_float16 || hidden_states.dtype() == dl_bfloat16)
-        << "FP8 per-channel MoE: hidden_states must be float8_e4m3fn, float16, or bfloat16.";
+    TVM_FFI_ICHECK_EQ(hidden_states.dtype(), dl_float8_e4m3fn)
+        << "FP8 per-channel MoE: hidden_states must be float8_e4m3fn.";
     TVM_FFI_ICHECK_EQ(gemm1_weights.dtype(), dl_float8_e4m3fn)
         << "FP8 per-channel MoE: gemm1_weights must be float8_e4m3fn.";
     TVM_FFI_ICHECK_EQ(gemm2_weights.dtype(), dl_float8_e4m3fn)
@@ -4735,12 +4730,6 @@ Array<Array<int64_t>> trtllm_get_valid_moe_configs(
                                                  intermediate_size, num_local_experts, num_tokens,
                                                  act_type, use_shuffled_weight, weight_layout,
                                                  dtype_act, dtype_weights, use_per_token_scaling);
-  } else if (fp8_quantization_type == Fp8QuantizationType::PerChannelFp8 &&
-             dtype_weights == btg::Dtype::E4m3) {
-    // FP8 per-channel with bf16/fp16 activations (E4m3/E4m3 case handled above).
-    return Fp8PerChannelLauncher::getValidConfigs(
-        top_k, hidden_size, hidden_size_output, intermediate_size, num_local_experts, num_tokens,
-        act_type, use_shuffled_weight, weight_layout, dtype_act, dtype_weights);
   } else if (dtype_weights == btg::Dtype::E2m1 || dtype_weights == btg::Dtype::MxE2m1) {
     // FP4 block scale
     return FP4BlockScaleLauncher::getValidConfigs(

--- a/csrc/trtllm_fused_moe_runner.cu
+++ b/csrc/trtllm_fused_moe_runner.cu
@@ -722,8 +722,20 @@ void Runner::run(MoERunnerArgs const& args, MoEWorkspace const& workspace, int d
     moe::dev::activation::run(activationData, stream);
     gemm2_input = workspace.activation_output;
     gemm2_input_scale = workspace.activation_output_scale;
+  } else if (mUsePerTokenScalingGemm2 && mGemm2.mDtypeAct == btg::Dtype::E4m3) {
+    FLASHINFER_CHECK(
+        mPermuteGemm1.mDtypeOutput == btg::Dtype::Bfloat16,
+        "When using explicit quantization, PermuteGemm1 output dtype must be Bfloat16.");
+    invokePerTokenQuantization<__nv_bfloat16, __nv_fp8_e4m3>(
+        reinterpret_cast<__nv_fp8_e4m3*>(workspace.activation_output),
+        reinterpret_cast<__nv_bfloat16 const*>(workspace.gemm1_output),
+        workspace.total_max_padded_tokens, args.intermediate_size, nullptr,
+        workspace.activation_output_scale, nullptr, tensorrt_llm::common::QuantMode::fp8RowWise(),
+        stream);
+
+    gemm2_input = workspace.activation_output;
+    gemm2_input_scale = workspace.activation_output_scale;
   } else if (mUsePerTokenScalingGemm2) {
-    // TODO(siyuan): currently only support per-token nvfp4 quantization
     FLASHINFER_CHECK(
         mPermuteGemm1.mDtypeOutput == btg::Dtype::Bfloat16,
         "When using explicit quantization, PermuteGemm1 output dtype must be Bfloat16.");

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -6288,6 +6288,12 @@ def trtllm_fp8_per_channel_scale_moe(
         when do_finalize=True, returns the final MoE output.
         otherwise, returns the intermediate results (gemm2_output, expert_weights, expanded_idx_to_permuted_idx).
     """
+    if hidden_states.dtype != torch.float8_e4m3fn:
+        raise ValueError(
+            "FP8 per-channel MoE hidden_states must have dtype "
+            f"torch.float8_e4m3fn, got {hidden_states.dtype}."
+        )
+
     result = get_trtllm_moe_sm100_module().trtllm_fp8_per_channel_scale_moe(
         routing_logits,
         None,
@@ -6424,6 +6430,12 @@ def trtllm_fp8_per_channel_scale_routed_moe(
         Final MoE output when ``do_finalize`` is ``True``; otherwise
         ``[gemm2_output, expert_weights, expanded_idx_to_permuted_idx]``.
     """
+    if hidden_states.dtype != torch.float8_e4m3fn:
+        raise ValueError(
+            "FP8 per-channel MoE hidden_states must have dtype "
+            f"torch.float8_e4m3fn, got {hidden_states.dtype}."
+        )
+
     result = get_trtllm_moe_sm100_module().trtllm_fp8_per_channel_scale_moe(
         None,  # routing_logits
         topk_ids,

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -6253,7 +6253,7 @@ def trtllm_fp8_per_channel_scale_moe(
     Args:
         routing_logits: [seq_len, num_experts] tensor of routing logits
         routing_bias: [num_experts] tensor of routing bias
-        hidden_states: [seq_len, hidden_size] tensor of input hidden states
+        hidden_states: [seq_len, hidden_size] FP8 E4M3 tensor of input hidden states
         hidden_states_scale: [seq_len, 1] FP32 per-token dequantization multipliers
         gemm1_weights: [num_experts, M, hidden_size] FP8 first layer weights,
             where M is 2*intermediate_size for gated activations and
@@ -6366,7 +6366,7 @@ def trtllm_fp8_per_channel_scale_routed_moe(
     routing_bias : Optional[torch.Tensor]
         ``[num_experts]`` tensor of routing bias. May be ``None``.
     hidden_states : torch.Tensor
-        ``[seq_len, hidden_size]`` tensor of input hidden states.
+        ``[seq_len, hidden_size]`` FP8 E4M3 tensor of input hidden states.
     hidden_states_scale : torch.Tensor
         ``[seq_len, 1]`` FP32 per-token dequantization multipliers.
     gemm1_weights : torch.Tensor

--- a/tests/moe/trtllm_gen_fused_moe_utils.py
+++ b/tests/moe/trtllm_gen_fused_moe_utils.py
@@ -1934,6 +1934,7 @@ class FP8PerChannelMoe(Moe):
         weight_processing,
     ):
         """Prepare quantized and shuffled weights for the kernel."""
+        del args_dequant
         del gemm1_weights_orig, gemm2_weights_orig, hidden_size, weight_processing
         epilogue_tile_m = 128
         gated = is_gated_activation(args.activation_type)
@@ -1981,22 +1982,18 @@ class FP8PerChannelMoe(Moe):
         ).squeeze(-1)
 
         gemm1_per_channel_weight_scale = 1.0 / gemm1_per_channel_scales
-        gemm2_per_channel_weight_scale = 1.0 / (
-            args_dequant.c_global_sf * gemm2_per_channel_scales
-        )
-        output1_scale_scalar = torch.full(
+        gemm2_per_channel_weight_scale = 1.0 / gemm2_per_channel_scales
+        unit_scale = torch.ones(
             (num_experts,),
-            args_dequant.c_global_sf,
             dtype=torch.float32,
             device=gemm1_per_channel_scales.device,
         )
-        unit_scale = torch.ones_like(output1_scale_scalar)
 
         return {
             "gemm1_weights": gemm1_weights_shuffled,
             "gemm2_weights": gemm2_weights_shuffled,
             "gemm1_per_channel_weight_scale": gemm1_per_channel_weight_scale,
-            "output1_scale_scalar": output1_scale_scalar,
+            "output1_scale_scalar": unit_scale,
             "output1_scale_gate_scalar": unit_scale,
             "gemm2_per_channel_weight_scale": gemm2_per_channel_weight_scale,
             "output2_scale_scalar": unit_scale,
@@ -3113,12 +3110,18 @@ def run_moe_dequant(args, quant_mode: QuantMode):
         )
         activation_output = activation_output.to(torch.float)
         args.c_global_sf = c_global_sf
-    elif quant_mode in (QuantMode.FP8_PER_TENSOR, QuantMode.FP8_PER_CHANNEL):
+    elif quant_mode == QuantMode.FP8_PER_TENSOR:
         activation_output, c_global_sf = quant_dequant_per_tensor_fp8(
             activation_output.to(torch.bfloat16)
         )
         activation_output = activation_output.to(torch.float)
         args.c_global_sf = c_global_sf
+    elif quant_mode == QuantMode.FP8_PER_CHANNEL:
+        activation_output, per_token_scales = quant_fp8_per_token(
+            activation_output.to(torch.bfloat16)
+        )
+        activation_output = activation_output.float() * per_token_scales
+        args.c_global_sf = 1.0
     elif (
         quant_mode == QuantMode.FP4_MXFP4_MXFP8
         or quant_mode == QuantMode.FP8_BLOCK_SCALE_MXFP8


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Extends the FP8 per-channel TRT-LLM MoE path with PR #2809 to use dynamic per-token FP8 quant between FC1 and FC2

We will need new cubins

Still can clean up this PR a bit but opening to raise awareness

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/issues/5079

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.). (n/a for now):

See below regarding test:

```
pytest -x -q tests/moe/test_trtllm_gen_fused_moe_routing_renormalize_fp8.py::test_fp8_per_channel_renormalize[Swiglu-Renorm_128e-384-1024-8]
```
Error
```
RuntimeError: Error in function 'TrtllmGenBatchedGemmRunner' at csrc/trtllm_batched_gemm_runner.cu:239: No kernel found for the given options: mDtypeA: E4m3,
  mDtypeB: E4m3, mDtypeC: Bfloat16, mUseDeepSeekFp8: 0, mActType: 0, mEltwiseActType: 0, mTransposeMmaOutput: 1, mRouteAct: 1, mFusedAct: 1, mIsStaticBatch: 0,
  mTileSize: 8, mBiasType: 0, mFusedBiasShuffleMode: 0, mBiasDtype: Bfloat16, mUsePerTokenScaling: 1, mPerTokenSfDtype: Fp32, mUsePerChannelScaling: 1
```

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved FP8 per-channel Mixture-of-Experts processing by applying per-token scaling correctly during the second projection.
  - Corrected FP8 E4M3 activation handling for supported MoE workloads.
  - Updated reference calculations to use per-token activation scales for more consistent results.
  - Corrected scale handling to prevent global dequantization factors from being applied twice.
  - FP8 per-channel MoE processing now requires FP8 E4M3 hidden states; FP16 and BF16 activations are no longer supported.
  - Added clear validation errors when unsupported activation types are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->