### PR TITLE
fix(infra): isolate distributed rendezvous ports by test worker

### DIFF
--- a/scripts/test_sharding/workers.py
+++ b/scripts/test_sharding/workers.py
@@ -22,6 +22,11 @@ from .progress import PYTEST_EVENT_PREFIX, decode_pytest_event
 from .summary import batch_directory, batch_xml_path
 
 
+_DEFAULT_MASTER_PORT = 29500
+_MASTER_PORT_STRIDE = 100
+_MAX_TCP_PORT = 65535
+
+
 @dataclass(frozen=True)
 class BatchExecution:
     status: str
@@ -351,6 +356,15 @@ def _pytest_command(
     ]
 
 
+def _worker_master_port(worker_index: int) -> str:
+    if worker_index < 0:
+        raise ValueError("worker index must be non-negative")
+    port = _DEFAULT_MASTER_PORT + worker_index * _MASTER_PORT_STRIDE
+    if port + _MASTER_PORT_STRIDE - 1 > _MAX_TCP_PORT:
+        raise ValueError(f"worker {worker_index} has no valid rendezvous port block")
+    return str(port)
+
+
 def _pytest_environment(request: BatchExecutionRequest) -> dict[str, str]:
     env = os.environ.copy()
     pythonpath = env.get("PYTHONPATH")
@@ -361,6 +375,10 @@ def _pytest_environment(request: BatchExecutionRequest) -> dict[str, str]:
     )
     if request.device is not None:
         env["CUDA_VISIBLE_DEVICES"] = request.device
+    # Isolate each concurrent worker's rendezvous and sibling TCPStore ports.
+    # Preserve explicit launcher configuration.
+    if "MASTER_PORT" not in env:
+        env["MASTER_PORT"] = _worker_master_port(request.worker_index)
     return env
 
 
@@ -370,6 +388,7 @@ def _run_pytest(
     command: list[str],
 ) -> _ProcessOutcome:
     launched_at = time.time()
+    environment = _pytest_environment(request)
     samples: list[tuple[float, float, float]] = []
     stop_monitor = threading.Event()
     monitor: threading.Thread | None = None
@@ -379,13 +398,19 @@ def _run_pytest(
     aborted = False
     exited_at: float | None = None
     output_errors: list[str] = []
+    write_console(
+        f"PYTEST BATCH START worker={request.worker_index} "
+        f"batch={request.batch.id} source={request.batch.source_file} "
+        f"device={environment.get('CUDA_VISIBLE_DEVICES', 'all')} "
+        f"master_port={environment['MASTER_PORT']}"
+    )
     with artifacts.log.open("a", encoding="utf-8") as log:
         log.write(f"command: {' '.join(command)}\n")
         log.flush()
         process = subprocess.Popen(
             command,
             cwd=request.pytest_root,
-            env=_pytest_environment(request),
+            env=environment,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             start_new_session=True,

--- a/tests/comm/conftest.py
+++ b/tests/comm/conftest.py
@@ -57,9 +57,14 @@ def mnnvl_available() -> bool:
 
 
 def pytest_addoption(parser):
+    master_port = int(os.environ.get("MASTER_PORT", "29500"))
     parser.addoption("--num_nodes", type=int, default=1)
     parser.addoption("--node_id", type=int, default=0)
-    parser.addoption("--dist_init_method", type=str, default="tcp://localhost:29501")
+    parser.addoption(
+        "--dist_init_method",
+        type=str,
+        default=f"tcp://localhost:{master_port + 1}",
+    )
 
 
 @pytest.fixture

--- a/tests/comm/conftest.py
+++ b/tests/comm/conftest.py
@@ -56,15 +56,35 @@ def mnnvl_available() -> bool:
     return MnnvlMemory.supports_mnnvl()
 
 
+def _default_dist_init_method() -> str:
+    value = os.environ.get("MASTER_PORT", "29500")
+    try:
+        master_port = int(value)
+    except ValueError as error:
+        raise pytest.UsageError(
+            f"MASTER_PORT must be an integer between 1 and 65534; got {value!r}"
+        ) from error
+    if not 1 <= master_port < 65535:
+        raise pytest.UsageError(
+            "MASTER_PORT must be between 1 and 65534 because tests/comm also "
+            f"uses MASTER_PORT + 1; got {master_port}"
+        )
+    return f"tcp://localhost:{master_port + 1}"
+
+
 def pytest_addoption(parser):
-    master_port = int(os.environ.get("MASTER_PORT", "29500"))
     parser.addoption("--num_nodes", type=int, default=1)
     parser.addoption("--node_id", type=int, default=0)
     parser.addoption(
         "--dist_init_method",
         type=str,
-        default=f"tcp://localhost:{master_port + 1}",
+        default=None,
     )
+
+
+def pytest_configure(config):
+    if config.getoption("dist_init_method") is None:
+        config.option.dist_init_method = _default_dist_init_method()
 
 
 @pytest.fixture

--- a/tests/test_sharding/test_runner_cli.py
+++ b/tests/test_sharding/test_runner_cli.py
@@ -128,6 +128,20 @@ def test_shard_count_precedence_is_cli_then_environment_then_one(
     )
 
 
+@pytest.mark.parametrize("gpu_count", [1, 2, 4, 8])
+def test_default_worker_count_matches_visible_gpu_count(
+    monkeypatch: pytest.MonkeyPatch, gpu_count: int
+) -> None:
+    monkeypatch.delenv("UNIT_TEST_WORKERS", raising=False)
+    monkeypatch.setenv(
+        "CUDA_VISIBLE_DEVICES", ",".join(str(index) for index in range(gpu_count))
+    )
+
+    args = unit_test_runner._parser().parse_args(["run"])
+
+    assert args.workers == gpu_count
+
+
 def test_explicit_zero_deadline_is_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1384,6 +1398,63 @@ def test_regular():
     assert result.returncode == 0, result.stdout + result.stderr
     assert (state / "solo-devices").read_text(encoding="utf-8") == "0,1"
     assert (state / "regular-devices").read_text(encoding="utf-8") in {"0", "1"}
+
+
+@pytest.mark.parametrize("worker_count", [1, 2, 4, 8])
+def test_workers_export_disjoint_master_port_blocks_for_visible_gpu_count(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, worker_count: int
+) -> None:
+    monkeypatch.delenv("MASTER_PORT", raising=False)
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    state = tmp_path / "port-state"
+    state.mkdir()
+    source = """\
+import os
+import time
+from pathlib import Path
+
+def test_worker_port():
+    state = Path(os.environ["PORT_STATE"])
+    record = state / (Path(__file__).stem + ".port")
+    record.write_text(
+        os.environ["CUDA_VISIBLE_DEVICES"] + ":" + os.environ["MASTER_PORT"],
+        encoding="utf-8",
+    )
+    deadline = time.monotonic() + 10
+    while len(list(state.glob("*.port"))) < int(os.environ["EXPECTED_WORKERS"]):
+        assert time.monotonic() < deadline, "parallel worker did not start"
+        time.sleep(0.05)
+"""
+    for index in range(worker_count):
+        (suite / f"test_{index}.py").write_text(source, encoding="utf-8")
+
+    visible_devices = ",".join(str(index) for index in range(worker_count))
+
+    result = _run(
+        tmp_path,
+        "run",
+        suite,
+        "--workers",
+        str(worker_count),
+        env_override={
+            "CUDA_VISIBLE_DEVICES": visible_devices,
+            "EXPECTED_WORKERS": str(worker_count),
+            "PORT_STATE": str(state),
+        },
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assignments = {
+        tuple(int(value) for value in path.read_text(encoding="utf-8").split(":"))
+        for path in state.glob("*.port")
+    }
+    assert assignments == {
+        (worker_index, 29500 + worker_index * 100)
+        for worker_index in range(worker_count)
+    }
+    for _, port in assignments:
+        assert f"master_port={port}" in result.stdout
 
 
 def test_long_running_dispatches_first_and_solo_runs_after_non_solo_finalized(

--- a/tests/test_sharding/test_runner_cli.py
+++ b/tests/test_sharding/test_runner_cli.py
@@ -1457,6 +1457,42 @@ def test_worker_port():
         assert f"master_port={port}" in result.stdout
 
 
+@pytest.mark.parametrize(
+    ("master_port", "extra", "expected_returncode"),
+    [
+        ("65534", (), 0),
+        ("65535", (), 4),
+        ("65535", ("--dist_init_method=tcp://localhost:41000",), 0),
+    ],
+)
+def test_comm_conftest_validates_sibling_master_port(
+    master_port: str, extra: tuple[str, ...], expected_returncode: int
+) -> None:
+    environment = os.environ.copy()
+    environment["MASTER_PORT"] = master_port
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--collect-only",
+            "-q",
+            "tests/comm/test_mixed_comm.py",
+            *extra,
+        ],
+        cwd=REPO_ROOT,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert result.returncode == expected_returncode
+    if expected_returncode:
+        assert "MASTER_PORT must be between" in result.stdout + result.stderr
+
+
 def test_long_running_dispatches_first_and_solo_runs_after_non_solo_finalized(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_sharding/test_workers.py
+++ b/tests/test_sharding/test_workers.py
@@ -4,6 +4,7 @@ import os
 import signal
 import time
 from contextlib import suppress
+from dataclasses import replace
 from io import StringIO
 from pathlib import Path
 
@@ -16,6 +17,8 @@ from scripts.test_sharding.workers import (
     BatchExecutionRequest,
     _BatchProgress,
     _forward_pytest_output,
+    _pytest_environment,
+    _worker_master_port,
     execute_batch,
 )
 
@@ -166,6 +169,54 @@ def _fake_batch_request(tmp_path: Path) -> BatchExecutionRequest:
         monitor_memory=False,
         memory_interval=1,
     )
+
+
+@pytest.mark.parametrize("worker_count", [1, 2, 4, 8])
+def test_pytest_workers_get_isolated_default_master_port_blocks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, worker_count: int
+) -> None:
+    monkeypatch.delenv("MASTER_PORT", raising=False)
+    request = _fake_batch_request(tmp_path)
+
+    ports = [
+        int(
+            _pytest_environment(replace(request, worker_index=worker_index))[
+                "MASTER_PORT"
+            ]
+        )
+        for worker_index in range(worker_count)
+    ]
+
+    assert ports == [29500 + worker_index * 100 for worker_index in range(worker_count)]
+    blocks = [set(range(port, port + 100)) for port in ports]
+    assert all(
+        left.isdisjoint(right)
+        for left_index, left in enumerate(blocks)
+        for right in blocks[left_index + 1 :]
+    )
+
+
+def test_explicit_master_port_is_preserved(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MASTER_PORT", "31234")
+
+    environment = _pytest_environment(
+        replace(_fake_batch_request(tmp_path), worker_index=360)
+    )
+
+    assert environment["MASTER_PORT"] == "31234"
+
+
+def test_worker_master_port_defines_a_valid_block() -> None:
+    assert _worker_master_port(0) == "29500"
+    assert _worker_master_port(3) == "29800"
+    assert _worker_master_port(359) == "65400"
+
+    with pytest.raises(ValueError, match="non-negative"):
+        _worker_master_port(-1)
+    with pytest.raises(ValueError, match="no valid rendezvous port block"):
+        _worker_master_port(360)
 
 
 def _install_fake_pytest(


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Parallel pytest workers could independently initialize `torch.distributed` using the default `MASTER_PORT=29500`. When their execution overlapped, multiple TCPStore servers attempted to bind the same port, causing intermittent `EADDRINUSE` failures: [pr#5075](https://github.com/flashinfer-ai/flashinfer/actions/runs/34558854785/job/103137289529?pr=5075), [pr 5111](https://github.com/flashinfer-ai/flashinfer/actions/runs/34548730763/job/103153534027?pr=5111)




## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved distributed worker startup by assigning each worker an isolated rendezvous port range.
  - Preserved explicitly configured `MASTER_PORT` values.
  - Worker defaults now align with the number of visible GPUs.
  - Added validation for derived distributed initialization ports.
  - Batch-start output now reports the assigned master port for easier troubleshooting.

- **Tests**
  - Added coverage for worker-count detection, port isolation, explicit port preservation, valid port ranges, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->