### PR TITLE
fix(jit): warn on cross-major CUDA toolkit mismatch

### DIFF
--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -76,7 +76,25 @@ def get_cuda_version() -> Version:
             raise RuntimeError(
                 f"Could not parse CUDA version from nvcc --version output: {txt}"
             )
-        return Version(matches[0])
+        cuda_version = Version(matches[0])
+        torch_cuda_version = (
+            Version(torch.version.cuda) if torch.version.cuda is not None else None
+        )
+        if (
+            torch_cuda_version is not None
+            and cuda_version.major != torch_cuda_version.major
+        ):
+            logger.warning(
+                "FlashInfer JIT resolved CUDA toolkit %s (version %s), but "
+                "PyTorch was built with CUDA %s. Cross-major CUDA JIT builds "
+                "may link against a CUDA runtime that is unavailable or "
+                "incompatible in worker processes. Set CUDA_HOME or CUDA_PATH "
+                "to the intended toolkit before compiling JIT modules.",
+                cuda_home,
+                cuda_version,
+                torch_cuda_version,
+            )
+        return cuda_version
     except (RuntimeError, FileNotFoundError, subprocess.CalledProcessError) as e:
         # NOTE(Zihao): when nvcc is unavailable, fall back to torch.version.cuda
         if torch.version.cuda is None:

--- a/tests/jit/test_jit_cpp_ext.py
+++ b/tests/jit/test_jit_cpp_ext.py
@@ -29,6 +29,25 @@ def test_nvcc_parallelism_flags_ignore_sccache_launcher(monkeypatch):
     assert cpp_ext.get_nvcc_parallelism_flags() == ["--threads=4"]
 
 
+def test_get_cuda_version_warns_on_cross_major_toolkit_mismatch(monkeypatch, caplog):
+    cpp_ext.get_cuda_version.cache_clear()
+    monkeypatch.setattr(cpp_ext, "get_cuda_path", lambda: "/usr/local/cuda-13.0")
+    monkeypatch.setattr(cpp_ext.torch.version, "cuda", "12.9")
+    monkeypatch.setattr(
+        cpp_ext.subprocess,
+        "check_output",
+        lambda *_args, **_kwargs: "Cuda compilation tools, release 13.0, V13.0.88",
+    )
+
+    with caplog.at_level(logging.WARNING, logger=cpp_ext.__name__):
+        assert cpp_ext.get_cuda_version() == cpp_ext.Version("13.0")
+
+    assert "/usr/local/cuda-13.0" in caplog.text
+    assert "PyTorch was built with CUDA 12.9" in caplog.text
+    assert "Set CUDA_HOME or CUDA_PATH" in caplog.text
+    cpp_ext.get_cuda_version.cache_clear()
+
+
 def test_jit_uses_size_optimized_fatbin_compression(monkeypatch):
     monkeypatch.setattr(core, "check_cuda_arch", lambda: None)
     monkeypatch.setattr(core, "get_nvcc_parallelism_flags", lambda: ["--threads=1"])
@@ -378,28 +397,7 @@ def test_prefill_jit_helper_skips_fa3_unsupported_large_head(monkeypatch):
     assert ("batch", "fa2", 512, 512) in calls
 
 
-
-    cpp_ext.get_cuda_version.cache_clear()
-    monkeypatch.setattr(cpp_ext, "get_cuda_path", lambda: "/usr/local/cuda-13.0")
-    monkeypatch.setattr(cpp_ext.torch.version, "cuda", "12.9")
-    monkeypatch.setattr(
-        cpp_ext.subprocess,
-        "check_output",
-        lambda *_args, **_kwargs: "Cuda compilation tools, release 13.0, V13.0.88",
-    )
-
-    with caplog.at_level(logging.WARNING, logger=cpp_ext.__name__):
-        assert cpp_ext.get_cuda_version() == cpp_ext.Version("13.0")
-
-    assert "/usr/local/cuda-13.0" in caplog.text
-    assert "PyTorch was built with CUDA 12.9" in caplog.text
-    assert "Set CUDA_HOME or CUDA_PATH" in caplog.text
-    cpp_ext.get_cuda_version.cache_clear()
-
-
-def test_get_cuda_version_does_not_warn_for_same_major_toolkit(
-    monkeypatch, caplog
-):
+def test_get_cuda_version_does_not_warn_for_same_major_toolkit(monkeypatch, caplog):
     cpp_ext.get_cuda_version.cache_clear()
     monkeypatch.setattr(cpp_ext, "get_cuda_path", lambda: "/usr/local/cuda-12.9")
     monkeypatch.setattr(cpp_ext.torch.version, "cuda", "12.8")

--- a/tests/jit/test_jit_cpp_ext.py
+++ b/tests/jit/test_jit_cpp_ext.py
@@ -378,9 +378,7 @@ def test_prefill_jit_helper_skips_fa3_unsupported_large_head(monkeypatch):
     assert ("batch", "fa2", 512, 512) in calls
 
 
-def test_get_cuda_version_warns_on_cross_major_toolkit_mismatch(
-    monkeypatch, caplog
-):
+
     cpp_ext.get_cuda_version.cache_clear()
     monkeypatch.setattr(cpp_ext, "get_cuda_path", lambda: "/usr/local/cuda-13.0")
     monkeypatch.setattr(cpp_ext.torch.version, "cuda", "12.9")

--- a/tests/jit/test_jit_cpp_ext.py
+++ b/tests/jit/test_jit_cpp_ext.py
@@ -378,7 +378,6 @@ def test_prefill_jit_helper_skips_fa3_unsupported_large_head(monkeypatch):
     assert ("batch", "fa2", 512, 512) in calls
 
 
-
 def test_get_cuda_version_warns_on_cross_major_toolkit_mismatch(
     monkeypatch, caplog
 ):

--- a/tests/jit/test_jit_cpp_ext.py
+++ b/tests/jit/test_jit_cpp_ext.py
@@ -1,3 +1,4 @@
+import logging
 import subprocess
 from types import SimpleNamespace
 
@@ -375,3 +376,44 @@ def test_prefill_jit_helper_skips_fa3_unsupported_large_head(monkeypatch):
     assert ("batch", "fa3", 512, 512) not in calls
     assert ("single", "fa2", 512, 512) in calls
     assert ("batch", "fa2", 512, 512) in calls
+
+
+
+def test_get_cuda_version_warns_on_cross_major_toolkit_mismatch(
+    monkeypatch, caplog
+):
+    cpp_ext.get_cuda_version.cache_clear()
+    monkeypatch.setattr(cpp_ext, "get_cuda_path", lambda: "/usr/local/cuda-13.0")
+    monkeypatch.setattr(cpp_ext.torch.version, "cuda", "12.9")
+    monkeypatch.setattr(
+        cpp_ext.subprocess,
+        "check_output",
+        lambda *_args, **_kwargs: "Cuda compilation tools, release 13.0, V13.0.88",
+    )
+
+    with caplog.at_level(logging.WARNING, logger=cpp_ext.__name__):
+        assert cpp_ext.get_cuda_version() == cpp_ext.Version("13.0")
+
+    assert "/usr/local/cuda-13.0" in caplog.text
+    assert "PyTorch was built with CUDA 12.9" in caplog.text
+    assert "Set CUDA_HOME or CUDA_PATH" in caplog.text
+    cpp_ext.get_cuda_version.cache_clear()
+
+
+def test_get_cuda_version_does_not_warn_for_same_major_toolkit(
+    monkeypatch, caplog
+):
+    cpp_ext.get_cuda_version.cache_clear()
+    monkeypatch.setattr(cpp_ext, "get_cuda_path", lambda: "/usr/local/cuda-12.9")
+    monkeypatch.setattr(cpp_ext.torch.version, "cuda", "12.8")
+    monkeypatch.setattr(
+        cpp_ext.subprocess,
+        "check_output",
+        lambda *_args, **_kwargs: "Cuda compilation tools, release 12.9, V12.9.86",
+    )
+
+    with caplog.at_level(logging.WARNING, logger=cpp_ext.__name__):
+        assert cpp_ext.get_cuda_version() == cpp_ext.Version("12.9")
+
+    assert "Cross-major CUDA JIT builds" not in caplog.text
+    cpp_ext.get_cuda_version.cache_clear()


### PR DESCRIPTION
## 📌 Description

FlashInfer resolves the CUDA toolkit used for NVCC JIT compilation independently from the CUDA version used to build PyTorch. When CUDA_HOME and CUDA_PATH are unset, the JIT resolver falls back to nvcc on PATH.

This can silently select a different CUDA major. For example, CUDA 13 NVCC can produce a JIT extension with an ELF dependency on libcudart.so.13 while distributed workers run with a CUDA 12.9 PyTorch/runtime environment. The resulting failure appears later when the extension is loaded or invoked and can surface as cudaErrorInsufficientDriver (35).

This change adds a non-fatal warning when the resolved NVCC toolkit and torch.version.cuda differ in major version. The warning reports the selected toolkit path, resolved NVCC version, PyTorch CUDA version, and CUDA_HOME / CUDA_PATH remediation.

Same-major minor-version differences remain accepted without warning. The version resolver is cached, so the warning is emitted at most once per process through this path.

## 🔍 Related Issues

Related to https://github.com/flashinfer-ai/flashinfer/issues/5145

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] Installed and ran the repository pre-commit hooks on the changed files.
- [x] Fixed all reported formatting and lint findings on the changed files.

## 🧪 Tests

- [x] Added CPU-safe mocked coverage for CUDA 13 NVCC with CUDA 12.9 PyTorch.
- [x] Added a negative case confirming CUDA 12.9 NVCC with CUDA 12.8 PyTorch does not warn.
- [x] Focused mocked tests for get_cuda_version (2 passed).
- [x] python -m compileall -q flashinfer/jit/cpp_ext.py tests/jit/test_jit_cpp_ext.py
- [x] git diff --check
- [x] pre-commit run --files flashinfer/jit/cpp_ext.py tests/jit/test_jit_cpp_ext.py

## 🔬 Experimental Track

Not applicable. This change does not add or modify an experimental API or backend.

## Reviewer Notes

The warning is intentionally limited to cross-major mismatches. A hard error could reject intentional advanced toolchain configurations, while warning on every minor mismatch would be noisy and may flag supported combinations.

The production incident evidence establishes the cross-major selection and runtime failure, but this PR does not claim that current main has a broken Ninja freshness check. Current main rewrites build.ninja and invokes Ninja for JIT artifacts; this PR focuses on surfacing the hazardous configuration before a late distributed-worker failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added a warning when the detected CUDA toolkit and PyTorch use different major CUDA versions, highlighting potential JIT linking compatibility issues.
  - CUDA version reporting remains unchanged and continues to use the detected toolkit version.

- **Tests**
  - Added coverage for matching and mismatched CUDA major-version scenarios.
  - Verified warnings include the toolkit location, PyTorch’s CUDA version, and guidance to configure CUDA environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->