### PR TITLE
fix: add discoverable MLA prefill API

### DIFF
--- a/docs/api/attention.rst
+++ b/docs/api/attention.rst
@@ -265,6 +265,7 @@ PageAttention for MLA
     :toctree: ../generated
 
     trtllm_batch_decode_with_kv_cache_mla
+    trtllm_prefill_with_kv_cache_mla
     trtllm_batch_decode_sparse_mla_dsv4
     nvfp4_quantize_pack_sparse_mla_cache
     nvfp4_quantize_append_sparse_mla_cache

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -4355,6 +4355,7 @@ def trtllm_batch_decode_with_kv_cache_mla(
     causal_seqlens_kv_global: Optional[torch.Tensor] = None,
     use_fp16_softmax: Optional[bool] = None,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+    """See :func:`_trtllm_batch_decode_with_kv_cache_mla_impl` for parameter documentation."""
     return _trtllm_batch_decode_with_kv_cache_mla_impl(
         query=query,
         kv_cache=kv_cache,

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -3402,8 +3402,7 @@ class CuteDslMlaDecodeRunner(TunableRunner):
         )
 
 
-@flashinfer_api(trace=trtllm_batch_decode_mla_trace_dispatch)
-def trtllm_batch_decode_with_kv_cache_mla(
+def _trtllm_batch_decode_with_kv_cache_mla_impl(
     query: torch.Tensor,
     kv_cache: torch.Tensor,
     workspace_buffer: torch.Tensor,
@@ -4319,6 +4318,171 @@ def trtllm_batch_decode_with_kv_cache_mla(
         # or 2D ``(B*q_len, H)`` when we allocated the default.
         return out, user_lse
     return out
+
+
+@flashinfer_api(trace=trtllm_batch_decode_mla_trace_dispatch)
+def trtllm_batch_decode_with_kv_cache_mla(
+    query: torch.Tensor,
+    kv_cache: torch.Tensor,
+    workspace_buffer: torch.Tensor,
+    qk_nope_head_dim: int,  # TODO: remove in 1.0?
+    kv_lora_rank: int,
+    qk_rope_head_dim: int,
+    block_tables: torch.Tensor,
+    seq_lens: Optional[torch.Tensor],
+    max_seq_len: int,
+    sparse_mla_top_k: int = 0,
+    out: Optional[torch.Tensor] = None,
+    bmm1_scale: Union[float, torch.Tensor] = 1.0,
+    bmm2_scale: Union[float, torch.Tensor] = 1.0,
+    sinks: Optional[List[torch.Tensor]] = None,
+    skip_softmax_threshold_scale_factor: Optional[float] = None,
+    enable_pdl: bool | None = None,
+    backend: str = "auto",
+    is_var_seq: bool = True,
+    uses_shared_paged_kv_idx: bool = True,
+    lse: Optional[torch.Tensor] = None,
+    return_lse: bool = False,
+    cute_dsl_impl: str = "auto",
+    kv_scale_format: str = "auto",
+    cum_seq_lens_q: Optional[torch.Tensor] = None,
+    max_q_len: Optional[int] = None,
+    multi_ctas_kv_counter_buffer: Optional[torch.Tensor] = None,
+    sparse_mla_top_k_lens: Optional[torch.Tensor] = None,
+    enable_dcp: bool = False,
+    cp_world: int = 1,
+    cp_rank: int = 0,
+    causal_seqlens_kv_global: Optional[torch.Tensor] = None,
+    use_fp16_softmax: Optional[bool] = None,
+) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+    return _trtllm_batch_decode_with_kv_cache_mla_impl(
+        query=query,
+        kv_cache=kv_cache,
+        workspace_buffer=workspace_buffer,
+        qk_nope_head_dim=qk_nope_head_dim,
+        kv_lora_rank=kv_lora_rank,
+        qk_rope_head_dim=qk_rope_head_dim,
+        block_tables=block_tables,
+        seq_lens=seq_lens,
+        max_seq_len=max_seq_len,
+        sparse_mla_top_k=sparse_mla_top_k,
+        out=out,
+        bmm1_scale=bmm1_scale,
+        bmm2_scale=bmm2_scale,
+        sinks=sinks,
+        skip_softmax_threshold_scale_factor=skip_softmax_threshold_scale_factor,
+        enable_pdl=enable_pdl,
+        backend=backend,
+        is_var_seq=is_var_seq,
+        uses_shared_paged_kv_idx=uses_shared_paged_kv_idx,
+        lse=lse,
+        return_lse=return_lse,
+        cute_dsl_impl=cute_dsl_impl,
+        kv_scale_format=kv_scale_format,
+        cum_seq_lens_q=cum_seq_lens_q,
+        max_q_len=max_q_len,
+        multi_ctas_kv_counter_buffer=multi_ctas_kv_counter_buffer,
+        sparse_mla_top_k_lens=sparse_mla_top_k_lens,
+        enable_dcp=enable_dcp,
+        cp_world=cp_world,
+        cp_rank=cp_rank,
+        causal_seqlens_kv_global=causal_seqlens_kv_global,
+        use_fp16_softmax=use_fp16_softmax,
+    )
+
+
+trtllm_batch_decode_with_kv_cache_mla.__doc__ = (
+    _trtllm_batch_decode_with_kv_cache_mla_impl.__doc__
+)
+
+
+@flashinfer_api(trace=trtllm_batch_decode_mla_trace_dispatch)
+def trtllm_prefill_with_kv_cache_mla(
+    query: torch.Tensor,
+    kv_cache: torch.Tensor,
+    workspace_buffer: torch.Tensor,
+    qk_nope_head_dim: int,  # TODO: remove in 1.0?
+    kv_lora_rank: int,
+    qk_rope_head_dim: int,
+    block_tables: torch.Tensor,
+    seq_lens: Optional[torch.Tensor],
+    max_seq_len: int,
+    sparse_mla_top_k: int = 0,
+    out: Optional[torch.Tensor] = None,
+    bmm1_scale: Union[float, torch.Tensor] = 1.0,
+    bmm2_scale: Union[float, torch.Tensor] = 1.0,
+    sinks: Optional[List[torch.Tensor]] = None,
+    skip_softmax_threshold_scale_factor: Optional[float] = None,
+    enable_pdl: bool | None = None,
+    backend: str = "auto",
+    is_var_seq: bool = True,
+    uses_shared_paged_kv_idx: bool = True,
+    lse: Optional[torch.Tensor] = None,
+    return_lse: bool = False,
+    cute_dsl_impl: str = "auto",
+    kv_scale_format: str = "auto",
+    cum_seq_lens_q: Optional[torch.Tensor] = None,
+    max_q_len: Optional[int] = None,
+    multi_ctas_kv_counter_buffer: Optional[torch.Tensor] = None,
+    sparse_mla_top_k_lens: Optional[torch.Tensor] = None,
+    enable_dcp: bool = False,
+    cp_world: int = 1,
+    cp_rank: int = 0,
+    causal_seqlens_kv_global: Optional[torch.Tensor] = None,
+    use_fp16_softmax: Optional[bool] = None,
+) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+    r"""Run MLA with decode-compatible semantics for prefill callers.
+
+    This function shares its implementation, argument and return contract,
+    exceptions, and backend selection with
+    :func:`trtllm_batch_decode_with_kv_cache_mla`. Use
+    ``q_len_per_request == 1`` for decode, or use a compatible backend with
+    ``q_len_per_request > 1`` for incremental prefill and multi-token
+    prediction (MTP).
+
+    XQA only supports ``q_len_per_request == 1``. Because ``backend="auto"``
+    may select XQA, callers that require multi-token prefill must select a
+    compatible backend explicitly.
+
+    This entrypoint is also available as
+    :func:`flashinfer.prefill.trtllm_prefill_with_kv_cache_mla`. See
+    :func:`trtllm_batch_decode_with_kv_cache_mla` for complete parameter and
+    return-value documentation.
+    """
+    return _trtllm_batch_decode_with_kv_cache_mla_impl(
+        query=query,
+        kv_cache=kv_cache,
+        workspace_buffer=workspace_buffer,
+        qk_nope_head_dim=qk_nope_head_dim,
+        kv_lora_rank=kv_lora_rank,
+        qk_rope_head_dim=qk_rope_head_dim,
+        block_tables=block_tables,
+        seq_lens=seq_lens,
+        max_seq_len=max_seq_len,
+        sparse_mla_top_k=sparse_mla_top_k,
+        out=out,
+        bmm1_scale=bmm1_scale,
+        bmm2_scale=bmm2_scale,
+        sinks=sinks,
+        skip_softmax_threshold_scale_factor=skip_softmax_threshold_scale_factor,
+        enable_pdl=enable_pdl,
+        backend=backend,
+        is_var_seq=is_var_seq,
+        uses_shared_paged_kv_idx=uses_shared_paged_kv_idx,
+        lse=lse,
+        return_lse=return_lse,
+        cute_dsl_impl=cute_dsl_impl,
+        kv_scale_format=kv_scale_format,
+        cum_seq_lens_q=cum_seq_lens_q,
+        max_q_len=max_q_len,
+        multi_ctas_kv_counter_buffer=multi_ctas_kv_counter_buffer,
+        sparse_mla_top_k_lens=sparse_mla_top_k_lens,
+        enable_dcp=enable_dcp,
+        cp_world=cp_world,
+        cp_rank=cp_rank,
+        causal_seqlens_kv_global=causal_seqlens_kv_global,
+        use_fp16_softmax=use_fp16_softmax,
+    )
 
 
 @flashinfer_api(trace=xqa_batch_decode_mla_trace)

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -37,6 +37,9 @@ from .jit import (
     setup_cubin_loader,
 )
 from .jit.attention.utils import _is_nvfp4_kv_dtype
+from .mla import (
+    trtllm_prefill_with_kv_cache_mla as trtllm_prefill_with_kv_cache_mla,
+)
 from .page import get_seq_lens
 from .quantization import packbits, segment_packbits
 from .trace.templates.attention import (

--- a/tests/attention/test_trtllm_gen_mla.py
+++ b/tests/attention/test_trtllm_gen_mla.py
@@ -1700,6 +1700,121 @@ def test_trtllm_batch_decode_mla_preallocated_out(
             )
 
 
+@pytest.mark.arch_blackwell
+def test_trtllm_mla_prefill_matches_decode_multi_token_bf16():
+    """The prefill name preserves explicit TRTLLM-GEN output/LSE semantics."""
+    cc = get_compute_capability(torch.device("cuda"))
+    if cc[0] != 10:
+        pytest.skip("trtllm-gen MLA requires SM100/SM103")
+
+    torch.manual_seed(42)
+    device = torch.device("cuda:0")
+    layer_dim = supported_mla_layer_dimensions[-1]
+    head_dim = layer_dim.head_dimensions
+    batch_size = 1
+    q_len_per_request = 2
+    page_size = 32
+    max_seq_len = 64
+    num_pages = max_seq_len // page_size
+    head_dim_qk = head_dim.kv_lora_rank + head_dim.qk_rope_head_dim
+
+    query = torch.randn(
+        batch_size,
+        q_len_per_request,
+        layer_dim.num_heads,
+        head_dim_qk,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    kv_cache = torch.randn(
+        num_pages,
+        1,
+        page_size,
+        head_dim_qk,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    block_tables = torch.arange(num_pages, dtype=torch.int32, device=device).reshape(
+        batch_size, num_pages
+    )
+    seq_lens = torch.full((batch_size,), max_seq_len, dtype=torch.int32, device=device)
+
+    expected_out_shape = (
+        batch_size,
+        q_len_per_request,
+        layer_dim.num_heads,
+        head_dim.kv_lora_rank,
+    )
+    expected_lse_shape = (
+        batch_size * q_len_per_request,
+        layer_dim.num_heads,
+    )
+    decode_workspace = torch.zeros(workspace_size, dtype=torch.int8, device=device)
+    prefill_workspace = torch.zeros(workspace_size, dtype=torch.int8, device=device)
+    decode_out = torch.empty(expected_out_shape, dtype=torch.bfloat16, device=device)
+    prefill_out = torch.empty_like(decode_out)
+    decode_lse = torch.empty(expected_lse_shape, dtype=torch.float32, device=device)
+    prefill_lse = torch.empty_like(decode_lse)
+    tensor_only_workspace = torch.zeros(workspace_size, dtype=torch.int8, device=device)
+    tensor_only_out = torch.empty_like(decode_out)
+
+    common = {
+        "query": query,
+        "kv_cache": kv_cache,
+        "qk_nope_head_dim": head_dim.qk_nope_head_dim,
+        "kv_lora_rank": head_dim.kv_lora_rank,
+        "qk_rope_head_dim": head_dim.qk_rope_head_dim,
+        "block_tables": block_tables,
+        "seq_lens": seq_lens,
+        "max_seq_len": max_seq_len,
+        "bmm1_scale": 1.0
+        / ((head_dim.qk_nope_head_dim + head_dim.qk_rope_head_dim) ** 0.5),
+        "bmm2_scale": 1.0,
+        "backend": "trtllm-gen",
+        "return_lse": True,
+    }
+    decode_result = flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla(
+        **common,
+        workspace_buffer=decode_workspace,
+        out=decode_out,
+        lse=decode_lse,
+    )
+    prefill_result = flashinfer.prefill.trtllm_prefill_with_kv_cache_mla(
+        **common,
+        workspace_buffer=prefill_workspace,
+        out=prefill_out,
+        lse=prefill_lse,
+    )
+
+    assert isinstance(decode_result, tuple) and len(decode_result) == 2
+    assert isinstance(prefill_result, tuple) and len(prefill_result) == 2
+    assert decode_result[0] is decode_out
+    assert prefill_result[0] is prefill_out
+    assert decode_result[1] is decode_lse
+    assert prefill_result[1] is prefill_lse
+    assert decode_out.shape == prefill_out.shape == expected_out_shape
+    assert decode_out.dtype == prefill_out.dtype == torch.bfloat16
+    assert decode_lse.shape == prefill_lse.shape == expected_lse_shape
+    assert decode_lse.dtype == prefill_lse.dtype == torch.float32
+    assert torch.isfinite(decode_out).all()
+    assert torch.isfinite(prefill_out).all()
+    assert torch.isfinite(decode_lse).all()
+    assert torch.isfinite(prefill_lse).all()
+    torch.testing.assert_close(decode_out, prefill_out, rtol=1e-2, atol=1e-2)
+    torch.testing.assert_close(decode_lse, prefill_lse, rtol=1e-3, atol=1e-3)
+
+    tensor_only_result = flashinfer.prefill.trtllm_prefill_with_kv_cache_mla(
+        **{**common, "return_lse": False},
+        workspace_buffer=tensor_only_workspace,
+        out=tensor_only_out,
+    )
+    assert tensor_only_result is tensor_only_out
+    assert tensor_only_result.shape == expected_out_shape
+    assert tensor_only_result.dtype == torch.bfloat16
+    assert torch.isfinite(tensor_only_result).all()
+    torch.testing.assert_close(tensor_only_result, decode_out, rtol=1e-2, atol=1e-2)
+
+
 @pytest.mark.parametrize(
     "layer_dimensions",
     supported_mla_layer_dimensions,

--- a/tests/attention/test_trtllm_mla_prefill_api.py
+++ b/tests/attention/test_trtllm_mla_prefill_api.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import inspect
+
+import pytest
+
+import flashinfer
+import flashinfer.decode
+import flashinfer.mla
+import flashinfer.prefill
+
+
+_TRTLLM_MLA_PARAMETERS = (
+    "query",
+    "kv_cache",
+    "workspace_buffer",
+    "qk_nope_head_dim",
+    "kv_lora_rank",
+    "qk_rope_head_dim",
+    "block_tables",
+    "seq_lens",
+    "max_seq_len",
+    "sparse_mla_top_k",
+    "out",
+    "bmm1_scale",
+    "bmm2_scale",
+    "sinks",
+    "skip_softmax_threshold_scale_factor",
+    "enable_pdl",
+    "backend",
+    "is_var_seq",
+    "uses_shared_paged_kv_idx",
+    "lse",
+    "return_lse",
+    "cute_dsl_impl",
+    "kv_scale_format",
+    "cum_seq_lens_q",
+    "max_q_len",
+    "multi_ctas_kv_counter_buffer",
+    "sparse_mla_top_k_lens",
+    "enable_dcp",
+    "cp_world",
+    "cp_rank",
+    "causal_seqlens_kv_global",
+    "use_fp16_softmax",
+)
+_NUM_REQUIRED_PARAMETERS = 9
+
+
+def test_trtllm_mla_prefill_has_exact_approved_exports():
+    prefill_api = flashinfer.mla.trtllm_prefill_with_kv_cache_mla
+    decode_api = flashinfer.mla.trtllm_batch_decode_with_kv_cache_mla
+
+    assert flashinfer.prefill.trtllm_prefill_with_kv_cache_mla is prefill_api
+    assert flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla is decode_api
+    assert "trtllm_prefill_with_kv_cache_mla" not in vars(flashinfer)
+    assert "trtllm_prefill_with_kv_cache_mla" not in vars(flashinfer.decode)
+
+    assert prefill_api is not decode_api
+    assert prefill_api.__name__ == "trtllm_prefill_with_kv_cache_mla"
+    assert decode_api.__name__ == "trtllm_batch_decode_with_kv_cache_mla"
+
+
+def test_trtllm_mla_prefill_signature_annotations_and_defaults_match_decode():
+    prefill_api = flashinfer.mla.trtllm_prefill_with_kv_cache_mla
+    decode_api = flashinfer.mla.trtllm_batch_decode_with_kv_cache_mla
+    prefill_signature = inspect.signature(prefill_api)
+    decode_signature = inspect.signature(decode_api)
+
+    assert tuple(prefill_signature.parameters) == _TRTLLM_MLA_PARAMETERS
+    assert prefill_signature == decode_signature
+
+
+def _patch_shared_impl_and_forbid_decode_routing(monkeypatch):
+    core = importlib.import_module("flashinfer.mla._core")
+    calls = []
+    result = object()
+
+    def capture_impl(*args, **kwargs):
+        calls.append((args, kwargs))
+        return result
+
+    def forbidden_decode(*args, **kwargs):
+        raise AssertionError("prefill must not route through the public decode wrapper")
+
+    monkeypatch.setattr(
+        core, "_trtllm_batch_decode_with_kv_cache_mla_impl", capture_impl
+    )
+    monkeypatch.setattr(core, "trtllm_batch_decode_with_kv_cache_mla", forbidden_decode)
+    monkeypatch.setattr(
+        flashinfer.mla, "trtllm_batch_decode_with_kv_cache_mla", forbidden_decode
+    )
+    monkeypatch.setattr(
+        flashinfer.decode, "trtllm_batch_decode_with_kv_cache_mla", forbidden_decode
+    )
+    return calls, result
+
+
+@pytest.mark.parametrize(
+    "api_name",
+    ["trtllm_batch_decode_with_kv_cache_mla", "trtllm_prefill_with_kv_cache_mla"],
+    ids=["decode", "prefill"],
+)
+def test_trtllm_mla_forwards_every_argument_to_shared_impl(monkeypatch, api_name):
+    api = getattr(flashinfer.mla, api_name)
+    signature = inspect.signature(api)
+    values = tuple(object() for _ in _TRTLLM_MLA_PARAMETERS)
+    calls, expected_result = _patch_shared_impl_and_forbid_decode_routing(monkeypatch)
+
+    actual_result = api(*values)
+
+    assert actual_result is expected_result
+    assert len(calls) == 1
+    forwarded = signature.bind(*calls[0][0], **calls[0][1])
+    assert tuple(forwarded.arguments) == _TRTLLM_MLA_PARAMETERS
+    for name, value in zip(_TRTLLM_MLA_PARAMETERS, values, strict=True):
+        assert forwarded.arguments[name] is value
+
+
+def test_trtllm_mla_prefill_forwards_required_only_call_with_decode_defaults(
+    monkeypatch,
+):
+    prefill_api = flashinfer.mla.trtllm_prefill_with_kv_cache_mla
+    signature = inspect.signature(prefill_api)
+    required_values = tuple(object() for _ in range(_NUM_REQUIRED_PARAMETERS))
+    expected = signature.bind(*required_values)
+    expected.apply_defaults()
+    calls, expected_result = _patch_shared_impl_and_forbid_decode_routing(monkeypatch)
+
+    actual_result = prefill_api(*required_values)
+
+    assert actual_result is expected_result
+    assert len(calls) == 1
+    forwarded = signature.bind(*calls[0][0], **calls[0][1])
+    assert tuple(forwarded.arguments) == _TRTLLM_MLA_PARAMETERS
+    for name in _TRTLLM_MLA_PARAMETERS[:_NUM_REQUIRED_PARAMETERS]:
+        assert forwarded.arguments[name] is expected.arguments[name]
+    for name in _TRTLLM_MLA_PARAMETERS[_NUM_REQUIRED_PARAMETERS:]:
+        assert forwarded.arguments[name] == expected.arguments[name]

--- a/tests/trace/test_fi_trace.py
+++ b/tests/trace/test_fi_trace.py
@@ -1260,6 +1260,54 @@ def test_trtllm_batch_decode_mla_fi_trace_dense_and_ragged():
     assert ragged["inputs"]["max_q_len"]["shape"] is None
 
 
+def test_trtllm_mla_prefill_fi_trace_only_changes_public_api_tag():
+    import flashinfer.mla
+    import flashinfer.prefill
+
+    kwargs = {
+        "query": torch.empty(2, 3, 128, 576, dtype=torch.bfloat16),
+        "kv_cache": torch.empty(4, 64, 576, dtype=torch.bfloat16),
+        "workspace_buffer": torch.empty(1024, dtype=torch.int8),
+        "qk_nope_head_dim": 512,
+        "kv_lora_rank": 512,
+        "qk_rope_head_dim": 64,
+        "block_tables": torch.zeros(2, 1, dtype=torch.int32),
+        "seq_lens": torch.full((2,), 64, dtype=torch.int32),
+        "max_seq_len": 64,
+    }
+    decode_api = flashinfer.mla.trtllm_batch_decode_with_kv_cache_mla
+    prefill_api = flashinfer.prefill.trtllm_prefill_with_kv_cache_mla
+
+    assert callable(decode_api.fi_trace)
+    assert callable(prefill_api.fi_trace)
+    decode_tag = "fi_api:flashinfer.mla._core.trtllm_batch_decode_with_kv_cache_mla"
+    prefill_tag = "fi_api:flashinfer.mla._core.trtllm_prefill_with_kv_cache_mla"
+    cases = [
+        kwargs,
+        {
+            **kwargs,
+            "query": torch.empty(5, 128, 576, dtype=torch.bfloat16),
+            "cum_seq_lens_q": torch.tensor([0, 2, 5], dtype=torch.int32),
+            "max_q_len": 3,
+        },
+    ]
+
+    for case in cases:
+        decode = decode_api.fi_trace(**case)
+        prefill = prefill_api.fi_trace(**case)
+
+        assert decode_tag in decode["tags"]
+        assert prefill_tag in prefill["tags"]
+
+        prefill_with_decode_tag = {
+            **prefill,
+            "tags": [
+                decode_tag if tag == prefill_tag else tag for tag in prefill["tags"]
+            ],
+        }
+        assert prefill_with_decode_tag == decode
+
+
 # ---------------------------------------------------------------------------
 # JSON file output
 # ---------------------------------------------------------------------------

--- a/tests/utils/test_logging_replay.py
+++ b/tests/utils/test_logging_replay.py
@@ -26,8 +26,12 @@ with all decorated FlashInfer APIs. For each API, we:
 5. Verify: original_output ≈ dumped_output ≈ replayed_output
 """
 
+import json
 import os
+import subprocess
 import sys
+import textwrap
+from pathlib import Path
 
 import pytest
 import torch
@@ -361,6 +365,117 @@ def test_cli_replay(level10_environment):
 # =============================================================================
 # Tests for FLASHINFER_DUMP_INCLUDE / FLASHINFER_DUMP_EXCLUDE filtering
 # =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("dump_include", "also_call_decode"),
+    [("*", False), ("*prefill*", True)],
+    ids=["single-record", "prefill-filter"],
+)
+def test_trtllm_mla_prefill_logging_attribution_in_fresh_process(
+    tmp_path: Path,
+    dump_include: str,
+    also_call_decode: bool,
+):
+    """The compatibility wrapper owns one prefill-named logging event.
+
+    A subprocess is required because ``flashinfer.api_logging`` snapshots its
+    logging and dump-filter environment when the module is imported.
+    """
+    repo_root = Path(__file__).parents[2]
+    dump_dir = tmp_path / "dumps"
+    log_path = tmp_path / "api.log"
+    script = textwrap.dedent(
+        """
+        import os
+
+        import torch
+
+        import flashinfer.decode as decode
+        import flashinfer.mla._core as core
+        import flashinfer.prefill as prefill
+
+        calls = []
+
+        def shared_impl(*args, **kwargs):
+            calls.append((args, kwargs))
+            return torch.tensor([len(calls)], dtype=torch.int32)
+
+        assert not hasattr(
+            core._trtllm_batch_decode_with_kv_cache_mla_impl, "__wrapped__"
+        )
+        core._trtllm_batch_decode_with_kv_cache_mla_impl = shared_impl
+        required = (
+            torch.empty(1),
+            torch.empty(1),
+            torch.empty(1, dtype=torch.uint8),
+            64,
+            256,
+            64,
+            torch.zeros(1, 1, dtype=torch.int32),
+            torch.ones(1, dtype=torch.int32),
+            1,
+        )
+
+        prefill_result = prefill.trtllm_prefill_with_kv_cache_mla(*required)
+        assert prefill_result.item() == 1
+        if os.environ["FLASHINFER_TEST_CALL_DECODE"] == "1":
+            decode_result = decode.trtllm_batch_decode_with_kv_cache_mla(*required)
+            assert decode_result.item() == 2
+        """
+    )
+    env = os.environ.copy()
+    pythonpath = [str(repo_root)]
+    if env.get("PYTHONPATH"):
+        pythonpath.append(env["PYTHONPATH"])
+    env.update(
+        {
+            "CUDA_VISIBLE_DEVICES": "",
+            "FLASHINFER_DUMP_DIR": str(dump_dir),
+            "FLASHINFER_DUMP_INCLUDE": dump_include,
+            "FLASHINFER_DUMP_MAX_COUNT": "10",
+            "FLASHINFER_DUMP_MAX_SIZE_GB": "1",
+            "FLASHINFER_LOGDEST": str(log_path),
+            "FLASHINFER_LOGLEVEL": "10",
+            "FLASHINFER_TEST_CALL_DECODE": "1" if also_call_decode else "0",
+            "FLASHINFER_WORKSPACE_BASE": str(tmp_path / "workspace"),
+            "PYTHONPATH": os.pathsep.join(pythonpath),
+        }
+    )
+    for name in (
+        "FLASHINFER_DUMP_EXCLUDE",
+        "FLASHINFER_DUMP_SAFETENSORS",
+        "FLASHINFER_TRACE_DUMP",
+    ):
+        env.pop(name, None)
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repo_root,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    dump_subdirs = [path for path in dump_dir.iterdir() if path.is_dir()]
+    assert len(dump_subdirs) == 1
+    metadata_records = [
+        json.loads(line)
+        for line in (dump_subdirs[0] / "metadata.jsonl").read_text().splitlines()
+        if line
+    ]
+    assert {
+        (record["function_name"], record["call_sequence"])
+        for record in metadata_records
+    } == {("trtllm_prefill_with_kv_cache_mla", 1)}
+    assert metadata_records[-1]["execution_status"] == "completed"
+
+    log_text = log_path.read_text()
+    assert log_text.count("FlashInfer API Call: trtllm_prefill_with_kv_cache_mla") == 1
+    assert "FlashInfer API Call: trtllm_batch_decode_with_kv_cache_mla" not in log_text
 
 
 def test_dump_include_filter(tmp_path):


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The existing TRTLLM MLA entrypoint supports compatible multi-token queries, but its decode-only name makes it difficult to find for prefill. Add `trtllm_prefill_with_kv_cache_mla` through `flashinfer.mla` and `flashinfer.prefill`, with a documented API entry and the same current signature and behavior as decode.

Both public functions have separately named API wrappers over one private implementation. This preserves prefill logging/dump attribution and the existing dense/ragged trace contract while keeping backend selection and kernels unchanged. Documentation explains that XQA only supports one query token and that multi-token callers must explicitly select a compatible backend.

## 🔍 Related Issues

Fixes #2877.

Builds on the API name and discoverability goal proposed by Ian Liu (@ianliuy) in #3073. Reimplements that approach against current main using a shared private call target instead of `.__wrapped__`, the expanded 32-parameter signature, and the current trace dispatcher. The new entrypoint is exported through MLA and prefill only.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

Targeted validation: **10 tests passed on SM100** after an editable install, covering exports, signatures/defaults, forwarding through both wrappers, logging/dump filtering, dense/ragged traces, and two-token BF16 TRTLLM-GEN output/LSE parity.

```sh
python3 -m pytest -q \
  tests/attention/test_trtllm_mla_prefill_api.py \
  tests/utils/test_logging_replay.py::test_trtllm_mla_prefill_logging_attribution_in_fresh_process \
  tests/trace/test_fi_trace.py::test_trtllm_batch_decode_mla_fi_trace_dense_and_ragged \
  tests/trace/test_fi_trace.py::test_trtllm_mla_prefill_fi_trace_only_changes_public_api_tag \
  tests/attention/test_trtllm_gen_mla.py::test_trtllm_mla_prefill_matches_decode_multi_token_bf16
```

Changed-file pre-commit checks passed, including mypy and Ruff. The all-files pre-commit checklist and full-suite test checkbox remain unchecked because validation was targeted. A full Sphinx build remains unverified; prior focused import/docstring/autosummary checks passed. Other GPU architectures were not tested.

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

Review focus: API compatibility and single-event instrumentation. Both wrappers must forward every argument unchanged; the existing decode entrypoint remains available without caller migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MLA prefill support for TRT-LLM through a public API.
  * Added tracing and logging support for MLA prefill operations.
  * Preserved existing MLA decode functionality through its public interface.

* **Documentation**
  * Added MLA prefill to the FlashInfer attention API documentation.

* **Tests**
  * Added coverage for prefill/decode consistency, API behavior, tracing, and logging attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->