### PR TITLE
Revert "build: raise the nvidia-cudnn-frontend floor to 1.28.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ nccl-extensions>=0.1.0
 nccl4py>=0.4.1
 ninja
 numpy
-nvidia-cudnn-frontend>=1.28.0
+nvidia-cudnn-frontend>=1.25.0
 nvidia-cutlass-dsl>=4.6.2a0
 nvidia-ml-py
 packaging>=24.2


### PR DESCRIPTION
Reverts flashinfer-ai/flashinfer#5131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Expanded support to include NVIDIA cuDNN Frontend versions 1.25.0 and later.
  * No other end-user-visible changes are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->