### PR TITLE
fix(gemm): accept cuDNN plans without knobs in structured tactic enumeration

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -3702,7 +3702,10 @@ def _cudnn_graph_engine_knob_tactics(graph) -> List[tuple]:
             )
             continue
         knob_items = tuple(
-            sorted((int(knob_type), int(value)) for knob_type, value in knobs.items())
+            sorted(
+                (int(knob_type), int(value))
+                for knob_type, value in (knobs or {}).items()
+            )
         )
         tactics.append((int(engine_id), knob_items))
     return tactics
@@ -3747,7 +3750,7 @@ def _get_cudnn_plan_index_for_tactic(graph, tactic) -> int:
                 tuple(
                     sorted(
                         (int(knob_type), int(value))
-                        for knob_type, value in knobs.items()
+                        for knob_type, value in (knobs or {}).items()
                     )
                 ),
             )

--- a/tests/gemm/test_cudnn_knob_tactics.py
+++ b/tests/gemm/test_cudnn_knob_tactics.py
@@ -1,0 +1,83 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""cuDNN structured tactics ``(engine_id, knob_items)`` must survive plans that
+carry no knobs.
+
+cudnn-frontend's unified plan list mixes backend plans (knobs: a dict) with
+python engines (FROST, opt-in via ``CUDNN_FRONTEND_ENABLE_FROST_ENGINES``),
+whose ``get_engine_and_knobs_at_index`` answered ``(engine_id, None)`` before
+cudnn-frontend PR #1024 normalized it to ``{}``. The enumeration must accept
+both, or every cuDNN GEMM path and the autotuner crash the moment frost is
+opted in. No GPU needed: the graph is a stub."""
+
+import pytest
+
+pytest.importorskip("cudnn")
+
+from flashinfer.gemm.gemm_base import (  # noqa: E402
+    _cudnn_graph_engine_knob_tactics,
+    _get_cudnn_plan_index_for_tactic,
+)
+
+
+class _StubGraph:
+    """Just the two calls the tactic code makes."""
+
+    def __init__(self, plans):
+        self._plans = plans
+
+    def get_execution_plan_count(self):
+        return len(self._plans)
+
+    def get_engine_and_knobs_at_index(self, i):
+        return self._plans[i]
+
+
+FROST_GEMM_ID = 20400  # python-engine id block; no cuDNN knob dict
+
+
+def test_enumeration_accepts_plans_without_knobs():
+    import cudnn
+
+    kt = cudnn.knob_type
+    graph = _StubGraph(
+        [
+            (FROST_GEMM_ID, None),  # pre-#1024 python plan
+            (FROST_GEMM_ID, {}),  # post-#1024 python plan
+            (0, {kt.TILE_M: 128, kt.TILE_N: 256}),  # backend plan
+        ]
+    )
+    tactics = _cudnn_graph_engine_knob_tactics(graph)
+    assert tactics == [
+        (FROST_GEMM_ID, ()),
+        (FROST_GEMM_ID, ()),
+        (0, ((int(kt.TILE_M), 128), (int(kt.TILE_N), 256))),
+    ]
+    # knob items are sorted by knob id so the same plan hashes the same
+    graph2 = _StubGraph([(0, {kt.TILE_N: 256, kt.TILE_M: 128})])
+    assert _cudnn_graph_engine_knob_tactics(graph2) == [tactics[2]]
+
+
+def test_plan_lookup_matches_knobless_tactic():
+    import cudnn
+
+    kt = cudnn.knob_type
+    graph = _StubGraph(
+        [(0, {kt.TILE_M: 128}), (FROST_GEMM_ID, None), (FROST_GEMM_ID, {})]
+    )
+    assert _get_cudnn_plan_index_for_tactic(graph, (FROST_GEMM_ID, ())) == 1
+    assert _get_cudnn_plan_index_for_tactic(graph, (0, ((int(kt.TILE_M), 128),))) == 0


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 📌 Description

cuDNN structured tactics `(engine_id, knob_items)` assumed every plan in cudnn-frontend's ranked list carries a knob dict. With cudnn-frontend's python engines opted in (`CUDNN_FRONTEND_ENABLE_FROST_ENGINES=1`), `get_engine_and_knobs_at_index` returns `(engine_id, None)` for a FROST GEMM plan (no tuning axes exposed yet), and `_cudnn_graph_engine_knob_tactics` / `_get_cudnn_plan_index_for_tactic` crash on `knobs.items()`:

```
AttributeError: 'NoneType' object has no attribute 'items'
```

Every cuDNN GEMM path (`mm_bf16`, `mm_fp4`, `bmm_fp8`, `bmm_mxfp8`, `bmm_bf16`) and `test_autotuner_bmm_fp8.py` fail this way under the opt-in (17 tests on B200, cuDNN 9.27, FE 1.29-dev + cutlass-dsl 4.7.1).

Fix: iterate `(knobs or {}).items()` in both places, so a knob-less plan is the tactic `(engine_id, ())`. cudnn-frontend normalizes its side to `{}` in NVIDIA/cudnn-frontend#1024; this keeps FlashInfer correct on frontends before and after that.

Not a behaviour change for backend plans (always a dict). This does **not** make frost opt-in safe for FlashInfer by itself — frost GEMM still refuses FlashInfer's operand layouts at execute time (2-D mats, flat block-scale blobs), tracked separately.

## 🔍 Related Issues

- NVIDIA/cudnn-frontend#1024 (one knob vocabulary for backend and python plans)
- Follow-up to the frost opt-in audit discussed on #5133 / NVIDIA/cudnn-frontend#1023

## 🚀 Pull Request Checklist

- [x] Pre-commit hooks pass (`ruff format`, `ruff check`)
- [x] Tests added: `tests/gemm/test_cudnn_knob_tactics.py` (stub graph, no GPU work): plans with `None`, `{}` and a real knob dict enumerate to stable sorted tactics; plan lookup finds the knob-less tactic.
- [x] Tests pass locally (B200, cuDNN 9.27): the new file 2 passed; with the frost opt-in + cutlass-dsl 4.7.1 the previously crashing `test_mm_bf16.py -k cudnn` (3), `test_bmm_fp8.py -k cudnn` (2), `test_bmm_bf16.py -k cudnn` (2), `test_autotuner_bmm_fp8.py` (15) pass.

## Reviewer Notes

Two-line functional change in `flashinfer/gemm/gemm_base.py`; the rest is the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>note to self: claude::61d24ed2-7c90-4a97-9cbb-b91ae18136fd — "PR #5133 auto backend: why not cuDNN" · cwd /home/scratch.yanxu_libs/flashinfer · workspace /home/scratch.yanxu_libs/flashinfer-wt-audit</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cuDNN GEMM tactic handling for plans without knob settings, preventing errors during tactic enumeration and matching.
  - Preserved consistent ordering and lookup behavior for tactics with and without knob values.

- **Tests**
  - Added coverage for missing, empty, and populated cuDNN knob configurations.
  - Added validation that these scenarios work without requiring GPU execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->