### PR TITLE
fix(moe): validate expert capacity in DeepSeek fused routing

### DIFF
--- a/csrc/fused_moe/noAuxTcKernels.cu
+++ b/csrc/fused_moe/noAuxTcKernels.cu
@@ -182,7 +182,9 @@ __global__ void deepseek_v3_topk_kernel(InputT* scores, OutputT* topkValues, Idx
       int32_t intermidiateExpert[NumInterTopKPerThread];
       for (int i = laneIdx; i < NumInterTopKPerThread * WARP_SIZE; i += WARP_SIZE) {
         int ii = i / WARP_SIZE;
-        if (i < NumInterTopK) {
+        // Stage one fills only the first ``topk`` of each ``MaxNumTopExperts``
+        // slot block, so the other slots are uninitialized reads; mask them out.
+        if (i < NumInterTopK && (i % MaxNumTopExperts) < topk) {
           intermidiateScore[ii] = smemInterTopScores[i];
           intermidiateExpert[ii] = smemInterTopExperts[i];
         } else {
@@ -239,17 +241,19 @@ void invokeNoAuxTc(InputT* scores, BiasT* bias, OutputT* topk_values, IdxT* topk
                    bool const launch_with_pdl, cudaStream_t const stream,
                    int16_t* routing_replay_out) {
 #ifdef FLASHINFER_CAKE_BACKEND
+  int64_t const cake_experts_per_group = n_group > 0 ? num_experts / n_group : 0;
   bool const cake_common = num_tokens > 0 && num_experts > 0 && n_group > 0 &&
                            num_experts % n_group == 0 && topk > 0 && topk <= 8 &&
-                           topk <= num_experts && topk_group > 0 && topk_group <= n_group &&
-                           topk_group * n_group >= topk;
-  bool const cake_single_group = cake_common && (n_group == 1) && (num_experts <= NumKimiK2Experts);
-  int64_t const cake_experts_per_group = n_group > 0 ? num_experts / n_group : 0;
+                           topk <= num_experts && topk_group > 0 && topk_group <= n_group;
+  // The single-group Cake schedules write one winner per token: top-1 only.
+  bool const cake_single_group =
+      cake_common && (n_group == 1) && (topk == 1) && (num_experts <= NumKimiK2Experts);
   bool const cake_multi_group = cake_common && (n_group >= 2) && (n_group <= 8) &&
                                 (topk_group <= 4) && (num_experts <= NumDeepseekExperts) &&
                                 (cake_experts_per_group >= 2) &&
                                 (cake_experts_per_group <= WARP_SIZE) &&
-                                (cake_experts_per_group * topk_group <= MaxNumExpertsUnit);
+                                (cake_experts_per_group * topk_group <= MaxNumExpertsUnit) &&
+                                (topk <= cake_experts_per_group * topk_group);
   TLLM_CHECK_WITH_INFO(cake_single_group || cake_multi_group,
                        "invokeNoAuxTc: unsupported configuration (n_group=%ld, num_experts=%ld, "
                        "topk_group=%ld). Please use original pytorch implementation.",

--- a/csrc/fused_moe/noAuxTcKernels.cu
+++ b/csrc/fused_moe/noAuxTcKernels.cu
@@ -27,6 +27,9 @@ static constexpr int MaxNumExpertsUnit = 128;
 static constexpr int NumTopGroupScores = 2;
 static constexpr int MaxNumTopExperts = 8;
 static constexpr int MaxNumTopGroups = 4;
+// The grouped schedule of ``deepseek_v3_topk_kernel`` launches one warp per
+// group score slot, so at most ``MaxNumGroupScores`` groups can be scored.
+static constexpr int MaxNumGroupScores = NumDeepseekExperts / WARP_SIZE;
 
 static __device__ inline float sigmoid_accurate(float x) { return 0.5f * tanhf(0.5f * x) + 0.5f; }
 
@@ -267,13 +270,16 @@ void invokeNoAuxTc(InputT* scores, BiasT* bias, OutputT* topk_values, IdxT* topk
   return;
 #endif
 
-  // Check if we can use the optimized deepseek_v3_topk_kernel
-  bool const is_single_group = (n_group == 1) && (num_experts <= NumKimiK2Experts);
+  // Check if we can use the optimized deepseek_v3_topk_kernel.  The grouped
+  // schedule scores at most ``MaxNumGroupScores`` groups, tracks at most
+  // ``MaxNumTopGroups`` selected groups, and needs >= 2 experts per group.
+  int64_t const experts_per_group = n_group > 0 ? num_experts / n_group : 0;  // 0 => unsupported
 
-  int64_t const experts_per_group = num_experts / n_group;
-  bool const is_multi_group = (n_group != 1) && (num_experts <= NumDeepseekExperts) &&
-                              (experts_per_group <= WARP_SIZE) &&
-                              (experts_per_group * topk_group <= MaxNumExpertsUnit);
+  bool const is_single_group = (n_group == 1) && (num_experts <= NumKimiK2Experts);
+  bool const is_multi_group =
+      (n_group > 1) && (n_group <= MaxNumGroupScores) && (num_experts <= NumDeepseekExperts) &&
+      (topk_group <= MaxNumTopGroups) && (experts_per_group >= NumTopGroupScores) &&
+      (experts_per_group <= WARP_SIZE) && (experts_per_group * topk_group <= MaxNumExpertsUnit);
 
   if (is_single_group || is_multi_group) {
     cudaLaunchConfig_t config;
@@ -362,13 +368,17 @@ void NoAuxTc(TensorView scores, TensorView bias, int64_t n_group, int64_t topk_g
       << "scores and bias must be on the same device";
   TVM_FFI_ICHECK(bias.dim() == 1 && bias.numel() == num_experts)
       << "bias must be 1D with length == number of experts (%ld)";
+  // This scalar routing contract is re-checked here because this FFI entry point
+  // is reachable with ``skip_check=True`` (``n_group`` is a divisor below).
+  TVM_FFI_ICHECK(n_group >= 1) << "n_group should be greater than or equal to 1";
+  TVM_FFI_ICHECK(n_group <= 8) << "n_group should be smaller than or equal to 8";
   TVM_FFI_ICHECK(num_experts % n_group == 0) << "num_experts should be divisible by n_group";
-  TVM_FFI_ICHECK(n_group <= 32)
-      << "n_group should be smaller than or equal to 32 for now";  //@todo: remove this restriction
-                                                                   // later
-  TVM_FFI_ICHECK(topk <= 32)
-      << "topk should be smaller than or equal to 32 for now";  //@todo: remove this restriction
-                                                                // later
+  TVM_FFI_ICHECK(topk_group >= 1 && topk_group <= n_group)
+      << "topk_group should be between 1 and n_group";
+  TVM_FFI_ICHECK(topk >= 1 && topk <= 8) << "topk should be between 1 and 8";
+  TVM_FFI_ICHECK(topk <= topk_group * (num_experts / n_group))
+      << "topk should be smaller than or equal to the number of experts reachable from the "
+         "selected topk_group groups";
   TVM_FFI_ICHECK(topk_values.dim() == 2) << "topk_values must be a 2D Tensor";
   TVM_FFI_ICHECK(topk_indices.dim() == 2) << "topk_indices must be a 2D Tensor";
   TVM_FFI_ICHECK(topk_values.sizes()[0] == num_tokens)

--- a/flashinfer/fused_moe/fused_routing_dsv3.py
+++ b/flashinfer/fused_moe/fused_routing_dsv3.py
@@ -162,10 +162,12 @@ def _check_dsv3_fused_routing_supported(
             f"Invalid configuration: topk_group ({topk_group}) must be in [1, n_group "
             f"({n_group})]"
         )
+    if topk <= 0:
+        raise ValueError(f"Invalid configuration: topk ({topk}) must be > 0")
 
     # The selected groups expose ``topk_group * num_experts / n_group`` experts,
     # and the kernel returns the top ``topk`` of exactly those candidates.
-    reachable_experts = topk_group * num_experts // n_group
+    reachable_experts = topk_group * (num_experts // n_group)
     if topk > reachable_experts:
         raise ValueError(
             f"Invalid configuration: topk ({topk}) must be <= the number of experts "
@@ -175,9 +177,29 @@ def _check_dsv3_fused_routing_supported(
 
     # Check kernel limits based on number of groups
     if n_group > 1:
-        experts_per_group = num_experts / n_group
+        experts_per_group = num_experts // n_group
         max_experts_in_selected_groups = experts_per_group * topk_group
 
+        # ``deepseek_v3_topk_kernel`` launches ``NumDeepseekExperts / WARP_SIZE``
+        # warps of the grouped schedule and keeps one group score per warp, so at
+        # most 8 groups can be scored, and it tracks at most ``MaxNumTopGroups``
+        # selected groups.
+        if n_group > 8:
+            raise ValueError(
+                f"Invalid configuration for n_group > 1: n_group ({n_group}) must be <= 8"
+            )
+        if topk_group > 4:
+            raise ValueError(
+                f"Invalid configuration for n_group > 1: topk_group ({topk_group}) must be "
+                f"<= 4"
+            )
+        # A group score is the sum of the two best experts of a group, which stays
+        # finite only for at least two experts per group.
+        if experts_per_group < 2:
+            raise ValueError(
+                f"Invalid configuration for n_group > 1: num_experts / n_group "
+                f"({experts_per_group}) must be >= 2"
+            )
         if topk > 8:
             raise ValueError(
                 f"Invalid configuration for n_group > 1: topk ({topk}) must be <= 8"
@@ -290,21 +312,25 @@ def fused_topk_deepseek(
         Per-expert routing bias of shape ``(num_experts,)``, same dtype as
         ``scores``.  Added to the sigmoid-activated scores before grouping.
     n_group : int
-        Number of expert groups.  Must satisfy ``n_group <= 32`` and
-        ``num_experts % n_group == 0``.  Typical value is 8 for DeepSeek-V3
-        with 256 experts (32 experts per group).
+        Number of expert groups.  Must satisfy ``1 <= n_group <= 8`` and
+        ``num_experts % n_group == 0``.  The grouped kernel keeps one group
+        score per warp of its launch, so at most 8 groups can be scored.
+        Typical value is 8 for DeepSeek-V3 with 256 experts (32 experts per
+        group).
     topk_group : int
-        Number of top groups to select.  Must satisfy ``topk_group <=
-        n_group`` and ``topk <= (num_experts / n_group) * topk_group``.
-        Typical value is 4.
+        Number of top groups to select.  Must satisfy ``1 <= topk_group <=
+        min(n_group, 4)`` and ``topk <= (num_experts / n_group) *
+        topk_group``; the kernel tracks at most 4 selected groups.  Typical
+        value is 4.
     topk : int
-        Number of top experts to select per token.  Must be ``<= num_experts``.
-        Hard cap ``topk <= 32``; in addition both branches of the kernel
-        require ``topk <= 8``.  Typical value is 8.
+        Number of top experts to select per token.  Must satisfy ``1 <=
+        topk <= 8`` and ``topk <= (num_experts / n_group) * topk_group``.
+        Typical value is 8.
 
         Further per-branch constraints:
 
-        - When ``n_group > 1``: ``num_experts / n_group <= 32`` and
+        - When ``n_group > 1``: ``2 <= num_experts / n_group <= 32`` (a
+          group score sums the two best experts of the group) and
           ``(num_experts / n_group) * topk_group <= 128``.
         - When ``n_group == 1``: ``num_experts <= 384``.
     routed_scaling_factor : float
@@ -334,6 +360,7 @@ def fused_topk_deepseek(
         Implementation backend. ``"default"`` preserves the existing
         FlashInfer implementation. ``"cake"`` explicitly selects the Cake
         kernel and raises when the call is outside its supported contract.
+        For ``"cake"``, single-group routing requires ``topk == 1``.
         Defaults to ``"default"``.
 
     Returns

--- a/flashinfer/fused_moe/fused_routing_dsv3.py
+++ b/flashinfer/fused_moe/fused_routing_dsv3.py
@@ -40,13 +40,20 @@ def _is_cake_dsv3_fused_routing_supported(
         return False
     if topk <= 0 or topk > 8 or topk > num_experts:
         return False
-    if topk_group <= 0 or topk_group > n_group or topk_group * n_group < topk:
+    if topk_group <= 0 or topk_group > n_group:
         return False
 
     if n_group == 1:
-        return num_experts <= 384
+        # The single-group Cake schedules write a single winner per token, so
+        # they only implement top-1 routing.
+        return topk == 1 and num_experts <= 384
 
     experts_per_group = num_experts // n_group
+    # The grouped Cake schedules select ``topk`` of the experts reachable from
+    # the ``topk_group`` selected groups.
+    if topk > topk_group * experts_per_group:
+        return False
+
     return (
         n_group <= 8
         and topk_group <= 4
@@ -141,11 +148,29 @@ def _check_dsv3_fused_routing_supported(
     # Extract number of experts from scores shape
     num_experts = scores.shape[1]
 
-    # Check basic configuration constraints
-    if topk_group * n_group < topk or topk_group > n_group:
+    # ``n_group`` must be positive and divide the expert count so that the
+    # per-group expert capacity is well defined.
+    if n_group <= 0:
+        raise ValueError(f"Invalid configuration: n_group ({n_group}) must be > 0")
+    if num_experts % n_group != 0:
         raise ValueError(
-            f"Invalid configuration: topk_group * n_group ({topk_group * n_group}) must be >= topk ({topk}) "
-            f"and topk_group ({topk_group}) must be <= n_group ({n_group})"
+            f"Invalid configuration: num_experts ({num_experts}) must be divisible by "
+            f"n_group ({n_group})"
+        )
+    if topk_group <= 0 or topk_group > n_group:
+        raise ValueError(
+            f"Invalid configuration: topk_group ({topk_group}) must be in [1, n_group "
+            f"({n_group})]"
+        )
+
+    # The selected groups expose ``topk_group * num_experts / n_group`` experts,
+    # and the kernel returns the top ``topk`` of exactly those candidates.
+    reachable_experts = topk_group * num_experts // n_group
+    if topk > reachable_experts:
+        raise ValueError(
+            f"Invalid configuration: topk ({topk}) must be <= the number of experts "
+            f"reachable from the topk_group ({topk_group}) selected groups "
+            f"({reachable_experts})"
         )
 
     # Check kernel limits based on number of groups
@@ -270,7 +295,8 @@ def fused_topk_deepseek(
         with 256 experts (32 experts per group).
     topk_group : int
         Number of top groups to select.  Must satisfy ``topk_group <=
-        n_group`` and ``topk_group * n_group >= topk``.  Typical value is 4.
+        n_group`` and ``topk <= (num_experts / n_group) * topk_group``.
+        Typical value is 4.
     topk : int
         Number of top experts to select per token.  Must be ``<= num_experts``.
         Hard cap ``topk <= 32``; in addition both branches of the kernel

--- a/tests/model_optimizations/test_dsv3_fused_routing.py
+++ b/tests/model_optimizations/test_dsv3_fused_routing.py
@@ -446,6 +446,24 @@ def validate_values(ground_truth, topk_values_kernel, tokens_to_skip, data_type)
         raise
 
 
+def _is_supported_dsv3_config(num_experts, n_group, topk_group, topk):
+    """Mirror ``_check_dsv3_fused_routing_supported`` so parametrized cases the
+    public API would reject are reported as skips instead of errors.
+    """
+    if n_group <= 0 or num_experts % n_group != 0:
+        return False
+    if topk_group <= 0 or topk_group > n_group:
+        return False
+    if topk <= 0 or topk > 8:
+        return False
+    experts_per_group = num_experts // n_group
+    if topk > topk_group * experts_per_group:
+        return False
+    if n_group > 1:
+        return experts_per_group <= 32 and experts_per_group * topk_group <= 128
+    return num_experts <= 384
+
+
 @pytest.mark.parametrize("backend", ["default", "cake"])
 @pytest.mark.parametrize(
     "num_experts,n_group,topk_group,topk",
@@ -516,6 +534,67 @@ def test_dsv3_fused_routing_backend_correctness(
     )
 
 
+@pytest.mark.parametrize("num_experts", [256, 384])
+@pytest.mark.parametrize("topk", [2, 4, 8])
+def test_dsv3_fused_routing_ungrouped_read_mask(num_experts, topk):
+    """Regression: ``n_group == 1`` multi-warp shared-memory read mask.
+
+    Stage one fills only the first ``topk`` of each 8-slot block, so a ``topk=8``
+    warmup with zero bias followed by a query with bias ``-2`` leaves stale
+    positive slot values that must be masked out; ``topk=8`` is the control.
+    """
+    num_tokens = 7
+    routed_scaling_factor = 1.0
+    device = "cuda"
+
+    generator = torch.Generator(device=device).manual_seed(4867)
+    ramp = torch.linspace(0.0, -1.0, num_experts, device=device, dtype=torch.float32)
+    scores = torch.stack(
+        [
+            ramp[torch.randperm(num_experts, device=device, generator=generator)]
+            for _ in range(num_tokens)
+        ]
+    )
+    bias = torch.full((num_experts,), -2.0, device=device, dtype=torch.float32)
+
+    ground_truth = DSv3RoutingGroundTruth(
+        scores.clone(), bias.clone(), 1, 1, topk, routed_scaling_factor, torch.float32
+    )
+
+    # Warmup uses a zero bias, so every stale slot holds a positive value.
+    warm_values = torch.empty(num_tokens, 8, device=device, dtype=torch.float32)
+    warm_indices = torch.empty(num_tokens, 8, device=device, dtype=torch.int32)
+    fused_topk_deepseek(
+        scores,
+        torch.zeros_like(bias),
+        1,
+        1,
+        8,
+        routed_scaling_factor,
+        warm_values,
+        warm_indices,
+    )
+
+    topk_values = torch.empty(num_tokens, topk, device=device, dtype=torch.float32)
+    topk_indices = torch.empty(num_tokens, topk, device=device, dtype=torch.int32)
+    fused_topk_deepseek(
+        scores, bias, 1, 1, topk, routed_scaling_factor, topk_values, topk_indices
+    )
+
+    for token_idx in range(num_tokens):
+        kernel_experts = set(topk_indices[token_idx].tolist())
+        reference_experts = set(ground_truth.ref_expert_indices[token_idx].tolist())
+        assert kernel_experts == reference_experts, (
+            f"token {token_idx}: kernel {sorted(kernel_experts)} != "
+            f"reference {sorted(reference_experts)}"
+        )
+
+    sorted_values, _ = torch.sort(topk_values, dim=-1, descending=True)
+    torch.testing.assert_close(
+        sorted_values, ground_truth.ref_expert_values, rtol=2e-6, atol=2e-6
+    )
+
+
 @pytest.mark.parametrize("num_tokens", [1, 8, 16, 64])
 @pytest.mark.parametrize("num_experts", [256, 384])
 @pytest.mark.parametrize("topk", [1, 2, 4, 8])
@@ -535,20 +614,8 @@ def test_dsv3_fused_routing_op(
     """
 
     # Skip invalid configurations
-    if topk_group * n_group < topk or topk_group > n_group:
-        pytest.skip(
-            "Invalid configuration: topk_group * n_group < topk or topk_group > n_group"
-        )
-    if n_group > 1:
-        if (
-            topk > 8
-            or num_experts / n_group > 32
-            or num_experts / n_group * topk_group > 128
-        ):
-            pytest.skip("Invalid configuration: exceeds kernel limits for n_group > 1")
-    else:
-        if num_experts > 384 or topk > 8:
-            pytest.skip("Invalid configuration: exceeds kernel limits for n_group = 1")
+    if not _is_supported_dsv3_config(num_experts, n_group, topk_group, topk):
+        pytest.skip("Invalid configuration for fused_topk_deepseek")
 
     # Generate random inputs
     torch.manual_seed(42)
@@ -613,18 +680,8 @@ def test_routing_replay_out_extended(
 
     Extended parametrization covering larger token counts (8, 64).
     """
-    if topk_group * n_group < topk or topk_group > n_group:
-        pytest.skip("Invalid configuration")
-    if n_group > 1:
-        if (
-            topk > 8
-            or num_experts / n_group > 32
-            or num_experts / n_group * topk_group > 128
-        ):
-            pytest.skip("Exceeds kernel limits for n_group > 1")
-    else:
-        if num_experts > 384 or topk > 8:
-            pytest.skip("Exceeds kernel limits for n_group = 1")
+    if not _is_supported_dsv3_config(num_experts, n_group, topk_group, topk):
+        pytest.skip("Invalid configuration for fused_topk_deepseek")
 
     torch.manual_seed(42)
     device = "cuda"
@@ -702,18 +759,8 @@ def test_routing_replay_out(
     that routing_replay_out matches topk_indices (as sets per token), and that
     passing None produces identical routing results (no side effects).
     """
-    if topk_group * n_group < topk or topk_group > n_group:
-        pytest.skip("Invalid configuration")
-    if n_group > 1:
-        if (
-            topk > 8
-            or num_experts / n_group > 32
-            or num_experts / n_group * topk_group > 128
-        ):
-            pytest.skip("Exceeds kernel limits for n_group > 1")
-    else:
-        if num_experts > 384 or topk > 8:
-            pytest.skip("Exceeds kernel limits for n_group = 1")
+    if not _is_supported_dsv3_config(num_experts, n_group, topk_group, topk):
+        pytest.skip("Invalid configuration for fused_topk_deepseek")
 
     torch.manual_seed(42)
     device = "cuda"

--- a/tests/model_optimizations/test_dsv3_fused_routing.py
+++ b/tests/model_optimizations/test_dsv3_fused_routing.py
@@ -337,6 +337,7 @@ class DSv3RoutingGroundTruth:
 
 
 def test_ground_truth_excludes_unselected_groups_with_negative_scores():
+    """Keep unselected groups excluded even when a selected expert scores below zero."""
     scores = torch.zeros((1, 8), dtype=torch.float32)
     bias = torch.tensor(
         [[2.5, 1.5, 0.5, -1.5, 0.0, -0.1, -0.2, -0.3]],
@@ -447,9 +448,7 @@ def validate_values(ground_truth, topk_values_kernel, tokens_to_skip, data_type)
 
 
 def _is_supported_dsv3_config(num_experts, n_group, topk_group, topk):
-    """Mirror ``_check_dsv3_fused_routing_supported`` so parametrized cases the
-    public API would reject are reported as skips instead of errors.
-    """
+    """Mirror the public validator so parametrized cases it rejects are skipped."""
     if n_group <= 0 or num_experts % n_group != 0:
         return False
     if topk_group <= 0 or topk_group > n_group:
@@ -460,7 +459,12 @@ def _is_supported_dsv3_config(num_experts, n_group, topk_group, topk):
     if topk > topk_group * experts_per_group:
         return False
     if n_group > 1:
-        return experts_per_group <= 32 and experts_per_group * topk_group <= 128
+        return (
+            n_group <= 8
+            and topk_group <= 4
+            and 2 <= experts_per_group <= 32
+            and experts_per_group * topk_group <= 128
+        )
     return num_experts <= 384
 
 
@@ -740,6 +744,202 @@ def test_routing_replay_out_extended(
 
     torch.testing.assert_close(topk_values, topk_values_no_replay)
     torch.testing.assert_close(topk_indices, topk_indices_no_replay)
+
+
+@pytest.mark.parametrize(
+    "num_experts,n_group,topk_group,topk",
+    [
+        pytest.param(16, 8, 4, 8, id="expert-capacity-two"),
+        pytest.param(16, 8, 2, 4, id="two-extreme-groups"),
+        pytest.param(64, 8, 4, 4, id="four-tracked-groups"),
+        pytest.param(128, 8, 4, 8, id="eight-groups-at-warp-limit"),
+        pytest.param(15, 5, 2, 6, id="five-groups-three-experts-per-group"),
+    ],
+)
+@pytest.mark.parametrize("data_type", [torch.float32, torch.float16, torch.bfloat16])
+def test_dsv3_fused_routing_grouped_small_capacity_numeric(
+    num_experts, n_group, topk_group, topk, data_type
+):
+    """Verify expert IDs and weights at legal grouped-capacity boundaries.
+
+    Widely separated biases avoid ties in expert and group selection.
+    """
+    num_tokens = 32
+    experts_per_group = num_experts // n_group
+
+    generator = torch.Generator(device="cuda").manual_seed(20240607)
+    scores = torch.randn(
+        num_tokens,
+        num_experts,
+        device="cuda",
+        dtype=torch.float32,
+        generator=generator,
+    ).to(data_type)
+
+    # A fixed permutation ranks the groups and the experts inside a group keep a
+    # strict order, so the biased scores are unique and widely spaced.
+    group_rank = torch.randperm(n_group, device="cuda", generator=generator)
+    expert_rank = (
+        group_rank.repeat_interleave(experts_per_group) * experts_per_group
+        + torch.arange(num_experts, device="cuda") % experts_per_group
+    )
+    bias = (-expert_rank.to(torch.float32) * 64.0).to(data_type)
+
+    ground_truth = DSv3RoutingGroundTruth(
+        scores.clone(), bias.clone(), n_group, topk_group, topk, 1.0, data_type
+    )
+
+    topk_values = torch.empty(num_tokens, topk, device="cuda", dtype=data_type)
+    topk_indices = torch.zeros(num_tokens, topk, device="cuda", dtype=torch.int32)
+    fused_topk_deepseek(
+        scores,
+        bias,
+        n_group,
+        topk_group,
+        topk,
+        1.0,
+        topk_values,
+        topk_indices,
+        launch_with_pdl=True,
+    )
+
+    # Account for float32 normalization and the output dtype's rounding.
+    rtol, atol = {
+        torch.bfloat16: (6e-3, 6e-3),
+        torch.float16: (8e-4, 8e-4),
+        torch.float32: (1e-5, 1e-5),
+    }[data_type]
+
+    for token_idx in range(num_tokens):
+        kernel_experts = set(topk_indices[token_idx].tolist())
+        reference_experts = set(ground_truth.ref_expert_indices[token_idx].tolist())
+        assert kernel_experts == reference_experts, (
+            f"token {token_idx}: kernel {sorted(kernel_experts)} != "
+            f"reference {sorted(reference_experts)}"
+        )
+
+    # Gather both outputs onto the expert axis so the comparison checks each
+    # expert weight instead of each output slot.
+    reference_weights = torch.zeros(
+        num_tokens, num_experts, device="cuda", dtype=torch.float32
+    )
+    reference_weights.scatter_(
+        1, ground_truth.ref_expert_indices, ground_truth.ref_expert_values
+    )
+    kernel_weights = torch.zeros(
+        num_tokens, num_experts, device="cuda", dtype=torch.float32
+    )
+    kernel_weights.scatter_(1, topk_indices.long(), topk_values.float())
+    torch.testing.assert_close(kernel_weights, reference_weights, rtol=rtol, atol=atol)
+
+
+@pytest.mark.parametrize(
+    "num_experts,n_group,topk_group,topk,match",
+    [
+        pytest.param(
+            256,
+            0,
+            4,
+            8,
+            r"n_group should be greater than or equal to 1",
+            id="n-group-zero-icheck",
+        ),
+        pytest.param(
+            256,
+            16,
+            4,
+            8,
+            r"n_group should be smaller than or equal to 8",
+            id="n-group-above-warp-count-icheck",
+        ),
+        pytest.param(
+            256,
+            8,
+            0,
+            8,
+            r"topk_group should be between 1 and n_group",
+            id="topk-group-zero-icheck",
+        ),
+        pytest.param(
+            64,
+            8,
+            5,
+            8,
+            r"unsupported configuration \(n_group=8, num_experts=64, topk_group=5\)",
+            id="topk-group-above-tracked-groups-gate",
+        ),
+        pytest.param(
+            8,
+            8,
+            4,
+            4,
+            r"unsupported configuration \(n_group=8, num_experts=8, topk_group=4\)",
+            id="experts-per-group-below-top-2-gate",
+        ),
+        pytest.param(
+            256,
+            8,
+            4,
+            0,
+            r"topk should be between 1 and 8",
+            id="topk-zero-icheck",
+        ),
+        pytest.param(
+            256,
+            8,
+            4,
+            9,
+            r"topk should be between 1 and 8",
+            id="topk-above-8-icheck",
+        ),
+        pytest.param(
+            32,
+            8,
+            1,
+            8,
+            r"topk should be smaller than or equal to the number of experts reachable",
+            id="topk-above-reachable-icheck",
+        ),
+    ],
+)
+def test_dsv3_fused_routing_grouped_contract_native_bypass(
+    num_experts, n_group, topk_group, topk, match
+):
+    """``skip_check=True`` still rejects unsupported grouped configurations.
+
+    The public validator is bypassed, so the native binding and the launch gate
+    have to reject each case themselves, and none of them may write to the
+    output tensors: the sentinels below must survive the raise unchanged.
+    """
+    num_tokens = 2
+    scores = torch.zeros(num_tokens, num_experts, device="cuda", dtype=torch.float32)
+    bias = torch.zeros(num_experts, device="cuda", dtype=torch.float32)
+    topk_values = torch.full(
+        (num_tokens, topk), -7.0, device="cuda", dtype=torch.float32
+    )
+    topk_indices = torch.full((num_tokens, topk), -1, device="cuda", dtype=torch.int32)
+    routing_replay_out = torch.full(
+        (num_tokens, topk), -3, device="cuda", dtype=torch.int16
+    )
+
+    with pytest.raises(RuntimeError, match=match):
+        fused_topk_deepseek(
+            scores,
+            bias,
+            n_group,
+            topk_group,
+            topk,
+            1.0,
+            topk_values,
+            topk_indices,
+            skip_check=True,
+            routing_replay_out=routing_replay_out,
+        )
+
+    torch.cuda.synchronize()
+    assert torch.equal(topk_values, torch.full_like(topk_values, -7.0))
+    assert torch.equal(topk_indices, torch.full_like(topk_indices, -1))
+    assert torch.equal(routing_replay_out, torch.full_like(routing_replay_out, -3))
 
 
 @pytest.mark.parametrize("num_tokens", [1, 7, 32])

--- a/tests/model_optimizations/test_dsv3_fused_routing_backend_selection.py
+++ b/tests/model_optimizations/test_dsv3_fused_routing_backend_selection.py
@@ -30,8 +30,12 @@ def _check_default(num_experts, n_group, topk_group, topk):
     num_tokens = 2
     scores = torch.zeros((num_tokens, num_experts), dtype=torch.float32)
     bias = torch.zeros((num_experts,), dtype=torch.float32)
-    topk_values = torch.empty((num_tokens, topk), dtype=torch.float32)
-    topk_indices = torch.empty((num_tokens, topk), dtype=torch.int32)
+    # ``topk`` may be non-positive in guard tests, so size the outputs with a
+    # non-negative width; a PyTorch allocation error would otherwise mask the
+    # production guard.
+    topk_width = max(0, topk)
+    topk_values = torch.empty((num_tokens, topk_width), dtype=torch.float32)
+    topk_indices = torch.empty((num_tokens, topk_width), dtype=torch.int32)
     return _check_dsv3_fused_routing_supported(
         scores,
         bias,
@@ -68,27 +72,145 @@ def test_default_backend_accepts_reachable_capacity(
 
 
 @pytest.mark.parametrize(
-    "num_experts,n_group,topk_group,topk",
+    "num_experts,n_group,topk_group,topk,match",
     [
-        pytest.param(16, 8, 1, 4, id="reachable-two-topk-four"),
-        pytest.param(4, 4, 4, 8, id="reachable-four-topk-eight"),
-        pytest.param(384, 1, 2, 8, id="topk-group-above-n-group"),
-        pytest.param(512, 1, 1, 8, id="experts-above-384"),
-        pytest.param(96, 3, 1, 32, id="topk-above-8"),
-        pytest.param(255, 8, 4, 8, id="experts-not-divisible"),
-        pytest.param(256, 0, 1, 8, id="n-group-zero"),
+        pytest.param(
+            16,
+            8,
+            1,
+            4,
+            r"topk \(4\) must be <= the number of experts reachable",
+            id="reachable-two-topk-four",
+        ),
+        pytest.param(
+            4,
+            4,
+            4,
+            8,
+            r"topk \(8\) must be <= the number of experts reachable",
+            id="reachable-four-topk-eight",
+        ),
+        pytest.param(
+            384,
+            1,
+            2,
+            8,
+            r"topk_group \(2\) must be in \[1, n_group \(1\)\]",
+            id="topk-group-above-n-group",
+        ),
+        pytest.param(
+            512,
+            1,
+            1,
+            8,
+            r"num_experts \(512\) must be <= 384",
+            id="experts-above-384",
+        ),
+        pytest.param(
+            96,
+            3,
+            1,
+            32,
+            r"topk \(32\) must be <= 8",
+            id="topk-above-8",
+        ),
+        pytest.param(
+            255,
+            8,
+            4,
+            8,
+            r"num_experts \(255\) must be divisible by n_group \(8\)",
+            id="experts-not-divisible",
+        ),
+        pytest.param(
+            256,
+            0,
+            1,
+            8,
+            r"n_group \(0\) must be > 0",
+            id="n-group-zero",
+        ),
+        pytest.param(
+            256,
+            8,
+            4,
+            0,
+            r"topk \(0\) must be > 0",
+            id="topk-zero",
+        ),
     ],
 )
 def test_default_backend_rejects_unreachable_capacity(
-    num_experts, n_group, topk_group, topk
+    num_experts, n_group, topk_group, topk, match
 ):
     """Configurations outside the reachable-expert capacity must raise.
 
     Includes ``16/8/1/4``, which the old ``topk_group * n_group`` product wrongly
-    admitted, plus the ``n_group``/divisibility guardrails.
+    admitted, plus the ``n_group``, divisibility and non-positive ``topk``
+    guardrails.  Each case asserts the validator names the offending parameter.
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=match):
         _check_default(num_experts, n_group, topk_group, topk)
+
+
+@pytest.mark.parametrize(
+    "num_experts,n_group,topk_group,topk,match",
+    [
+        pytest.param(
+            256,
+            16,
+            4,
+            8,
+            r"n_group \(16\) must be <= 8",
+            id="n-group-above-warp-count",
+        ),
+        pytest.param(
+            64,
+            8,
+            5,
+            8,
+            r"topk_group \(5\) must be <= 4",
+            id="topk-group-above-tracked-groups",
+        ),
+        pytest.param(
+            8,
+            8,
+            4,
+            4,
+            r"num_experts / n_group \(1\) must be >= 2",
+            id="experts-per-group-below-top-2",
+        ),
+    ],
+)
+def test_default_backend_rejects_grouped_constraint_violations(
+    num_experts, n_group, topk_group, topk, match
+):
+    """Grouped configurations outside the kernel contract must raise.
+
+    Each case asserts the validator reports the offending parameter.
+    """
+    with pytest.raises(ValueError, match=match):
+        _check_default(num_experts, n_group, topk_group, topk)
+
+
+@pytest.mark.parametrize(
+    "num_experts,n_group,topk_group,topk",
+    [
+        pytest.param(128, 8, 4, 8, id="eight-groups-at-warp-limit"),
+        pytest.param(64, 8, 4, 4, id="four-tracked-groups"),
+        pytest.param(16, 8, 4, 8, id="two-experts-per-group"),
+    ],
+)
+def test_default_backend_accepts_grouped_constraint_boundaries(
+    num_experts, n_group, topk_group, topk
+):
+    """The grouped constraints stay inclusive at their exact legal boundary.
+
+    ``128/8/4/8`` sits exactly at ``n_group == 8``, ``64/8/4/4`` at
+    ``topk_group == 4`` and ``16/8/4/8`` at ``experts_per_group == 2``, so each
+    must still be admitted (contrast with the rejects above).
+    """
+    assert _check_default(num_experts, n_group, topk_group, topk) is True
 
 
 @pytest.mark.parametrize("capability", [(10, 0), (10, 3)])
@@ -120,11 +242,13 @@ def test_cake_backend_accepts_contract_dtype_and_arch_union(
     ],
 )
 def test_cake_backend_rejects_calls_outside_contract(overrides):
+    """Reject unsupported shapes, dtypes, architectures, and reachable capacities."""
     assert not _supported(**overrides)
 
 
 @pytest.mark.parametrize("num_experts", [2, 128, 256, 384])
 def test_cake_backend_accepts_single_group_boundary(num_experts):
+    """Admit single-group top-1 routing through the 384-expert capacity limit."""
     assert _supported(
         num_experts=num_experts,
         n_group=1,
@@ -151,12 +275,12 @@ def test_cake_backend_accepts_within_group_capacity(overrides):
 
 
 def test_cake_backend_rejects_single_group_above_boundary():
+    """Reject single-group calls exceeding the 384-expert kernel capacity."""
     assert not _supported(num_experts=385, n_group=1, topk_group=1, topk=1)
 
 
 def test_cake_backend_single_group_requires_topk_one():
-    # The single-group Cake schedules write a single winner per token, so the
-    # only executable request is ``topk == 1``.
+    """Keep Cake's single-group schedules limited to their one output per token."""
     assert _supported(num_experts=256, n_group=1, topk_group=1, topk=1)
     assert not _supported(num_experts=256, n_group=1, topk_group=1, topk=2)
     assert not _supported(num_experts=256, n_group=1, topk_group=1, topk=8)

--- a/tests/model_optimizations/test_dsv3_fused_routing_backend_selection.py
+++ b/tests/model_optimizations/test_dsv3_fused_routing_backend_selection.py
@@ -5,6 +5,7 @@ import torch
 
 import flashinfer.fused_moe.fused_routing_dsv3 as fused_routing
 from flashinfer.fused_moe.fused_routing_dsv3 import (
+    _check_dsv3_fused_routing_supported,
     _is_cake_dsv3_fused_routing_supported,
 )
 
@@ -22,6 +23,72 @@ def _supported(**overrides):
     }
     params.update(overrides)
     return _is_cake_dsv3_fused_routing_supported(**params)
+
+
+def _check_default(num_experts, n_group, topk_group, topk):
+    """Run the real default-backend validator on CPU tensors (no GPU needed)."""
+    num_tokens = 2
+    scores = torch.zeros((num_tokens, num_experts), dtype=torch.float32)
+    bias = torch.zeros((num_experts,), dtype=torch.float32)
+    topk_values = torch.empty((num_tokens, topk), dtype=torch.float32)
+    topk_indices = torch.empty((num_tokens, topk), dtype=torch.int32)
+    return _check_dsv3_fused_routing_supported(
+        scores,
+        bias,
+        n_group,
+        topk_group,
+        topk,
+        1.0,
+        topk_values,
+        topk_indices,
+        False,
+    )
+
+
+@pytest.mark.parametrize(
+    "num_experts,n_group,topk_group,topk",
+    [
+        pytest.param(256, 1, 1, 8, id="issue4867-single-group-k8"),
+        pytest.param(384, 1, 1, 8, id="kimi-k2-single-group-k8"),
+        pytest.param(256, 1, 1, 1, id="single-group-top1"),
+        pytest.param(64, 8, 1, 8, id="topk-equals-reachable"),
+        pytest.param(96, 3, 1, 5, id="partial-group-capacity"),
+        pytest.param(256, 8, 4, 8, id="deepseek-v3-canonical"),
+    ],
+)
+def test_default_backend_accepts_reachable_capacity(
+    num_experts, n_group, topk_group, topk
+):
+    """``topk`` at or below ``topk_group * num_experts / n_group`` is admitted.
+
+    Covers issue #4867 (``256/1/1/8``), which the old ``topk_group * n_group``
+    product rejected.
+    """
+    assert _check_default(num_experts, n_group, topk_group, topk) is True
+
+
+@pytest.mark.parametrize(
+    "num_experts,n_group,topk_group,topk",
+    [
+        pytest.param(16, 8, 1, 4, id="reachable-two-topk-four"),
+        pytest.param(4, 4, 4, 8, id="reachable-four-topk-eight"),
+        pytest.param(384, 1, 2, 8, id="topk-group-above-n-group"),
+        pytest.param(512, 1, 1, 8, id="experts-above-384"),
+        pytest.param(96, 3, 1, 32, id="topk-above-8"),
+        pytest.param(255, 8, 4, 8, id="experts-not-divisible"),
+        pytest.param(256, 0, 1, 8, id="n-group-zero"),
+    ],
+)
+def test_default_backend_rejects_unreachable_capacity(
+    num_experts, n_group, topk_group, topk
+):
+    """Configurations outside the reachable-expert capacity must raise.
+
+    Includes ``16/8/1/4``, which the old ``topk_group * n_group`` product wrongly
+    admitted, plus the ``n_group``/divisibility guardrails.
+    """
+    with pytest.raises(ValueError):
+        _check_default(num_experts, n_group, topk_group, topk)
 
 
 @pytest.mark.parametrize("capability", [(10, 0), (10, 3)])
@@ -47,7 +114,7 @@ def test_cake_backend_accepts_contract_dtype_and_arch_union(
         {"n_group": 8, "num_experts": 8, "topk_group": 4},
         {"n_group": 8, "num_experts": 264},
         {"n_group": 8, "num_experts": 256, "topk": 9},
-        {"n_group": 3, "num_experts": 96, "topk_group": 1, "topk": 5},
+        {"n_group": 8, "num_experts": 16, "topk_group": 1, "topk": 4},
         {"score_dtype": torch.float64},
         {"bias_dtype": torch.float64},
     ],
@@ -66,11 +133,32 @@ def test_cake_backend_accepts_single_group_boundary(num_experts):
     )
 
 
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"n_group": 3, "num_experts": 96, "topk_group": 1, "topk": 5},
+        {"n_group": 4, "num_experts": 64, "topk_group": 1, "topk": 8},
+        {"n_group": 8, "num_experts": 64, "topk_group": 1, "topk": 8},
+    ],
+)
+def test_cake_backend_accepts_within_group_capacity(overrides):
+    """``topk`` may use every expert reachable from the selected groups.
+
+    ``topk_group * num_experts / n_group`` is the real capacity; a ``topk``
+    equal to it (``64/8/1/8``) is the boundary case.
+    """
+    assert _supported(**overrides)
+
+
 def test_cake_backend_rejects_single_group_above_boundary():
-    assert not _supported(num_experts=385, n_group=1, topk_group=1)
+    assert not _supported(num_experts=385, n_group=1, topk_group=1, topk=1)
 
 
-def test_cake_backend_preserves_source_single_group_topk_constraint():
+def test_cake_backend_single_group_requires_topk_one():
+    # The single-group Cake schedules write a single winner per token, so the
+    # only executable request is ``topk == 1``.
+    assert _supported(num_experts=256, n_group=1, topk_group=1, topk=1)
+    assert not _supported(num_experts=256, n_group=1, topk_group=1, topk=2)
     assert not _supported(num_experts=256, n_group=1, topk_group=1, topk=8)
 
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

`fused_topk_deepseek` rejects the GLM-5 and Kimi-K2.5 benchmark routing configurations (`n_group=topk_group=1`, `topk=8`, 256/384 experts) before kernel execution. The check counts groups instead of the experts available in the selected groups. Validate against `topk_group * (num_experts // n_group)`, including equality, and reject insufficient capacity.

For the newly admitted default single-group top-k calls, mask unwritten slots in the intermediate shared-memory reduction. Otherwise, top-k below eight can select stale candidates. Keep Cake's single-group top-1 limitation explicit in both its Python and native checks; its grouped checks use the corrected expert capacity. Also align the default grouped checks with the kernel's limits: at most eight groups, at most four selected groups, and at least two experts per group. Validate positive group counts before native division and reject invalid top-k even when the Python check is bypassed. Update the API documentation and the numerical/replay tests' matching skip conditions.

## 🔍 Related Issues

Fixes #4867

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.). Full GPU CI matrix requires upstream CI; completed validation is listed below.

Validated against main `715c3c9f15af2ffbf14068fabcb1f39af19c47dd`, using repository-pinned CUTLASS/CCCL/spdlog dependencies:

- The updated CPU validation file passes with no visible GPU: **62 passed**. Against the previous PR head (`0a17574`), the new grouped-limit and zero-top-k regressions produce **4 failed / 58 passed**. The original capacity checks also reproduced the issue on upstream baseline (9 failed / 46 passed).
- Both affected test files on an NVIDIA L40S, Python 3.12.14, PyTorch 2.13.0+cu130: **956 passed, 3960 skipped**. Skips cover unsupported parameter combinations and Cake's SM100/SM103 requirement. New tests require the expected diagnostic for invalid inputs and compare exact expert IDs plus per-expert weights at legal boundaries.
- An independent CPU boundary sweep checks **42,213 configurations** against a separately constructed parameter contract: all agree after the fix; the previous PR head incorrectly accepts 2,075.
- An independent GPU sweep passes **216 legal shape/dtype combinations**, with exact expert IDs, per-expert weight checks, and replay-buffer checks. It also verifies **48 native rejections** across direct FFI and `skip_check=True` calls, unchanged output sentinels, and a successful legal call after every rejection. Compute Sanitizer **memcheck and synccheck both report 0 errors** on this sweep.
- The original **198-configuration** public-API sweep still passes, including a separate CUDA stream and three CUDA Graph replays per configuration. The original 24 negative-bias reuse runs passed, and seven top-8 controls were bitwise identical between baseline and the initial fix.
- Full `pre-commit run --all-files`: **14 passed, 1 skipped**.
- Cake was freshly compiled for SM100a and loaded, without launching its kernels.

Commands:
```bash
python -m pytest tests/model_optimizations/test_dsv3_fused_routing.py \
  tests/model_optimizations/test_dsv3_fused_routing_backend_selection.py -q
pre-commit run --all-files
```

The full B300/GB300 NVFP4 MoE benchmarks and Cake GPU numerics were not run.

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

AI-assisted implementation and review. The change keeps the benchmark's model routing parameters intact and does not change the routing algorithm or claim a performance improvement. Particular review points are the inclusive capacity boundary, agreement between Python and native scalar checks, and preserving Cake's actual single-group top-1 contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved fused routing reliability by preventing invalid intermediate expert selections during multi-warp processing.
  - Strengthened validation for grouped routing, including expert capacity, group counts, and supported top-k ranges.
  - Improved backend selection for single-group and multi-group routing configurations.
  - Unsupported configurations are now rejected earlier with clearer validation behavior.

- **Tests**
  - Added coverage for routing edge cases, backend selection, warmup reuse, invalid parameters, and boundary-capacity configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
