### PR TITLE
perf(sparse): build variable-block attention indices on GPU

### DIFF
--- a/benchmarks/bench_variable_block_sparse_plan.py
+++ b/benchmarks/bench_variable_block_sparse_plan.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Measure host planning and plan+run latency; run on both comparison revisions."""
+
+import argparse
+import json
+import statistics
+import time
+
+import torch
+
+from flashinfer.sparse import VariableBlockSparseAttentionWrapper
+
+
+def make_case(heads, rows, cols, seq_len, density, group_size=4, head_dim=64):
+    torch.manual_seed(42)
+    row_sizes = torch.full((heads, rows), seq_len // rows, dtype=torch.int32)
+    row_sizes[:, -1] += seq_len % rows
+    col_sizes = torch.full((heads, cols), seq_len // cols, dtype=torch.int32)
+    col_sizes[:, -1] += seq_len % cols
+    mask = torch.rand(heads, rows, cols, device="cuda") < density
+    mask[:, :, 0] = True
+    plan_args = (
+        mask,
+        row_sizes.cuda(),
+        col_sizes.cuda(),
+        heads * group_size,
+        heads,
+        head_dim,
+    )
+    q = torch.randn(
+        heads * group_size, seq_len, head_dim, device="cuda", dtype=torch.float16
+    )
+    k = torch.randn(heads, seq_len, head_dim, device="cuda", dtype=torch.float16)
+    return plan_args, (q, k, torch.randn_like(k))
+
+
+def measure(wrapper, plan_args, run_args, repeat):
+    stream = torch.cuda.current_stream()
+    for _ in range(3):
+        wrapper.plan(*plan_args)
+        wrapper.run(*run_args)
+    stream.synchronize()
+    plan_times, total_times = [], []
+    for _ in range(repeat):
+        start = time.perf_counter()
+        wrapper.plan(*plan_args)
+        stream.synchronize()
+        plan_times.append((time.perf_counter() - start) * 1000)
+        start = time.perf_counter()
+        wrapper.plan(*plan_args)
+        wrapper.run(*run_args)
+        stream.synchronize()
+        total_times.append((time.perf_counter() - start) * 1000)
+    return {
+        "plan_ms": statistics.median(plan_times),
+        "plan_run_ms": statistics.median(total_times),
+        "nnz": wrapper._paged_kv_indices_buf.numel(),
+    }
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--heads", type=int, default=16)
+    parser.add_argument("--rows", type=int, default=20)
+    parser.add_argument("--cols", type=int, default=100)
+    parser.add_argument("--seq-len", type=int, default=8192)
+    parser.add_argument("--density", type=float, default=0.2)
+    parser.add_argument("--repeat", type=int, default=20)
+    args = parser.parse_args()
+    plan_args, run_args = make_case(
+        args.heads, args.rows, args.cols, args.seq_len, args.density
+    )
+    wrapper = VariableBlockSparseAttentionWrapper(
+        torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda"),
+        backend="fa2",
+    )
+    result = measure(wrapper, plan_args, run_args, args.repeat)
+    print(
+        json.dumps(
+            {
+                "gpu": torch.cuda.get_device_name(),
+                "torch": torch.__version__,
+                "cuda": torch.version.cuda,
+                **vars(args),
+                **result,
+            },
+            indent=2,
+        )
+    )

--- a/flashinfer/sparse.py
+++ b/flashinfer/sparse.py
@@ -1638,6 +1638,79 @@ class BlockSparseAttentionWrapper:
         pass
 
 
+def _build_variable_block_sparse_metadata(
+    block_mask_map: torch.Tensor,
+    block_row_sz: torch.Tensor,
+    block_col_sz: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build page-size-one CSR indices; copy only scheduler metadata to the host."""
+    device = block_mask_map.device
+    num_heads, num_rows, num_cols = block_mask_map.shape
+    zero = torch.zeros(1, dtype=torch.int64, device=device)
+    block_indptr = torch.cumsum(
+        block_mask_map * block_col_sz[:, None, :], dim=-1, dtype=torch.int64
+    )
+    qo_indptr = torch.cat(
+        [zero, torch.cumsum(block_row_sz.reshape(-1), 0, dtype=torch.int64)]
+    )
+    kv_indptr = torch.cat([zero, torch.cumsum(block_indptr[:, :, -1].reshape(-1), 0)])
+    col_indptr = torch.cumsum(block_col_sz.reshape(-1), 0, dtype=torch.int64)
+
+    # The CPU scheduler needs these two small indptr arrays. Their single
+    # blocking copy also supplies the exact allocation size, avoiding nonzero
+    # and repeat_interleave's separate device-to-host synchronization points.
+    indptr_size = num_heads * num_rows + 1
+    metadata_host = torch.cat([qo_indptr, kv_indptr, col_indptr[-1:]]).cpu()
+    q_total = int(metadata_host[indptr_size - 1])
+    nnz = int(metadata_host[2 * indptr_size - 1])
+    kv_total = int(metadata_host[-1])
+    if min(q_total, nnz, kv_total) < 0 or max(q_total, nnz, kv_total) > 2**31 - 1:
+        raise ValueError("Variable block-sparse attention indices must fit in int32")
+
+    qo_indptr_host = metadata_host[:indptr_size].to(torch.int32)
+    kv_indptr_host = metadata_host[indptr_size : 2 * indptr_size].to(torch.int32)
+    qo_indptr = qo_indptr.to(torch.int32)
+    kv_indptr = kv_indptr.to(torch.int32)
+    kv_indices = torch.empty(nnz, dtype=torch.int32, device=device)
+    if nnz:
+        kernel = None
+        if get_compute_capability(device)[0] >= 8:
+            try:
+                from .triton.sparse import _expand_variable_block_sparse_indices
+
+                kernel = _expand_variable_block_sparse_indices
+            except ModuleNotFoundError as error:
+                if error.name != "triton":
+                    raise
+        if kernel is not None:
+            with torch.cuda.device(device):
+                kernel[(num_heads * num_rows * num_cols,)](
+                    block_indptr,
+                    col_indptr,
+                    kv_indptr,
+                    kv_indices,
+                    num_rows,
+                    num_cols,
+                    BLOCK_SIZE=256,
+                )
+        else:
+            # Keep older architectures and installations without Triton usable.
+            # output_size avoids repeat_interleave's allocation-size host sync.
+            lengths = (block_mask_map * block_col_sz[:, None, :]).reshape(-1)
+            starts = torch.cumsum(lengths, 0) - lengths
+            bases = (
+                (col_indptr - block_col_sz.reshape(-1))
+                .reshape(num_heads, 1, num_cols)
+                .expand(-1, num_rows, -1)
+                .reshape(-1)
+            )
+            kv_indices = (
+                torch.repeat_interleave(bases - starts, lengths, output_size=nnz)
+                + torch.arange(nnz, device=device)
+            ).to(torch.int32)
+    return qo_indptr, kv_indptr, kv_indices, qo_indptr_host, kv_indptr_host
+
+
 class VariableBlockSparseAttentionWrapper:
     r"""Wrapper class for attention computation with a block-sparse matrix as attention mask.
     This API supports variable block sizes provided by ``block_row_sz`` and ``block_col_sz``.
@@ -1818,6 +1891,11 @@ class VariableBlockSparseAttentionWrapper:
         :meth:`run_return_lse` calls, auxiliary data structures will be created
         during this call and cached for multiple kernel runs.
 
+        Token indices are constructed on the GPU. Planning transfers only the
+        compact row pointers to the CPU scheduler and synchronizes that copy;
+        planning cannot be captured in a CUDA graph. The planned attention
+        execution remains graph-capturable.
+
         The ``num_qo_heads`` must be a multiple of ``num_kv_heads``. If ``num_qo_heads``
         is not equal to ``num_kv_heads``, the function will use
         `grouped query attention <https://arxiv.org/abs/2305.13245>`_.
@@ -1835,104 +1913,29 @@ class VariableBlockSparseAttentionWrapper:
         num_blocks_row = block_row_sz.shape[-1]
         num_blocks_col = block_col_sz.shape[-1]
 
-        # q layout: [seq_len, num_kv_heads, gqa_group_size, head_dim]
-        # padded into: [seq_len * num_kv_heads, 1, gqa_group_size, head_dim]
-        qo_indptr = torch.cat(
-            [
-                torch.zeros(1, dtype=torch.int32, device=block_row_sz.device),
-                torch.cumsum(block_row_sz.flatten(), dim=0, dtype=torch.int32),
-            ],
-            dim=0,
-        )
-        qo_indptr_host = qo_indptr.to("cpu", non_blocking=non_blocking)
-        last_block_len = torch.full(
-            (num_blocks_row * num_kv_heads,),
-            1,
-            dtype=torch.int32,
-            device=block_mask_map.device,
-        )  # We use page_size == 1 for variable length support
-
-        # HND kv layout: [num_kv_heads, num_blocks, block_size, head_dim]
-        # padded into: [num_kv_heads * num_blocks, block_size, 1, head_dim]
-        # for customized attention mask for each kv_head
-        # NOTE(Yilong): This could be perf bottleneck. Consider Triton implementation.
-        def _block_mask_map_to_expanded_indices(
-            block_mask_map: torch.Tensor,  # [H, R, C] bool / {0,1}
-            block_col_sz: torch.Tensor,  # [H, C]     int
-        ) -> Tuple[torch.Tensor, torch.Tensor]:
-            """
-            Args:
-                block_mask_map:  bool/int  [num_kv_heads, num_blocks_row, num_blocks_col]
-                block_col_sz:    int32/64  [num_kv_heads, num_blocks_col]
-            Returns:
-                kv_indptr:  [H*R + 1]  int32  —  CSR indptr
-                kv_indices: [nnz]      int32  —  token indices per (head, row)
-            """
-            device = block_mask_map.device
-            dtype_i = torch.int32
-
-            # 1) Calculate the total length of each row (head, row)
-            row_lengths = (block_mask_map * block_col_sz[:, None, :]).sum(-1)  # [H,R]
-            kv_indptr = torch.cat(
-                [
-                    torch.zeros(1, dtype=dtype_i, device=device),
-                    torch.cumsum(row_lengths.flatten(), 0),
-                ],
-                dim=0,
-            )
-
-            # 2) Calculate the offset of each column block within its head
-            col_offset = (
-                torch.cumsum(block_col_sz.to(dtype_i), 1) - block_col_sz
-            )  # [H,C]
-            head_len = block_col_sz.sum(1, dtype=dtype_i)
-            head_offset = torch.cumsum(head_len, 0) - head_len
-
-            # 3) Find all selected (h,r,c)
-            h_idx, r_idx, c_idx = block_mask_map.nonzero(as_tuple=True)
-            lengths = block_col_sz[h_idx, c_idx].to(dtype_i)  # [N]
-            base = head_offset[h_idx] + col_offset[h_idx, c_idx]  # [N]
-
-            # 4) Expand variable-length column blocks into token-level indices
-            cum = torch.cumsum(lengths, 0)
-            starts = torch.repeat_interleave(cum - lengths, lengths)  # [total]
-            offsets_within = torch.arange(cum[-1], device=device) - starts
-            kv_indices = torch.repeat_interleave(base, lengths) + offsets_within
-
-            return kv_indptr.to(dtype=dtype_i, device=device), kv_indices.to(
-                dtype=dtype_i, device=device
-            )
-
-        kv_indptr, kv_indices = _block_mask_map_to_expanded_indices(
-            block_mask_map, block_col_sz
-        )
-        kv_indptr_host = kv_indptr.to("cpu", non_blocking=non_blocking)
-        kv_indices_host = kv_indices.to("cpu", non_blocking=non_blocking)
-
-        self._qo_indptr = qo_indptr.to(self.device, non_blocking=non_blocking)
-        self._paged_kv_indptr_buf = kv_indptr.to(self.device, non_blocking=non_blocking)
-        self._paged_kv_indices_buf = kv_indices.to(
-            self.device, non_blocking=non_blocking
-        )
-        self._paged_kv_last_page_len = last_block_len.to(
-            self.device, non_blocking=non_blocking
-        )
-        torch.cuda.synchronize()  # for non-blocking copy
-        self._mask_mode = MaskMode.CAUSAL.value if causal else MaskMode.NON_CAUSAL.value
-
-        # Sanity check
         assert num_qo_heads % num_kv_heads == 0, (
             "num_qo_heads must be a multiple of num_kv_heads"
         )
-        assert num_blocks_row * num_kv_heads + 1 == kv_indptr_host.shape[0]
-        assert kv_indptr_host[-1].item() == kv_indices_host.shape[0], (
-            f"{kv_indptr_host[-1].item()} != {kv_indices_host.shape[0]}"
+        assert block_mask_map.shape == (num_kv_heads, num_blocks_row, num_blocks_col)
+        assert block_row_sz.shape == (num_kv_heads, num_blocks_row)
+        assert block_col_sz.shape == (num_kv_heads, num_blocks_col)
+
+        (
+            self._qo_indptr,
+            self._paged_kv_indptr_buf,
+            self._paged_kv_indices_buf,
+            qo_indptr_host,
+            kv_indptr_host,
+        ) = _build_variable_block_sparse_metadata(
+            block_mask_map.to(self.device, non_blocking=non_blocking),
+            block_row_sz.to(self.device, non_blocking=non_blocking),
+            block_col_sz.to(self.device, non_blocking=non_blocking),
         )
-        assert num_kv_heads == block_mask_map.shape[0]
-        assert num_kv_heads == block_row_sz.shape[0]
-        assert num_kv_heads == block_col_sz.shape[0]
-        assert num_blocks_row == block_mask_map.shape[1]
-        assert num_blocks_col == block_mask_map.shape[2]
+        # Page size one represents variable column-block lengths.
+        self._paged_kv_last_page_len = torch.ones(
+            num_blocks_row * num_kv_heads, dtype=torch.int32, device=self.device
+        )
+        self._mask_mode = MaskMode.CAUSAL.value if causal else MaskMode.NON_CAUSAL.value
 
         if self._backend == "auto":
             self._backend = determine_attention_backend(

--- a/flashinfer/triton/sparse.py
+++ b/flashinfer/triton/sparse.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _expand_variable_block_sparse_indices(
+    block_indptr,
+    col_indptr,
+    kv_indptr,
+    kv_indices,
+    NUM_ROWS: tl.constexpr,
+    NUM_COLS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    block = tl.program_id(0)
+    row = block // NUM_COLS
+    col = block % NUM_COLS
+    head = row // NUM_ROWS
+    block_end = tl.load(block_indptr + row * NUM_COLS + col)
+    block_start = tl.load(block_indptr + row * NUM_COLS + col - 1, col > 0, other=0)
+    length = block_end - block_start
+    if length > 0:
+        col_idx = head * NUM_COLS + col
+        source_start = tl.load(col_indptr + col_idx - 1, col_idx > 0, other=0)
+        dest_start = tl.load(kv_indptr + row).to(tl.int64) + block_start
+        for start in tl.range(0, length, BLOCK_SIZE):
+            offsets = start + tl.arange(0, BLOCK_SIZE)
+            tl.store(
+                kv_indices + dest_start + offsets,
+                source_start + offsets,
+                offsets < length,
+            )

--- a/tests/attention/test_variable_block_sparse_planning.py
+++ b/tests/attention/test_variable_block_sparse_planning.py
@@ -1,0 +1,182 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from flashinfer.sparse import VariableBlockSparseAttentionWrapper
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("group_size", [1, 4])
+@pytest.mark.parametrize("metadata_device", ["cpu", "cuda"])
+@pytest.mark.parametrize("non_blocking", [False, True])
+def test_variable_sparse_plan_matches_dense(
+    dtype, group_size, metadata_device, non_blocking
+):
+    torch.manual_seed(123)
+    row_sizes = torch.tensor([[3, 0, 5, 9], [7, 4, 0, 6]], dtype=torch.int32)
+    col_sizes = torch.tensor(
+        [[0, 1, 257, 3, 2], [128, 0, 4, 130, 1]], dtype=torch.int32
+    )
+    pattern = torch.tensor(
+        [
+            [[0, 1, 1, 0, 0], [1, 1, 1, 1, 1], [0, 0, 0, 0, 0], [0, 1, 0, 1, 1]],
+            [[1, 0, 0, 0, 1], [0, 1, 1, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 1, 1]],
+        ],
+        dtype=torch.bool,
+    )
+    # Preserve non-contiguous mask and size inputs.
+    mask_storage = torch.empty((2, 4, 10), dtype=torch.bool, device=metadata_device)
+    mask = mask_storage[..., ::2]
+    mask.copy_(pattern)
+    size_storage = torch.empty((2, 10), dtype=torch.int64, device=metadata_device)
+    cols = size_storage[:, ::2]
+    cols.copy_(col_sizes)
+    rows = row_sizes.to(metadata_device)
+
+    wrapper = VariableBlockSparseAttentionWrapper(
+        torch.empty(32 * 1024 * 1024, dtype=torch.uint8, device="cuda"),
+        backend="fa2",
+    )
+    q = torch.randn(2 * group_size, 17, 64, dtype=dtype, device="cuda")
+    k = torch.randn(2, 263, 64, dtype=dtype, device="cuda")
+    v = torch.randn_like(k)
+
+    # Replanning must replace the pattern even when tensor shapes stay fixed.
+    for changed in (False, True):
+        expected_pattern = pattern.clone()
+        if changed:
+            expected_pattern[:, :, 0] = True
+            mask.copy_(expected_pattern)
+        wrapper.plan(
+            mask,
+            rows,
+            cols,
+            2 * group_size,
+            2,
+            64,
+            q_data_type=dtype,
+            non_blocking=non_blocking,
+        )
+        expected_indices = []
+        expected_indptr = [0]
+        for head in range(2):
+            for row in range(4):
+                offset = head * 263
+                for col, length in enumerate(col_sizes[head].tolist()):
+                    if expected_pattern[head, row, col]:
+                        expected_indices.extend(range(offset, offset + length))
+                    offset += length
+                expected_indptr.append(len(expected_indices))
+        torch.testing.assert_close(
+            wrapper._paged_kv_indices_buf.cpu(),
+            torch.tensor(expected_indices, dtype=torch.int32),
+        )
+        torch.testing.assert_close(
+            wrapper._paged_kv_indptr_buf.cpu(),
+            torch.tensor(expected_indptr, dtype=torch.int32),
+        )
+
+        output = wrapper.run(q, k, v)
+        for head in range(2):
+            dense_mask = (
+                expected_pattern[head]
+                .repeat_interleave(row_sizes[head].long(), dim=0)
+                .repeat_interleave(col_sizes[head].long(), dim=1)
+                .to("cuda")
+            )
+            reference = F.scaled_dot_product_attention(
+                q[head * group_size : (head + 1) * group_size].float(),
+                k[head : head + 1].float(),
+                v[head : head + 1].float(),
+                attn_mask=dense_mask,
+            ).to(dtype)
+            torch.testing.assert_close(
+                output[head * group_size : (head + 1) * group_size],
+                reference,
+                atol=2e-2,
+                rtol=2e-2,
+            )
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = wrapper.run(q, k, v)
+    q.add_(0.125)
+    expected = wrapper.run(q, k, v)
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(captured, expected)
+
+
+def test_variable_sparse_plan_empty_mask():
+    wrapper = VariableBlockSparseAttentionWrapper(
+        torch.empty(32 * 1024 * 1024, dtype=torch.uint8, device="cuda"),
+        backend="fa2",
+    )
+    wrapper.plan(
+        torch.zeros((2, 3, 4), dtype=torch.bool, device="cuda"),
+        torch.tensor([[2, 3, 4], [4, 3, 2]], dtype=torch.int32, device="cuda"),
+        torch.ones((2, 4), dtype=torch.int32, device="cuda"),
+        2,
+        2,
+        64,
+    )
+    assert wrapper._paged_kv_indices_buf.numel() == 0
+    torch.testing.assert_close(
+        wrapper._paged_kv_indptr_buf,
+        torch.zeros(7, dtype=torch.int32, device="cuda"),
+    )
+
+
+def test_variable_sparse_plan_torch_fallback(monkeypatch):
+    import flashinfer.sparse
+
+    monkeypatch.setattr(flashinfer.sparse, "get_compute_capability", lambda _: (7, 5))
+    test_variable_sparse_plan_matches_dense(torch.float16, 4, "cuda", True)
+
+
+def test_variable_sparse_plan_wide_block_map():
+    from flashinfer.sparse import _build_variable_block_sparse_metadata
+
+    cols = 65536
+    mask = torch.zeros((1, 1, cols), dtype=torch.bool, device="cuda")
+    mask[:, :, ::1000] = True
+    _, indptr, indices, _, _ = _build_variable_block_sparse_metadata(
+        mask,
+        torch.ones((1, 1), dtype=torch.int32, device="cuda"),
+        torch.ones((1, cols), dtype=torch.int32, device="cuda"),
+    )
+    torch.testing.assert_close(
+        indices, torch.arange(0, cols, 1000, dtype=torch.int32, device="cuda")
+    )
+    assert indptr[-1].item() == indices.numel()
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Requires two CUDA devices")
+def test_variable_sparse_plan_noncurrent_device():
+    from flashinfer.sparse import _build_variable_block_sparse_metadata
+
+    with torch.cuda.device(0):
+        result = _build_variable_block_sparse_metadata(
+            torch.tensor([[[True, False, True]]], device="cuda:1"),
+            torch.tensor([[2]], dtype=torch.int32, device="cuda:1"),
+            torch.tensor([[2, 3, 1]], dtype=torch.int32, device="cuda:1"),
+        )
+        assert torch.cuda.current_device() == 0
+        torch.testing.assert_close(
+            result[2],
+            torch.tensor([0, 1, 5], dtype=torch.int32, device="cuda:1"),
+        )


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Repeated calls to VariableBlockSparseAttentionWrapper.plan() currently expand dynamic block masks through nonzero/repeat_interleave, then copy the full expanded token-index array to the host. For the reported dynamic sparse attention workload, these synchronizations and transfers contribute directly to planning latency.

Build prefix sums on the GPU and expand selected variable-sized blocks with a Triton kernel. Copy only compact row pointers and allocation totals for the existing CPU scheduler. Keep a PyTorch fallback for older architectures or installations without Triton, and preserve the public API and attention backend dispatch.

Measured against exact main baseline 715c3c9f15af2ffbf14068fabcb1f39af19c47dd on an RTX 3090 (SM86), PyTorch 2.13.0+cu130 / CUDA 13.0 / Triton 3.7.1, FA2, FP16, head_dim=64 and GQA group size=4. Values are medians of 15 alternating A/B rounds after three warmups, measured with host timers and stream synchronization. Both variants use identical inputs and unchanged warmed attention modules. Density is the mask sampling probability; the first column is always selected.

| KV heads | Block grid | Q/KV length | Density | Plan ms: before → after | Reduction | Plan+run ms: before → after | Reduction |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 4 | 20×100 | 4096 | 0.2 | 0.924 → 0.492 | 46.8% | 1.368 → 0.931 | 32.0% |
| 16 | 20×100 | 8192 | 0.2 | 1.423 → 0.859 | 39.6% | 5.891 → 5.324 | 9.6% |
| 16 | 64×128 | 32768 | 0.2 | 5.723 → 2.376 | 58.5% | 63.115 → 60.215 | 4.6% |
| 4 | 20×100 | 4096 | 0.8 | 1.270 → 0.608 | 52.1% | 2.382 → 1.735 | 27.1% |

For the 16-head, 20×100-block, length-8192 case, a CUDA profiler trace records DtoH transfers dropping from 9 calls / 2,175,474 bytes to 1 call / 5,144 bytes. These are planning and plan+run measurements, not full SVG2 model benchmarks.

The added benchmark can be run on both revisions:

~~~bash
python benchmarks/bench_variable_block_sparse_plan.py --heads 16 --rows 20 --cols 100 --seq-len 8192 --density 0.2 --repeat 20
~~~

## 🔍 Related Issues

Addresses #2938.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

- Validated scope: 29 passed on RTX 3090, comprising all 20 new planning tests and 9 existing variable-block sparse attention cases selected across sequence lengths 256/4096/8192, densities 0.2/0.7/0.9, head dimensions 64/128 and GQA configurations.
- Exact CSR checks and dense SDPA comparisons cover FP16/BF16, uneven and zero-length blocks, an empty attention row, strided inputs, CPU/GPU metadata, replanning and graph replay. Separate cases cover an all-empty mask, a 65536-column block map, fallback and a non-current CUDA device.
- Compute Sanitizer memcheck: 19 passed, 1 skipped (only one GPU visible), 0 errors.
- Full pre-commit hooks passed. The complete repository test suite and upstream CI have not been run.

~~~bash
python -m pytest -q tests/attention/test_variable_block_sparse_planning.py
compute-sanitizer --tool memcheck --error-exitcode 86 python -m pytest -q tests/attention/test_variable_block_sparse_planning.py
pre-commit run --all-files
~~~

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

Planning still requires a CPU scheduler and a blocking metadata copy; it is not CUDA-graph-capturable. The planned run path remains graph-capturable. No public API or attention compute kernel changes are introduced.

SM86/FA2 was tested; Hopper/FA3 and physical SM75 hardware were not. The PyTorch fallback was exercised by overriding the capability query on SM86. Implementation and validation were performed with Codex assistance. Review focus: expansion offsets, device/stream ordering, and fallback compatibility.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved variable block-sparse attention planning efficiency, including reduced data transfer overhead.
  - Added optimized GPU processing for sparse attention metadata.

- **Compatibility**
  - Improved support for different GPU configurations and large sparse attention layouts.
  - Preserved CUDA graph capture and replay support for attention execution.

- **Testing**
  - Expanded coverage for replanning, empty sparse masks, fallback processing, multi-device usage, and CUDA graph execution.

- **Benchmarking**
  - Added configurable performance benchmarks for variable block-sparse attention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->