### PR TITLE
fix(mla): bound the MLA plan work list instead of assuming 16384

### DIFF
--- a/include/flashinfer/attention/scheduler.cuh
+++ b/include/flashinfer/attention/scheduler.cuh
@@ -1622,9 +1622,11 @@ inline cudaError_t MLAPlan(void* float_buffer, size_t float_workspace_size_in_by
   int cluster_tile_q = cluster_size * cta_tile_q;
 
   int64_t total_kv_lens = 0;
+  int64_t total_num_qo_tiles = 0;
   for (auto& [_, qo_len, kv_len] : idx_qo_kv_len_vec) {
     int packed_qo_len = qo_len * num_heads;
     int num_qo_tiles = ceil_div(packed_qo_len, cluster_tile_q);
+    total_num_qo_tiles += num_qo_tiles;
     for (int qo_tile_idx = num_qo_tiles - 1; qo_tile_idx >= 0; --qo_tile_idx) {
       int effective_kv_len = causal ? packed_causal_kv_end(qo_len, kv_len, qo_tile_idx,
                                                            cluster_tile_q, num_qo_tiles, num_heads)
@@ -1738,13 +1740,30 @@ inline cudaError_t MLAPlan(void* float_buffer, size_t float_workspace_size_in_by
                    "Internal Error: merge_cta_counter should be less than or equal to num_sm, "
                    "please report this bug to the developers");
 
-  int max_total_num_works = 16384;  // NOTE(Zihao): adjust it later
+  // Upper bound on total_num_works, so the per-work plan arrays below are always large enough.
+  //
+  // The loop above emits max(ceil_div(remaining_len, kv_len_limit), 1) works per (request, q tile),
+  // and ceil_div(a, b) <= a / b + 1, so
+  //
+  //   total_num_works <= sum(remaining_len) / kv_len_limit + total_num_qo_tiles
+  //
+  // sum(remaining_len) is total_kv_lens, and kv_len_limit >= ceil_div(total_kv_lens, num_clusters)
+  // because f() is non-shrinking, so the first term is at most num_clusters.
+  //
+  // The 16384 floor is what this used to allocate unconditionally. Keeping it means every problem
+  // that fits today keeps the exact plan-info offsets it has now, which matters because a captured
+  // CUDA graph reuses the int workspace across replans.
+  int max_total_num_works = static_cast<int>(
+      std::max<int64_t>(16384, total_num_qo_tiles + static_cast<int64_t>(num_clusters)));
 
   std::vector<IdType> work_indptr_vec(num_clusters + 1, 0);
   for (uint32_t i = 0; i < num_clusters; ++i) {
     work_indptr_vec[i + 1] = work_indptr_vec[i] + cluster_q_indptr[i].size();
   }
   int total_num_works = work_indptr_vec.back();
+  FLASHINFER_CHECK(total_num_works <= max_total_num_works,
+                   "Internal Error: total_num_works should be less than or equal to "
+                   "max_total_num_works, please report this bug to the developers");
   auto q_indptr_vec = flatten(cluster_q_indptr, total_num_works);
   auto kv_indptr_vec = flatten(cluster_kv_indptr, total_num_works);
   auto partial_indptr_vec = flatten(cluster_partial_indptr, total_num_works);

--- a/tests/attention/test_deepseek_mla.py
+++ b/tests/attention/test_deepseek_mla.py
@@ -1670,3 +1670,64 @@ if __name__ == "__main__":
     #     155, 1024, 8, 128, 128, 16, False, 1, "fa3", torch.half
     # )
     # test_batch_mla_page_attention(1, 1024, 128, 128, False, 1, "fa2", True, torch.half)
+
+
+def test_batch_mla_work_list_exceeding_plan_capacity():
+    """MLAPlan sizes its per-work arrays from an upper bound on the work list.
+    When that bound was a hardcoded 16384 with no check, a batch producing more
+    works than that scattered the tail of the plan past the end of those arrays:
+    silently wrong output just past the limit, illegal memory access further up.
+
+    Every request here is identical and shares the same pages, so all rows of
+    the output must be equal. Works are one per request for this shape, so the
+    batch size is what crosses the old limit."""
+    torch.manual_seed(0)
+    device = torch.device("cuda:0")
+    batch_size, qo_len, kv_len, page_size = 16600, 1, 4, 1
+    num_heads = 16
+    num_pages = kv_len // page_size
+
+    q_nope = torch.randn(
+        1, num_heads, HEAD_DIM_CKV, device=device, dtype=torch.bfloat16
+    ).expand(batch_size, num_heads, HEAD_DIM_CKV)
+    q_pe = torch.randn(
+        1, num_heads, HEAD_DIM_KPE, device=device, dtype=torch.bfloat16
+    ).expand(batch_size, num_heads, HEAD_DIM_KPE)
+    ckv = torch.randn(
+        num_pages, page_size, HEAD_DIM_CKV, device=device, dtype=torch.bfloat16
+    )
+    kpe = torch.randn(
+        num_pages, page_size, HEAD_DIM_KPE, device=device, dtype=torch.bfloat16
+    )
+
+    qo_indptr = (
+        torch.arange(0, batch_size + 1, device=device, dtype=torch.int32) * qo_len
+    )
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, device=device, dtype=torch.int32) * num_pages
+    )
+    kv_indices = torch.arange(num_pages, device=device, dtype=torch.int32).repeat(
+        batch_size
+    )
+    kv_len_arr = torch.full((batch_size,), kv_len, device=device, dtype=torch.int32)
+
+    workspace = torch.empty(256 * 1024 * 1024, dtype=torch.int8, device=device)
+    wrapper = flashinfer.mla.BatchMLAPagedAttentionWrapper(workspace, backend="fa2")
+    wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_len_arr,
+        num_heads,
+        HEAD_DIM_CKV,
+        HEAD_DIM_KPE,
+        page_size,
+        causal=False,
+        sm_scale=1.0 / math.sqrt(HEAD_DIM_CKV + HEAD_DIM_KPE),
+        q_data_type=torch.bfloat16,
+        kv_data_type=torch.bfloat16,
+    )
+    o = wrapper.run(q_nope.contiguous(), q_pe.contiguous(), ckv, kpe)
+
+    torch.testing.assert_close(o, o[0].unsqueeze(0).expand_as(o), rtol=0, atol=0)
+    clear_cuda_cache(device)


### PR DESCRIPTION
MLAPlan allocated its per-work plan arrays from a hardcoded max_total_num_works of 16384 and never checked total_num_works against it, so a batch producing more works than that wrote past the end of eight arrays. On an RTX 3050 with num_heads=16 and qo_len=1 that is correct output at batch 16384, one silently wrong row at 16385, 216 wrong rows at 16600, and CUDA_ERROR_ILLEGAL_ADDRESS from 17000 up.

Derive the bound instead. The scheduling loop emits max(ceil_div(remaining_len, kv_len_limit), 1) works per request and q tile, and kv_len_limit is at least ceil_div(total_kv_lens, num_clusters), so total_num_works is at most total_num_qo_tiles + num_clusters. Keep 16384 as a floor so every problem that fits today keeps the plan-info offsets it has now, which a captured CUDA graph depends on, and add the same FLASHINFER_CHECK that TwoStageHolisticPlan already has.

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MLA attention planning for very large batches, including workloads exceeding the previous work-list capacity boundary.
  - Added safeguards to size planning capacity based on the workload, reducing the risk of planning failures during large-scale attention operations.
  - Ensured attention results remain consistent when many requests share paged key-value data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->