### PR TITLE
fix(comm): fence DCP receiver unpack before async output copy

### DIFF
--- a/csrc/nv_internal/tensorrt_llm/kernels/helixAllToAll.cu
+++ b/csrc/nv_internal/tensorrt_llm/kernels/helixAllToAll.cu
@@ -454,6 +454,10 @@ __global__ void helixAllToAllKernel(HelixAllToAllParams params) {
       LL128Proto::protoUnpack(shmem, tail, singlePacked128ByteCount, fifoEntry128ByteIndexBase,
                               loaded128ByteCount, laneId);
 
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+      asm volatile("fence.proxy.async.shared::cta;" : : : "memory");
+      __syncwarp();
+#endif
       // note: fields are already unpacked in shared memory
       s2gAllFields<ALLOW_VARIABLE_FIELD1>(params.recvFields, dataIndex, shmem, laneId);
       // wait for data to be read from shared memory


### PR DESCRIPTION
## 📌 Description

Order the LL128 receiver's shared-memory unpack stores before its asynchronous shared-to-global output copy.

In `helixAllToAllKernel`, `LL128Proto::protoUnpack` restores payload words over protocol flags using generic shared-memory stores. Its `__syncwarp()` orders the warp's generic accesses, but does not establish visibility to the async proxy used by `cp_async_bulk_s2g` in `s2gAllFields`.

Add `fence.proxy.async.shared::cta` on each receiver lane, then synchronize the warp before lane 0 issues the bulk copy. This follows the [PTX generic/async proxy ordering requirement](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#asynchronous-data-movement-async-proxy). No block-wide barrier is introduced into the divergent sender/receiver paths.

## 🔍 Related Issues

The affected kernel was introduced in #2951. No separate issue filed.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

Ran `pre-commit run --files csrc/nv_internal/tensorrt_llm/kernels/helixAllToAll.cu`: all applicable checks passed. The full-repository hook sweep was not run.

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

No standalone failing reproducer or new unit test is included. No full upstream-suite pass is claimed. A compact reproducer that reliably exposes the missing proxy ordering is still needed for a red/green regression test.

## Reviewer Notes

This is a four-line memory-ordering correctness change, not a performance claim. Please focus on generic-to-async shared-memory ordering and the all-lane fence followed by the warp rendezvous. The rationale above is based on the public kernel implementation and PTX specification; no private workload data or logs are attached.

AI-assisted patch preparation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data synchronization during communication operations on newer NVIDIA GPU architectures, helping ensure received data is read correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->