### PR TITLE
bench: add GLM-5 and Kimi K3 MoE presets

### DIFF
--- a/benchmarks/bench_moe_deepseek.py
+++ b/benchmarks/bench_moe_deepseek.py
@@ -14,6 +14,8 @@ Usage:
     python bench_moe_deepseek.py --model kimi-k3 --ep 8
     # Kimi K3 compares NVFP4 experiments, not its native MXFP4 checkpoint.
     # TRTLLM BF16 is omitted because its kernels do not support SiTU.
+    # TRTLLM NVFP4 is also omitted with --use-per-token-activation: its SiTU
+    # kernels do not support per-token scaling.
 
     # Throughput benchmark (large batches: 128-4096 tokens)
     python bench_moe_deepseek.py
@@ -183,7 +185,7 @@ def _make_routing(inputs):
     return route
 
 
-def _select_backends(backends):
+def _select_backends(backends, use_per_token_activation=False):
     selected = (
         set(backends)
         if backends is not None
@@ -193,6 +195,13 @@ def _select_backends(backends):
         selected.add("trtllm-bf16")
     if "trtllm-bf16" in selected and CFG.situ_beta is not None:
         raise ValueError("TRTLLM BF16 does not support the Kimi K3 SiTU activation")
+    if CFG.situ_beta is not None and use_per_token_activation:
+        if backends is None:
+            selected.discard("trtllm-nvfp4")
+        elif "trtllm-nvfp4" in selected:
+            raise ValueError(
+                "TRTLLM NVFP4 does not support SiTU with per-token activation scaling"
+            )
     return selected
 
 
@@ -824,6 +833,7 @@ def bench_trtllm(
             and weights without quantization; FP4 activation flags do not
             affect it.
     """
+    _select_backends([f"trtllm-{precision}"], use_per_token_activation)
     from flashinfer.fused_moe import RoutingMethodType
     from flashinfer.tllm_enums import ActivationType
     from flashinfer.fused_moe.da_tuner import (
@@ -854,8 +864,6 @@ def bench_trtllm(
     )
 
     if precision == "bf16":
-        if CFG.situ_beta is not None:
-            raise ValueError("TRTLLM BF16 does not support the Kimi K3 SiTU activation")
         from flashinfer.fused_moe import (
             TrtllmBf16Config,
             trtllm_bf16_moe,
@@ -1172,9 +1180,9 @@ def run_benchmark(
     Returns:
         List of BenchResult objects
     """
-    _select_backends(backends)
-    if profile_backend == "trtllm-bf16" and CFG.situ_beta is not None:
-        raise ValueError("TRTLLM BF16 does not support the Kimi K3 SiTU activation")
+    _select_backends(backends, use_per_token_activation)
+    if profile_backend is not None:
+        _select_backends([profile_backend], use_per_token_activation)
     if tp_config < 1 or BASE_INTERMEDIATE_SIZE % tp_config != 0:
         raise ValueError(
             f"tp_config must be a positive divisor of {BASE_INTERMEDIATE_SIZE}"
@@ -1279,7 +1287,7 @@ def _benchmark_single(
     inputs = create_inputs(n, routing_bias_scale=routing_bias_scale)
     histogram_record = _collect_expert_histogram(inputs, num_local, local_offset)
 
-    selected = _select_backends(backends)
+    selected = _select_backends(backends, use_per_token_activation)
     run_cute_dsl_w4a4 = "cutedsl" in selected and profile_backend in (
         None,
         "cute-dsl",
@@ -1806,11 +1814,11 @@ def main():
     if args.profile_backend == "cutlass" and args.use_per_token_activation:
         parser.error("CUTLASS does not consume the per-token activation scale")
     try:
-        _select_backends(backends)
+        selected = _select_backends(backends, args.use_per_token_activation)
+        if args.profile_backend is not None:
+            _select_backends([args.profile_backend], args.use_per_token_activation)
     except ValueError as exc:
         parser.error(str(exc))
-    if args.profile_backend == "trtllm-bf16" and CFG.situ_beta is not None:
-        parser.error("TRTLLM BF16 does not support the Kimi K3 SiTU activation")
     if not is_sm100_family():
         print("ERROR: Requires SM100 family GPU (Blackwell: SM100, SM103)")
         return 1
@@ -1841,9 +1849,20 @@ def main():
     print(f"CuteDSL API: {'Functional' if args.functional_api else 'Wrapper'}")
     print(f"Per-token activation: {args.use_per_token_activation}")
     print(f"Initial activation quantization: {args.include_activation_quant}")
+    backend_names = {
+        "cutedsl": "CuteDSL W4A4 and CuteDSL W4A16",
+        "cutlass": "CUTLASS",
+        "trtllm-nvfp4": "TRTLLM NVFP4",
+        "trtllm-bf16": "TRTLLM BF16",
+    }
     print(
-        "CuteDSL modes: W4A4 and W4A16; baselines: TRTLLM NVFP4"
-        + (" and TRTLLM BF16" if CFG.situ_beta is None else "")
+        "Backends: "
+        + ", ".join(
+            name
+            for backend, name in backend_names.items()
+            if backend in selected
+            and not (backend == "cutlass" and args.use_per_token_activation)
+        )
     )
     if CFG.situ_beta is not None:
         print(
@@ -1851,6 +1870,10 @@ def main():
             f"linear beta={CFG.situ_linear_beta:g})"
         )
         print("TRTLLM BF16 omitted: its kernels do not support SiTU.")
+        if args.use_per_token_activation:
+            print(
+                "TRTLLM NVFP4 omitted: its SiTU kernels do not support per-token activation scaling."
+            )
         print(
             "Kimi K3 scope: routed latent experts only; NVFP4 experiments, not native MXFP4."
         )
@@ -1878,9 +1901,15 @@ def main():
         f"{'atomic fused' if args.use_fused_finalize else 'deterministic two-stage'}"
     )
 
-    print(
-        "TRTLLM NVFP4 / TRTLLM BF16 finalize: native (unaffected by --no-fused-finalize)."
-    )
+    trtllm_names = [
+        name
+        for backend, name in backend_names.items()
+        if backend in selected and backend.startswith("trtllm-")
+    ]
+    if trtllm_names:
+        print(
+            f"{' / '.join(trtllm_names)} finalize: native (unaffected by --no-fused-finalize)."
+        )
 
     run_benchmark(
         token_counts=tokens,

--- a/benchmarks/bench_moe_deepseek.py
+++ b/benchmarks/bench_moe_deepseek.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""DeepSeek-V3 MoE Performance Benchmark - CuteDSL vs CUTLASS vs TRTLLM.
+"""MoE Performance Benchmark - CuteDSL vs CUTLASS vs TRTLLM.
 
-Compares NVFP4 and BF16 MoE backends on DeepSeek-V3 configuration:
+Compares NVFP4 and BF16 MoE backends on DeepSeek-V3, GLM-5, and Kimi K3 shapes:
 - CuteDSL W4A4: NVFP4 activations and weights
 - CuteDSL W4A16: BF16 activations with NVFP4 weights decoded online
 - CUTLASS: NVIDIA CUTLASS-based implementation
@@ -9,6 +9,12 @@ Compares NVFP4 and BF16 MoE backends on DeepSeek-V3 configuration:
 - TRTLLM BF16: unquantized BF16 activations and weights
 
 Usage:
+    # Model presets (Kimi K3 uses its routed latent width and SiTU activation)
+    python bench_moe_deepseek.py --model glm5 --ep 8
+    python bench_moe_deepseek.py --model kimi-k3 --ep 8
+    # Kimi K3 compares NVFP4 experiments, not its native MXFP4 checkpoint.
+    # TRTLLM BF16 is omitted because its kernels do not support SiTU.
+
     # Throughput benchmark (large batches: 128-4096 tokens)
     python bench_moe_deepseek.py
 
@@ -66,13 +72,14 @@ import argparse
 import contextlib
 import gc
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import numpy as np
 import torch
 
 
 @dataclass
-class DeepSeekConfig:
+class MoEConfig:
+    name: str = "DeepSeek-V3"
     hidden_size: int = 7168
     intermediate_size: int = 2048
     num_experts: int = 256
@@ -80,26 +87,113 @@ class DeepSeekConfig:
     topk_group: int = 4
     top_k: int = 8
     routed_scaling_factor: float = 2.5
+    situ_beta: float | None = None
+    situ_linear_beta: float | None = None
 
 
-CFG = DeepSeekConfig()
+MODEL_CONFIGS = {
+    "deepseek-v3": MoEConfig(),
+    # https://huggingface.co/zai-org/GLM-5/blob/c183ef8c61faee82855eca1ed9bb3a9a7ce3b0b2/config.json
+    "glm5": MoEConfig(name="GLM-5", hidden_size=6144, n_group=1, topk_group=1),
+    # https://huggingface.co/moonshotai/Kimi-K3/blob/f831ab66814297da540d832a5235f8e904f29d06/config.json
+    "kimi-k3": MoEConfig(
+        name="Kimi K3",
+        hidden_size=3584,
+        intermediate_size=3072,
+        num_experts=896,
+        n_group=1,
+        topk_group=1,
+        top_k=16,
+        routed_scaling_factor=1.0,
+        situ_beta=4.0,
+        situ_linear_beta=25.0,
+    ),
+}
+CFG = replace(MODEL_CONFIGS["deepseek-v3"])
 BASE_INTERMEDIATE_SIZE = CFG.intermediate_size
 TOKEN_COUNTS = [128, 256, 512, 1024, 2048, 4096]
 
 # Generation phase token counts (small batches typical in decode)
 GEN_PHASE_TOKENS = [1, 2, 4, 8, 16, 32, 64, 128]
 
-# Expert Parallelism configurations
-# EP=1: all 256 experts on single GPU
-# EP=8: 32 experts per GPU (256/8)
-# EP=16: 16 experts per GPU (256/16)
-EP_CONFIGS = {
-    1: {"num_local_experts": 256, "local_expert_offset": 0},
-    2: {"num_local_experts": 128, "local_expert_offset": 0},
-    4: {"num_local_experts": 64, "local_expert_offset": 0},
-    8: {"num_local_experts": 32, "local_expert_offset": 0},
-    16: {"num_local_experts": 16, "local_expert_offset": 0},
-}
+
+def set_model_config(model, num_experts=None):
+    """Select a fresh preset before applying EP/TP simulation."""
+    global CFG, BASE_INTERMEDIATE_SIZE
+    CFG = replace(MODEL_CONFIGS[model])
+    if num_experts is not None:
+        CFG.num_experts = num_experts
+    BASE_INTERMEDIATE_SIZE = CFG.intermediate_size
+
+
+def _make_routing(inputs):
+    """Prepare graph-stable routing; the returned call stays inside timing."""
+    if CFG.n_group == 1:
+        from flashinfer.fused_moe import RoutingMethodType
+        from flashinfer.fused_moe.core import (
+            allocate_trtllm_moe_canonical_routing,
+            canonicalize_trtllm_moe_routing_,
+        )
+
+        # The standalone DeepSeek top-k kernel cannot express these presets.
+        # Reuse TRTLLM's native router and replay outputs without reconstructing
+        # expert IDs from its permutation. The full expert range keeps every
+        # route valid; each MoE backend applies its own EP partition afterward.
+        canonical = allocate_trtllm_moe_canonical_routing(
+            inputs["router_logits"], top_k=CFG.top_k, tile_n=8
+        )
+
+        def route(router_logits, routing_bias, topk_values, topk_indices):
+            canonicalize_trtllm_moe_routing_(
+                canonical,
+                router_logits,
+                routing_bias,
+                inputs["hidden_bf16"],
+                top_k=CFG.top_k,
+                n_group=CFG.n_group,
+                topk_group=CFG.topk_group,
+                local_expert_offset=0,
+                local_num_experts=CFG.num_experts,
+                routed_scaling_factor=CFG.routed_scaling_factor,
+                routing_method_type=RoutingMethodType.DeepSeekV3,
+                use_routing_scales_on_input=False,
+                use_deep_seek_fp8=False,
+                norm_topk_prob=True,
+                enable_pdl=True,
+            )
+            # Native route weights are BF16; widen them for CuTe/CUTLASS.
+            topk_values.copy_(canonical.expert_weights)
+            topk_indices.copy_(canonical.routing_replay_ids)
+
+    else:
+        from flashinfer.fused_moe import fused_topk_deepseek
+
+        def route(router_logits, routing_bias, topk_values, topk_indices):
+            fused_topk_deepseek(
+                scores=router_logits,
+                bias=routing_bias,
+                n_group=CFG.n_group,
+                topk_group=CFG.topk_group,
+                topk=CFG.top_k,
+                routed_scaling_factor=CFG.routed_scaling_factor,
+                topk_values=topk_values,
+                topk_indices=topk_indices,
+            )
+
+    return route
+
+
+def _select_backends(backends):
+    selected = (
+        set(backends)
+        if backends is not None
+        else {"cutedsl", "cutlass", "trtllm-nvfp4"}
+    )
+    if backends is None and CFG.situ_beta is None:
+        selected.add("trtllm-bf16")
+    if "trtllm-bf16" in selected and CFG.situ_beta is not None:
+        raise ValueError("TRTLLM BF16 does not support the Kimi K3 SiTU activation")
+    return selected
 
 
 def _autotune_context(do_autotune, cache):
@@ -373,7 +467,6 @@ def bench_cute_dsl(
         profile_iters: Number of cold-L2 graph replays to capture.
     """
     from flashinfer import SfLayout, nvfp4_quantize
-    from flashinfer.fused_moe import fused_topk_deepseek
     from flashinfer.cute_dsl.utils import convert_sf_to_mma_layout
     from flashinfer.fp4_quantization import fp4_quantize
     from flashinfer.quantization.nvfp4_quantization_utils import (
@@ -469,6 +562,7 @@ def bench_cute_dsl(
 
     # Pre-convert routing bias to float32
     routing_bias_f32 = inputs["routing_bias"].float()
+    route_tokens = _make_routing(inputs)
 
     if use_wrapper:
         # Use CuteDslMoEWrapper (recommended for CUDA graph)
@@ -485,20 +579,13 @@ def bench_cute_dsl(
             local_expert_offset=local_expert_offset,
             use_fused_finalize=use_fused_finalize,
             quant_mode=quant_mode,
+            situ_beta=CFG.situ_beta,
+            situ_linear_beta=CFG.situ_linear_beta,
         )
 
         def run(x, x_sf, router_logits, routing_bias, topk_values, topk_indices):
             x, x_sf, per_token_scale = prepare_activation(x, x_sf)
-            fused_topk_deepseek(
-                scores=router_logits,
-                bias=routing_bias,
-                n_group=CFG.n_group,
-                topk_group=CFG.topk_group,
-                topk=CFG.top_k,
-                routed_scaling_factor=CFG.routed_scaling_factor,
-                topk_values=topk_values,
-                topk_indices=topk_indices,
-            )
+            route_tokens(router_logits, routing_bias, topk_values, topk_indices)
             return moe.run(
                 x=x,
                 x_sf=x_sf,
@@ -519,16 +606,7 @@ def bench_cute_dsl(
 
         def run(x, x_sf, router_logits, routing_bias, topk_values, topk_indices):
             x, x_sf, per_token_scale = prepare_activation(x, x_sf)
-            fused_topk_deepseek(
-                scores=router_logits,
-                bias=routing_bias,
-                n_group=CFG.n_group,
-                topk_group=CFG.topk_group,
-                topk=CFG.top_k,
-                routed_scaling_factor=CFG.routed_scaling_factor,
-                topk_values=topk_values,
-                topk_indices=topk_indices,
-            )
+            route_tokens(router_logits, routing_bias, topk_values, topk_indices)
             return cute_dsl_fused_moe(
                 x=x,
                 x_sf=x_sf,
@@ -548,6 +626,8 @@ def bench_cute_dsl(
                 quant_mode=quant_mode,
                 per_token_scale=per_token_scale,
                 use_fused_finalize=use_fused_finalize,
+                situ_beta=CFG.situ_beta,
+                situ_linear_beta=CFG.situ_linear_beta,
             )
 
     # Pass input tensors via input_kwargs for cold L2 cache rotation
@@ -604,7 +684,8 @@ def bench_cutlass(
     Args:
         do_autotune: See ``bench_cute_dsl`` for the autotune-scope rationale.
     """
-    from flashinfer.fused_moe import fused_topk_deepseek, cutlass_fused_moe
+    from flashinfer.fused_moe import cutlass_fused_moe
+    from flashinfer.tllm_enums import ActivationType
     from flashinfer.fp4_quantization import fp4_quantize
 
     if num_local_experts is None:
@@ -645,6 +726,7 @@ def bench_cutlass(
 
     # Pre-convert routing bias to float32
     routing_bias_f32 = inputs["routing_bias"].float()
+    route_tokens = _make_routing(inputs)
 
     # Pre-compute values that need conversion
     w1_fp4_view = w1_fp4_local.contiguous().view(torch.long)
@@ -653,20 +735,26 @@ def bench_cutlass(
     # Compute EP size from config
     ep_size = CFG.num_experts // num_local_experts
 
+    activation_kwargs = {}
+    if CFG.situ_beta is not None:
+        activation_kwargs = dict(
+            activation_type=ActivationType.Situ,
+            situ_beta=torch.full(
+                (num_local_experts,), CFG.situ_beta, dtype=torch.float32, device=dev
+            ),
+            situ_linear_beta=torch.full(
+                (num_local_experts,),
+                CFG.situ_linear_beta,
+                dtype=torch.float32,
+                device=dev,
+            ),
+        )
+
     def run(hidden, sf, router_logits, routing_bias, topk_values, topk_indices):
         if include_activation_quant:
             hidden, sf = fp4_quantize(hidden, a1_gs, sv, False, True)
         # Routing (included in timing for fair comparison with TRTLLM)
-        fused_topk_deepseek(
-            scores=router_logits,
-            bias=routing_bias,
-            n_group=CFG.n_group,
-            topk_group=CFG.topk_group,
-            topk=CFG.top_k,
-            routed_scaling_factor=CFG.routed_scaling_factor,
-            topk_values=topk_values,
-            topk_indices=topk_indices,
-        )
+        route_tokens(router_logits, routing_bias, topk_values, topk_indices)
         cutlass_fused_moe(
             hidden,
             topk_indices.to(torch.int),
@@ -679,6 +767,7 @@ def bench_cutlass(
             output=output,
             ep_size=ep_size,
             ep_rank=0,  # Simulating rank 0 of EP
+            **activation_kwargs,
         )
         return output
 
@@ -736,6 +825,7 @@ def bench_trtllm(
             affect it.
     """
     from flashinfer.fused_moe import RoutingMethodType
+    from flashinfer.tllm_enums import ActivationType
     from flashinfer.fused_moe.da_tuner import (
         RoutingRealizationFactory,
         RoutingRealizationKey,
@@ -764,6 +854,8 @@ def bench_trtllm(
     )
 
     if precision == "bf16":
+        if CFG.situ_beta is not None:
+            raise ValueError("TRTLLM BF16 does not support the Kimi K3 SiTU activation")
         from flashinfer.fused_moe import (
             TrtllmBf16Config,
             trtllm_bf16_moe,
@@ -900,6 +992,19 @@ def bench_trtllm(
         )
         logits_moe = trtllm_fp4_block_scale_moe
         routed_moe = trtllm_fp4_block_scale_routed_moe
+        if CFG.situ_beta is not None:
+            moe_kwargs.update(
+                activation_type=ActivationType.Situ,
+                gemm1_alpha=torch.full(
+                    (num_local_experts,), CFG.situ_beta, dtype=torch.float32, device=dev
+                ),
+                gemm1_beta=torch.full(
+                    (num_local_experts,),
+                    CFG.situ_linear_beta,
+                    dtype=torch.float32,
+                    device=dev,
+                ),
+            )
     else:
         raise ValueError(f"Unsupported TRTLLM precision: {precision}")
 
@@ -1027,7 +1132,7 @@ def run_benchmark(
     autotune_cache=None,
 ):
     """
-    Unified benchmark for DeepSeek-V3 MoE backends.
+    Unified benchmark for the selected MoE shape and activation preset.
 
     Autotuning runs in each backend's pre-warm step (under ``autotune(True)``)
     so the autotuner profiles all tactics on the default stream before
@@ -1067,6 +1172,9 @@ def run_benchmark(
     Returns:
         List of BenchResult objects
     """
+    _select_backends(backends)
+    if profile_backend == "trtllm-bf16" and CFG.situ_beta is not None:
+        raise ValueError("TRTLLM BF16 does not support the Kimi K3 SiTU activation")
     if tp_config < 1 or BASE_INTERMEDIATE_SIZE % tp_config != 0:
         raise ValueError(
             f"tp_config must be a positive divisor of {BASE_INTERMEDIATE_SIZE}"
@@ -1171,7 +1279,7 @@ def _benchmark_single(
     inputs = create_inputs(n, routing_bias_scale=routing_bias_scale)
     histogram_record = _collect_expert_histogram(inputs, num_local, local_offset)
 
-    selected = set(backends or ("cutedsl", "cutlass", "trtllm-nvfp4", "trtllm-bf16"))
+    selected = _select_backends(backends)
     run_cute_dsl_w4a4 = "cutedsl" in selected and profile_backend in (
         None,
         "cute-dsl",
@@ -1299,12 +1407,12 @@ def _print_header(
     print("\n" + "=" * table_width)
     if use_per_token_activation:
         print(
-            "DeepSeek-V3 MoE Benchmark: CuteDSL W4A4/W4A16 vs TRTLLM NVFP4 / TRTLLM BF16 "
+            f"{CFG.name} MoE Benchmark: CuteDSL W4A4/W4A16 vs TRTLLM NVFP4 / TRTLLM BF16 "
             f"(EP={ep_config}, TP={tp_config})"
         )
     else:
         print(
-            "DeepSeek-V3 MoE Benchmark: CuteDSL W4A4/W4A16 vs CUTLASS vs TRTLLM NVFP4 / TRTLLM BF16 "
+            f"{CFG.name} MoE Benchmark: CuteDSL W4A4/W4A16 vs CUTLASS vs TRTLLM NVFP4 / TRTLLM BF16 "
             f"(EP={ep_config}, TP={tp_config})"
         )
     print("=" * table_width)
@@ -1484,22 +1592,16 @@ def _print_footer(use_per_token_activation):
 
 
 def _collect_expert_histogram(inputs, num_local, local_offset):
-    from flashinfer.fused_moe import fused_topk_deepseek
-
     num_tokens = inputs["router_logits"].shape[0]
     dev = inputs["router_logits"].device
     topk_values = torch.empty(num_tokens, CFG.top_k, dtype=torch.float32, device=dev)
     topk_indices = torch.empty(num_tokens, CFG.top_k, dtype=torch.int32, device=dev)
 
-    fused_topk_deepseek(
-        scores=inputs["router_logits"],
-        bias=inputs["routing_bias"].float(),
-        n_group=CFG.n_group,
-        topk_group=CFG.topk_group,
-        topk=CFG.top_k,
-        routed_scaling_factor=CFG.routed_scaling_factor,
-        topk_values=topk_values,
-        topk_indices=topk_indices,
+    _make_routing(inputs)(
+        inputs["router_logits"],
+        inputs["routing_bias"].float(),
+        topk_values,
+        topk_indices,
     )
 
     expert_hist = torch.bincount(
@@ -1527,7 +1629,13 @@ def _collect_expert_histogram(inputs, num_local, local_offset):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="DeepSeek-V3 MoE Performance Benchmark"
+        description="DeepSeek-V3, GLM-5, and Kimi K3 MoE Performance Benchmark"
+    )
+    parser.add_argument(
+        "--model",
+        choices=tuple(MODEL_CONFIGS),
+        default="deepseek-v3",
+        help="MoE shape and activation preset (Kimi K3 excludes TRTLLM BF16: SiTU unsupported)",
     )
     parser.add_argument(
         "--num-tokens",
@@ -1554,13 +1662,13 @@ def main():
     parser.add_argument(
         "--num-experts",
         type=int,
-        default=CFG.num_experts,
-        help="Number of global routing experts",
+        default=None,
+        help="Override the preset number of global routing experts",
     )
     parser.add_argument(
         "--backends",
         type=str,
-        help="Comma-separated subset of cutedsl,cutlass,trtllm-nvfp4,trtllm-bf16 (default: all)",
+        help="Comma-separated subset of cutedsl,cutlass,trtllm-nvfp4,trtllm-bf16 (default: all supported by the model)",
     )
     parser.add_argument(
         "--distributions",
@@ -1652,12 +1760,13 @@ def main():
         help="Scale for random routing bias. Larger values tend to create expert imbalance.",
     )
     args = parser.parse_args()
+    set_model_config(args.model, args.num_experts)
 
     if args.tp < 1:
         parser.error("--tp must be positive")
-    if args.num_experts < 1:
+    if CFG.num_experts < 1:
         parser.error("--num-experts must be positive")
-    if args.num_experts % args.ep != 0:
+    if CFG.num_experts % args.ep != 0:
         parser.error("--ep must divide --num-experts")
     backends = None
     if args.backends:
@@ -1696,11 +1805,16 @@ def main():
             )
     if args.profile_backend == "cutlass" and args.use_per_token_activation:
         parser.error("CUTLASS does not consume the per-token activation scale")
+    try:
+        _select_backends(backends)
+    except ValueError as exc:
+        parser.error(str(exc))
+    if args.profile_backend == "trtllm-bf16" and CFG.situ_beta is not None:
+        parser.error("TRTLLM BF16 does not support the Kimi K3 SiTU activation")
     if not is_sm100_family():
         print("ERROR: Requires SM100 family GPU (Blackwell: SM100, SM103)")
         return 1
 
-    CFG.num_experts = args.num_experts
     if args.routing_input_mode == "routed" and not args.no_cuda_graph:
         os.environ["FLASHINFER_DIST_AWARE_AUTOTUNE"] = "1"
         os.environ["FLASHINFER_DA_DISTRIBUTIONS"] = ",".join(distributions)
@@ -1716,12 +1830,47 @@ def main():
         tokens = TOKEN_COUNTS  # [128, 256, 512, 1024, 2048, 4096]
     if args.profile_cuda and len(tokens) != 1:
         parser.error("--profile-cuda requires exactly one token count")
-    print("\nDeepSeek-V3 MoE Performance Benchmark")
+    print(f"\n{CFG.name} MoE Performance Benchmark")
     print(f"GPU: {torch.cuda.get_device_name(0)}")
+    print(
+        f"Shape: hidden={CFG.hidden_size}, intermediate={BASE_INTERMEDIATE_SIZE}, "
+        f"experts={CFG.num_experts}, top_k={CFG.top_k}; "
+        f"EP={args.ep} ({CFG.num_experts // args.ep} local experts), "
+        f"TP={args.tp} (local intermediate={BASE_INTERMEDIATE_SIZE // args.tp})"
+    )
     print(f"CuteDSL API: {'Functional' if args.functional_api else 'Wrapper'}")
     print(f"Per-token activation: {args.use_per_token_activation}")
     print(f"Initial activation quantization: {args.include_activation_quant}")
-    print("CuteDSL modes: W4A4 and W4A16; baselines: TRTLLM NVFP4 and TRTLLM BF16")
+    print(
+        "CuteDSL modes: W4A4 and W4A16; baselines: TRTLLM NVFP4"
+        + (" and TRTLLM BF16" if CFG.situ_beta is None else "")
+    )
+    if CFG.situ_beta is not None:
+        print(
+            f"Activation: SiTU (gate beta={CFG.situ_beta:g}, "
+            f"linear beta={CFG.situ_linear_beta:g})"
+        )
+        print("TRTLLM BF16 omitted: its kernels do not support SiTU.")
+        print(
+            "Kimi K3 scope: routed latent experts only; NVFP4 experiments, not native MXFP4."
+        )
+    else:
+        print("Activation: SwiGLU")
+    print(
+        f"Routing: groups={CFG.n_group}, top groups={CFG.topk_group}, "
+        f"scale={CFG.routed_scaling_factor}; "
+        + (
+            "native TRTLLM routing; CuTe DSL/CUTLASS also include permutation and replay casts"
+            if CFG.n_group == 1
+            else "fused DeepSeek routing"
+        )
+        + " (included in timing)"
+    )
+    if CFG.n_group == 1:
+        print(
+            "CuTe DSL/CUTLASS routing: native BF16 weights widened to FP32; "
+            "full-range router permutation and two replay copies are timed."
+        )
     print(f"Tensor parallelism simulation: TP={args.tp}")
     print(f"CUDA profiler capture: {args.profile_cuda}")
     print(

--- a/benchmarks/bench_moe_deepseek.py
+++ b/benchmarks/bench_moe_deepseek.py
@@ -1221,7 +1221,7 @@ def run_benchmark(
         gc.collect()
         torch.cuda.empty_cache()
 
-    if verbose and backends is not None:
+    if verbose and (backends is not None or CFG.situ_beta is not None):
         print("backend,tokens,latency_ms,tflops")
         for row, _ in rows_and_histograms:
             for result in row:


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

@humansand

Extend `benchmarks/bench_moe_deepseek.py` with public GLM-5 and Kimi K3 routed-MoE presets and native K3 SiTU activation. Collect inference per-tensor, inference per-token, and deterministic RL performance from 1 through 8,192 input tokens.

- **Reuse:** preserve the existing benchmark functions, shared TRTLLM precision dispatch, tuning, graph timing, and backend names. The DeepSeek-V3 preset remains the default; the new `--model` option selects a fresh configuration.

- **Backends:** GLM-5 compares CuteDSL W4A4, CuteDSL W4A16, TRTLLM NVFP4, and TRTLLM BF16. Kimi K3 compares both CuTe modes with native SiTU in all recipes and TRTLLM NVFP4 in inference per-tensor. TRTLLM BF16 lacks SiTU; TRTLLM NVFP4 lacks SiTU with per-token scaling. Explicit unsupported requests fail before benchmarking. CUTLASS is omitted from all collected sweeps to avoid its compilation cost.

- **Downloadable evidence:** [all unrounded results, complete validation logs, harnesses and reproduction instructions](https://gist.github.com/zianglih/03c74e097c8bbcb6f8a6a3979d887785). The bundle contains all 798 raw JSON measurements, all printed CSV values, the retained validation failures and the exact validation harnesses. Follow its README to reproduce the validation commands below.

### Model and activation contract

| Setting | GLM-5 | Kimi K3 |
| --- | --- | --- |
| Model hidden width | 6144 | 7168 |
| Routed expert input/output width | 6144 | 3584 (latent) |
| Routed expert intermediate width | 2048 | 3072 |
| Global / local experts at EP8 | 256 / 32 | 896 / 112 |
| Top-k / groups / selected groups | 8 / 1 / 1 | 16 / 1 / 1 |
| Normalized sigmoid route scale | 2.5 | 1.0 |
| Activation | SwiGLU | SiTU: gate beta 4, linear beta 25 |
| Logical local FC1 weights | `[32,4096,6144]` | `[112,6144,3584]` |
| Logical local FC2 weights | `[32,6144,2048]` | `[112,3584,3072]` |

- **Pinned public sources:** [GLM-5 config](https://huggingface.co/zai-org/GLM-5/blob/c183ef8c61faee82855eca1ed9bb3a9a7ce3b0b2/config.json), [GLM-5 implementation](https://github.com/huggingface/transformers/blob/415e6d2f596ef2bd44fdee4261799200a7fc02bf/src/transformers/models/glm_moe_dsa/modeling_glm_moe_dsa.py#L480), [Kimi K3 config](https://huggingface.co/moonshotai/Kimi-K3/blob/f831ab66814297da540d832a5235f8e904f29d06/config.json), and [Kimi K3 implementation](https://huggingface.co/moonshotai/Kimi-K3/blob/f831ab66814297da540d832a5235f8e904f29d06/modeling_kimi_linear.py). FC1 combines both gate and up projections. K3 uses its 3584-wide routed latent core, not the 7168-wide model states.

- **SiTU:** `4*tanh(gate/4)*sigmoid(gate) * (25*tanh(up/25))`; forward gate beta 4 and linear beta 25 to the existing backend activation controls.

- **Routing:** logits are FP32 random values; correction bias is generated in BF16 with scale 0.01. Bias affects expert selection; selected unbiased sigmoid scores are normalized and scaled. For these single-group presets, reuse TRTLLM's native canonical router with the full global expert range and tile size 8. CuTe receives the native replay expert IDs and native BF16 route weights widened to FP32, without recomputing the route probabilities. The legacy standalone DeepSeek top-k kernel remains the path for the default grouped DeepSeek preset.

- **Precision scope:** source activations and expert weights are synthetic BF16 tensors, with the NVFP4 backends quantizing those weights. W4A16 consumes BF16 activations and dequantizes NVFP4 weights online. The released Kimi K3 routed checkpoint uses MXFP4; these NVFP4 experiments reproduce logical dimensions and SiTU, not its native checkpoint precision or tensor values.

### Environment and provenance

- **Source:** measured `a2b23d27c43379a78561f5d5c4c6bc7d0bd49786`; based on upstream `488ffbd9fe4455c3b4c3030cf668b5603c6698e4`, which includes merged [#4985](https://github.com/flashinfer-ai/flashinfer/pull/4985). This is a new model-shape comparison using the same three runtime recipes.

- **Container:** `nvcr.io/nvidia/pytorch:26.05-py3`; immutable image `nvcr.io/nvidia/pytorch@sha256:222d8b18e671be5c3ef91cb41727a2572a0b23f59ded6c39f373a96946f6f2ba`. CUDA 13.2.1, nvcc 13.2.78. The installed PyTorch comes from this image; its runtime version and package versions are recorded below.

- **Hardware:** C2, eight NVIDIA B300 SXM6 AC GPUs present; each sweep uses only CUDA device 0. EP8 is a local-expert simulation on one GPU, with TP1. No cross-GPU transfer is timed.

<details>
<summary>Collected environment and relevant installed package versions</summary>

```text
==== FlashInfer package version ====
flashinfer                   : 0.7.0

==== Python / Platform ====
Python            : 3.12.3 (main, Mar 23 2026, 19:04:32) [GCC 13.3.0]
Python executable : /usr/bin/python3
Platform          : Linux-6.8.0-137-generic-x86_64-with-glibc2.39
libc              : glibc 2.39
OS                : Ubuntu 24.04.4 LTS
Container         : yes

==== GPU / Driver ====
Driver version       : 590.48.01
CUDA_VISIBLE_DEVICES : <unset>
GPU 0 (CUDA order)   : NVIDIA B300 SXM6 AC | SM103 | 148 SMs | 267.7 GiB
GPU 1 (CUDA order)   : NVIDIA B300 SXM6 AC | SM103 | 148 SMs | 267.7 GiB
GPU 2 (CUDA order)   : NVIDIA B300 SXM6 AC | SM103 | 148 SMs | 267.7 GiB
GPU 3 (CUDA order)   : NVIDIA B300 SXM6 AC | SM103 | 148 SMs | 267.7 GiB
GPU 4 (CUDA order)   : NVIDIA B300 SXM6 AC | SM103 | 148 SMs | 267.7 GiB
GPU 5 (CUDA order)   : NVIDIA B300 SXM6 AC | SM103 | 148 SMs | 267.7 GiB
GPU 6 (CUDA order)   : NVIDIA B300 SXM6 AC | SM103 | 148 SMs | 267.7 GiB
GPU 7 (CUDA order)   : NVIDIA B300 SXM6 AC | SM103 | 148 SMs | 267.7 GiB

==== CUDA Toolkit ====
nvcc on PATH                            : /usr/local/cuda/bin/nvcc
CUDA_HOME (env)                         : /usr/local/cuda
CUDA toolkit resolved by flashinfer JIT : /usr/local/cuda (version 13.2)
nvcc version                            : release 13.2, V13.2.78

==== PyTorch ====
torch                          : 2.12.0a0+5aff3928d8.nv26.05
torch.version.cuda             : 13.2
torch CXX11 ABI                : True
torch compiled archs           : sm_75 sm_80 sm_86 sm_90 sm_100 sm_120 compute_120
torch.backends.cudnn.version() : 92200
torch file                     : /usr/local/lib/python3.12/dist-packages/torch/__init__.py

==== GPU Libraries: loaded vs on disk ====
libcudnn:
    LOADED   /usr/lib/x86_64-linux-gnu/  [v9.22.0]
libcublas:
    LOADED   /usr/local/cuda-13.2/targets/x86_64-linux/lib/  [v13.4.1.1]
libcudart:
    LOADED   /usr/local/cuda-13.2/targets/x86_64-linux/lib/  [v13.2.75]
libnvrtc:
    LOADED   /usr/local/cuda-13.2/targets/x86_64-linux/lib/  [v13.2.78]
libnccl:
    LOADED   /usr/lib/x86_64-linux-gnu/  [v2.30.4]
libcuda (driver)  ⚠ other installs on disk (check which one you expect):
    LOADED   /usr/local/cuda-13.2/compat/lib.real/  [v595.58.03]
    on disk  /usr/lib/x86_64-linux-gnu/  [v590.48.01]

==== Relevant pip freeze entries ====
apache-tvm-ffi==0.1.13.post3
cuda-bindings==13.2.0
cuda-python==13.2.0
cupti-python==13.2.0
einops==0.8.2
ninja==1.13.0
numpy==2.1.0
nvidia-cuda-cupti==13.2.86
nvidia-cutlass-dsl==4.7.0
nvidia-cutlass-dsl-libs-base==4.7.0
nvidia-cutlass-dsl-libs-core==4.7.0
nvidia-cutlass-dsl-libs-cu12==4.7.0
nvidia-cutlass-dsl-libs-cu13==4.7.0
pytest==9.1.1
pytest-timeout==2.4.0
setuptools==81.0.0

==== Container CUDA version ====
CUDA_VERSION                     : 13.2.1.009
NVIDIA_PYTORCH_VERSION           : 26.05
```

</details>

### Timing methodology and limits

- **Workload:** all powers of two from 1 through 8,192 tokens; EP8/TP1, local expert offset 0, seed 42, router-bias scale 0.01, logits routing mode, and uniform autotuner distributions. Three fresh processes per model/configuration. Sweeps alternate the two models and their three recipes within each repeat. Captured run timestamps span `2026-09-13T02:17:50.257691+00:00` through `2026-09-13T02:47:24.047886+00:00`.

- **Measurement:** 10 warmup iterations and 100 measured samples per backend/token pair; CUDA graphs and CUPTI enabled, with cold-L2 flushing outside the measured operation. Each backend first runs inside `autotune(True)`; the measurement loop runs outside that context. Each recorded latency is the median of that sweep's 100 samples. The derived tables take the median of the three sweep latencies, then divide baseline latency by W4A16 latency.

- **Included:** routing from precomputed logits, expert dispatch/gather, both expert GEMMs, activation, reduction/finalize, and initial NVFP4 activation quantization for FP4-activation backends. For CuTe's new native-router adapter, the timed call includes canonical routing/permutation generation plus two output copies: expert IDs to the CuTe ID buffer and BF16 route weights to the FP32 weight buffer. TRTLLM times its complete native logits-MoE path and native finalize. The adapters have different routing/dispatch work, so these are API-level routed-MoE comparisons rather than isolated GEMM comparisons.

- **Recipes:** inference per-tensor sets per-token activation scaling false and uses CuTe atomic fused finalize; inference per-token sets scaling true and retains fused finalize. Deterministic RL uses per-token scaling, 4over6 MSE with E4M3 maximum 256, 4over6 error fast math enabled, FP4 quantization fast math disabled, and CuTe separate finalize. TRTLLM keeps its native finalize in every recipe.

- **Repeat variability:** K3 W4A16 at 8,192 tokens varied by 21.65% (inference per-tensor) and 20.50% (inference per-token), measured as max/min minus 1 across the three sweeps. The per-token activation flag does not change the W4A16 path; differences between these two medians should not be attributed to activation scaling. K3 TRTLLM NVFP4's per-tensor latency decreases from 4,096 to 8,192 tokens in all three sweeps. These aggregate timings do not establish the implementation causes.

- **Throughput:** the existing TFLOPS metric uses `tokens × top_k × (local_experts/global_experts) × 6 × H × I / seconds / 1e12`. It assumes uniform local assignments rather than using each sample's actual expert histogram and excludes routing/activation FLOPs. Latency is the primary measured quantity.

- **Excluded:** weight creation, quantization and packing; autotuning and graph capture; router GEMM; K3 latent input/output projections and RMSNorm; shared experts; attention; inter-GPU communication; checkpoint routing replay and full-model execution. Cross-precision numerical equivalence and end-to-end training determinism are not established by these performance sweeps. Do not compare absolute timings directly with #4985 as a source-identical regression test: the model shapes, routing adapter, and upstream source revision differ.

### Reproduction

Run in Bash inside the image above on a B300. Start the container with GPU access, for example:

```bash
docker run --gpus all --ipc=host -it nvcr.io/nvidia/pytorch@sha256:222d8b18e671be5c3ef91cb41727a2572a0b23f59ded6c39f373a96946f6f2ba bash
```

Install the exact source revision and the same benchmark dependencies:

```bash
set -euo pipefail
git clone https://github.com/flashinfer-ai/flashinfer.git
cd flashinfer
git fetch https://github.com/zianglih/flashinfer.git a2b23d27c43379a78561f5d5c4c6bc7d0bd49786
git checkout --detach FETCH_HEAD
git submodule update --init --recursive
export BUILD_NVEP=0 FLASHINFER_BUILD_NO_PIP=1 MAX_JOBS=16
python3 -m pip install 'setuptools>=77' 'apache-tvm-ffi==0.1.13.post3'
python3 -m pip install 'nvidia-cutlass-dsl[cu13]==4.7.0' 'cupti-python==13.2.0' 'nvidia-cuda-cupti==13.2.86' ninja einops pytest pytest-timeout
python3 -m pip install --no-build-isolation --no-deps -e .
mkdir -p benchmark-results
python3 -m flashinfer.collect_env > benchmark-results/environment.txt
python3 -m pip freeze > benchmark-results/pip-freeze.txt
```

The public script prints CSV whenever `--backends` is explicit. This small wrapper additionally saves its returned, unrounded `BenchResult` objects; it does not change the measured functions:

<details>
<summary>Create capture_benchmark.py in the checkout</summary>

```bash
cat > capture_benchmark.py <<'PY'
#!/usr/bin/env python3
"""Retain the public CLI output and capture its unrounded result objects."""

import argparse
from dataclasses import asdict
import json
from pathlib import Path
import sys

parser = argparse.ArgumentParser()
parser.add_argument("--repo", type=Path, required=True)
parser.add_argument("--json-out", type=Path, required=True)
args, forwarded = parser.parse_known_args()
sys.path[:0] = [str(args.repo), str(args.repo / "benchmarks")]
import bench_moe_deepseek as benchmark  # noqa: E402

original = benchmark.run_benchmark
original_single = benchmark._benchmark_single


def capture_row(*positional, **keyword):
    row = original_single(*positional, **keyword)
    print(f"Completed token row: {positional[0]}", flush=True)
    return row


def capture(*positional, **keyword):
    results = original(*positional, **keyword)
    args.json_out.write_text(json.dumps([asdict(row) for row in results], indent=2) + "\n")
    return results


benchmark.run_benchmark = capture
benchmark._benchmark_single = capture_row
sys.argv = [str(args.repo / "benchmarks/bench_moe_deepseek.py"), *forwarded]
raise SystemExit(benchmark.main())
PY
```

</details>

Run the same 18 processes in repeat/model/configuration order; the commands explicitly omit CUTLASS. Run on an otherwise idle GPU and retain the JIT cache between processes:

```bash
set -euo pipefail
export CUDA_VISIBLE_DEVICES=0 MAX_JOBS=16 PYTHONUNBUFFERED=1
for variable in ${!FLASHINFER_NVFP4_4OVER6@}; do unset "$variable"; done
unset FLASHINFER_DISABLE_FP4_QUANT_FAST_MATH FLASHINFER_AUTOTUNER_LOAD_FROM_FILE
unset FLASHINFER_DIST_AWARE_AUTOTUNE FLASHINFER_DA_DISTRIBUTIONS
tokens=1,2,4,8,16,32,64,128,256,512,1024,2048,4096,8192
for repeat in 1 2 3; do
  for model in glm5 kimi-k3; do
    backends=cutedsl,trtllm-nvfp4
    if [[ "$model" == glm5 ]]; then backends+=,trtllm-bf16; fi
    output=benchmark-results/$model
    mkdir -p "$output"
    common=(--repo . --model "$model" --num-tokens "$tokens" --ep 8 --tp 1
      --warmup 10 --iters 100 --routing-input-mode logits --routing-bias-scale 0.01
      --include-activation-quant)
    python3 capture_benchmark.py "${common[@]}" --backends "$backends" \
      --json-out "$output/inference-per-tensor-$repeat.json" \
      2>&1 | tee "$output/inference-per-tensor-$repeat.log"
    if [[ "$model" == kimi-k3 ]]; then backends=cutedsl; fi
    python3 capture_benchmark.py "${common[@]}" --backends "$backends" --use-per-token-activation \
      --json-out "$output/inference-per-token-$repeat.json" \
      2>&1 | tee "$output/inference-per-token-$repeat.log"
    env FLASHINFER_NVFP4_4OVER6=1 FLASHINFER_NVFP4_4OVER6_E4M3_USE_256=1 \
      FLASHINFER_NVFP4_4OVER6_ERR_MODE=MSE FLASHINFER_NVFP4_4OVER6_ERR_USE_FAST_MATH=1 \
      FLASHINFER_DISABLE_FP4_QUANT_FAST_MATH=1 \
      python3 capture_benchmark.py "${common[@]}" --backends "$backends" --use-per-token-activation --no-fused-finalize \
      --json-out "$output/rl-$repeat.json" 2>&1 | tee "$output/rl-$repeat.log"
  done
done
```

## Performance results

Measured commit: `a2b23d27c43379a78561f5d5c4c6bc7d0bd49786`. All 18 sweeps completed successfully: 798 backend/token measurements, 14 powers of two from 1 through 8,192 tokens, and three repeats for each model/configuration. Every latency and TFLOPS value below is checked against both the captured JSON and the script's printed CSV.

Raw table cells contain `latency_ms/TFLOPS` for **run 1; run 2; run 3**, at the CSV's original six-decimal precision. Captured JSON and the structured summary retain all unrounded values. Derived values use the median of the three unrounded measurements. **W4A16 speedup = baseline median latency / CuteDSL W4A16 median latency**; greater than 1 means W4A16 is faster.

CUTLASS is omitted from all configurations at the user's request to avoid its compilation cost. Kimi K3 uses native SiTU; TRTLLM BF16 is omitted because its kernels do not support that activation, and TRTLLM NVFP4 is omitted from per-token/RL because no SiTU kernel supports per-token scaling. The deterministic RL label identifies the requested quantization/finalize configuration; these timing runs do not establish end-to-end training determinism.

### GLM-5 — Inference per-tensor

<details>
<summary>Complete raw results — three sweeps</summary>

| Tokens | CuteDSL W4A4 | CuteDSL W4A16 | TRTLLM NVFP4 | TRTLLM BF16 |
| --- | --- | --- | --- | --- |
| 1 | 0.031377/2.406179; 0.031520/2.395186; 0.034721/2.174404 | 0.040192/1.878420; 0.040193/1.878374; 0.040192/1.878420 | 0.024384/3.096189; 0.024545/3.075943; 0.024160/3.124895 | 0.046992/1.606586; 0.043761/1.725242; 0.045025/1.676809 |
| 2 | 0.039233/3.848672; 0.039265/3.845584; 0.039169/3.855010 | 0.044513/3.392154; 0.044833/3.367942; 0.045217/3.339340 | 0.033600/4.493830; 0.034592/4.364962; 0.034225/4.411896 | 0.069857/2.161486; 0.069793/2.163468; 0.069600/2.169468 |
| 4 | 0.053440/5.651008; 0.053441/5.650903; 0.053504/5.644196 | 0.060465/4.994458; 0.060816/4.965591; 0.059904/5.041189 | 0.045281/6.669314; 0.044609/6.769708; 0.047984/6.293554 | 0.103090/2.929381; 0.103106/2.928941; 0.103122/2.928486 |
| 8 | 0.068017/8.879901; 0.068048/8.875725; 0.068033/8.877747 | 0.073473/8.220432; 0.074113/8.149444; 0.074081/8.152910 | 0.057345/10.532388; 0.057233/10.552999; 0.057457/10.511857 | 0.136913/4.411397; 0.138546/4.359417; 0.136962/4.409835 |
| 16 | 0.078785/15.332355; 0.078624/15.363751; 0.078945/15.301280 | 0.084033/14.374824; 0.085122/14.191004; 0.082113/14.710942 | 0.068241/17.701375; 0.068193/17.713835; 0.068193/17.713705 | 0.168098/7.186044; 0.167170/7.225935; 0.167042/7.231472 |
| 32 | 0.107873/22.395854; 0.107794/22.412475; 0.107889/22.392636 | 0.112289/21.515189; 0.112513/21.472355; 0.112290/21.514998 | 0.098945/24.416788; 0.098402/24.551649; 0.098145/24.615814 | 0.257411/9.385454; 0.258867/9.332665; 0.258756/9.336687 |
| 64 | 0.133698/36.139944; 0.133410/36.217961; 0.133730/36.131431 | 0.139458/34.647264; 0.139458/34.647389; 0.139331/34.678970 | 0.122817/39.341770; 0.122738/39.367093; 0.122722/39.372225 | 0.332355/14.538184; 0.332532/14.530446; 0.333172/14.502534 |
| 128 | 0.138818/69.614001; 0.139394/69.326344; 0.139250/69.398035 | 0.144049/67.085803; 0.143906/67.152700; 0.143858/67.175106 | 0.130081/74.289684; 0.129921/74.381173; 0.129858/74.417546 | 0.354517/27.258749; 0.354612/27.251408; 0.354629/27.250102 |
| 256 | 0.144738/133.533831; 0.144545/133.711204; 0.144482/133.769970 | 0.148802/129.886378; 0.148706/129.970229; 0.149042/129.677224 | 0.136817/141.264264; 0.136929/141.148203; 0.136706/141.378965 | 0.368756/52.412307; 0.368724/52.416856; 0.368245/52.485038 |
| 512 | 0.146914/263.111110; 0.146642/263.599144; 0.146786/263.340548 | 0.153986/251.027403; 0.154130/250.793688; 0.153986/251.027403 | 0.142914/270.475290; 0.143090/270.142607; 0.143106/270.112404 | 0.374580/103.194793; 0.374420/103.238753; 0.374597/103.190110 |
| 1024 | 0.151794/509.304790; 0.151890/508.984567; 0.151906/508.929281 | 0.172595/447.925115; 0.172786/447.428677; 0.172627/447.840786 | 0.290660/265.979303; 0.292387/264.407827; 0.291397/265.306589 | 0.382485/202.124034; 0.382853/201.930016; 0.382757/201.980134 |
| 2048 | 0.161506/957.356523; 0.161426/957.830973; 0.161554/957.072079 | 0.219955/702.956617; 0.220066/702.600453; 0.219923/703.058901 | 0.288996/535.019707; 0.289058/534.904951; 0.289332/534.399315 | 0.409845/377.261703; 0.409830/377.275971; 0.409493/377.585536 |
| 4096 | 0.195394/1582.636342; 0.195411/1582.498658; 0.195427/1582.373144 | 0.339652/910.454363; 0.340116/909.212284; 0.339973/909.594719 | 0.283620/1090.323832; 0.285300/1083.905318; 0.283652/1090.200828 | 0.462117/669.175362; 0.462454/668.689166; 0.462534/668.572787 |
| 8192 | 0.267875/2308.816187; 0.268035/2307.442277; 0.267988/2307.846958 | 0.598135/1034.006187; 0.605511/1021.409652; 0.599256/1032.071920 | 0.354564/1744.326245; 0.356004/1737.273062; 0.359365/1721.022611 | 0.699912/883.646585; 0.700808/882.516823; 0.711434/869.336755 |

</details>

**Derived performance summary (median of three sweeps)**

| Tokens | CuteDSL W4A4 ms | CuteDSL W4A16 ms | TRTLLM NVFP4 ms | TRTLLM BF16 ms | W4A16 vs TRTLLM NVFP4 speedup | W4A16 vs TRTLLM BF16 speedup |
| --- | --- | --- | --- | --- | --- | --- |
| 1 | 0.031520 | 0.040192 | 0.024384 | 0.045025 | 0.607× | 1.120× |
| 2 | 0.039233 | 0.044833 | 0.034225 | 0.069793 | 0.763× | 1.557× |
| 4 | 0.053441 | 0.060465 | 0.045281 | 0.103106 | 0.749× | 1.705× |
| 8 | 0.068033 | 0.074081 | 0.057345 | 0.136962 | 0.774× | 1.849× |
| 16 | 0.078785 | 0.084033 | 0.068193 | 0.167170 | 0.812× | 1.989× |
| 32 | 0.107873 | 0.112290 | 0.098402 | 0.258756 | 0.876× | 2.304× |
| 64 | 0.133698 | 0.139458 | 0.122738 | 0.332532 | 0.880× | 2.384× |
| 128 | 0.139250 | 0.143906 | 0.129921 | 0.354612 | 0.903× | 2.464× |
| 256 | 0.144545 | 0.148802 | 0.136817 | 0.368724 | 0.919× | 2.478× |
| 512 | 0.146786 | 0.153986 | 0.143090 | 0.374580 | 0.929× | 2.433× |
| 1024 | 0.151890 | 0.172627 | 0.291397 | 0.382757 | 1.688× | 2.217× |
| 2048 | 0.161506 | 0.219955 | 0.289058 | 0.409830 | 1.314× | 1.863× |
| 4096 | 0.195411 | 0.339973 | 0.283652 | 0.462454 | 0.834× | 1.360× |
| 8192 | 0.267988 | 0.599256 | 0.356004 | 0.700808 | 0.594× | 1.169× |

W4A16 speedup range across token counts — TRTLLM NVFP4: 0.594–1.688×; TRTLLM BF16: 1.120–2.478×.

### GLM-5 — Inference per-token

<details>
<summary>Complete raw results — three sweeps</summary>

| Tokens | CuteDSL W4A4 | CuteDSL W4A16 | TRTLLM NVFP4 | TRTLLM BF16 |
| --- | --- | --- | --- | --- |
| 1 | 0.041985/1.798222; 0.041936/1.800302; 0.042016/1.796874 | 0.040096/1.882918; 0.040161/1.879870; 0.040256/1.875434 | 0.032513/2.322070; 0.032192/2.345225; 0.032176/2.346391 | 0.043809/1.723352; 0.043809/1.723352; 0.045264/1.667918 |
| 2 | 0.051505/2.931656; 0.056688/2.663614; 0.051393/2.938074 | 0.045313/3.332265; 0.046560/3.242984; 0.046273/3.263133 | 0.042464/3.555834; 0.042353/3.565196; 0.042336/3.566585 | 0.069970/2.158011; 0.070001/2.157040; 0.071217/2.120209 |
| 4 | 0.068433/4.412960; 0.068449/4.411896; 0.068321/4.420194 | 0.061408/4.917721; 0.060241/5.013071; 0.060305/5.007709 | 0.055824/5.409630; 0.054080/5.584133; 0.056256/5.368137 | 0.103538/2.916720; 0.103105/2.928955; 0.105538/2.861433 |
| 8 | 0.083649/7.220450; 0.083713/7.214886; 0.083505/7.232814 | 0.073618/8.204296; 0.073713/8.193667; 0.074274/8.131834 | 0.066081/9.140061; 0.065921/9.162176; 0.066001/9.151070 | 0.138049/4.375096; 0.137202/4.402137; 0.137298/4.399043 |
| 16 | 0.093057/12.980926; 0.093105/12.974164; 0.092994/12.989650 | 0.084001/14.380300; 0.083873/14.402246; 0.084017/14.377561 | 0.078545/15.379204; 0.076961/15.695736; 0.076928/15.702367 | 0.168098/7.186044; 0.166690/7.246743; 0.167987/7.190813 |
| 32 | 0.123938/19.493044; 0.123953/19.490528; 0.123906/19.497999 | 0.112017/21.567433; 0.111841/21.601276; 0.112850/21.408233 | 0.107105/22.556548; 0.107073/22.563290; 0.106545/22.674999 | 0.258467/9.347109; 0.258291/9.353478; 0.258547/9.344216 |
| 64 | 0.150946/32.010376; 0.150594/32.085197; 0.150594/32.085197 | 0.139474/34.643414; 0.139074/34.742930; 0.139155/34.722831 | 0.131570/36.724607; 0.131697/36.688914; 0.132113/36.573526 | 0.334356/14.451200; 0.331620/14.570407; 0.333637/14.482343 |
| 128 | 0.158242/61.068973; 0.158274/61.056819; 0.158290/61.050454 | 0.144226/67.003705; 0.144066/67.078353; 0.144066/67.078120 | 0.138690/69.678249; 0.138722/69.662176; 0.138578/69.734564 | 0.354228/27.280950; 0.354116/27.289579; 0.353380/27.346377 |
| 256 | 0.163250/118.391135; 0.163074/118.518911; 0.163363/118.309605 | 0.149010/129.705072; 0.149153/129.580284; 0.149058/129.663304 | 0.144642/133.621997; 0.144354/133.889049; 0.144530/133.725544 | 0.368132/52.501077; 0.368868/52.396322; 0.368277/52.480478 |
| 512 | 0.168690/229.146397; 0.168433/229.496035; 0.168403/229.537600 | 0.154209/250.664395; 0.154146/250.766842; 0.153907/251.156255 | 0.153314/252.127697; 0.153186/252.338371; 0.153570/251.707402 | 0.375845/102.847465; 0.374148/103.313806; 0.374277/103.278336 |
| 1024 | 0.177826/434.746291; 0.177890/434.591103; 0.177650/435.176998 | 0.172019/449.423676; 0.171794/450.012290; 0.171875/449.800211 | 0.290307/266.301805; 0.298196/259.257471; 0.300196/257.529785 | 0.381668/202.556437; 0.383412/201.635083; 0.383301/201.693738 |
| 2048 | 0.196514/786.806178; 0.195939/789.119150; 0.196227/787.960967 | 0.219714/703.727676; 0.219843/703.314741; 0.219651/703.929518 | 0.304916/507.087448; 0.303635/509.225954; 0.304564/507.672682 | 0.411797/375.473407; 0.411221/375.999335; 0.411430/375.808790 |
| 4096 | 0.246596/1254.027934; 0.246595/1254.030476; 0.247652/1248.680688 | 0.339541/910.753343; 0.339637/910.495913; 0.339845/909.937311 | 0.315636/979.730244; 0.315493/980.174316; 0.314964/981.819018 | 0.464245/666.108008; 0.464102/666.313968; 0.464038/666.405866 |
| 8192 | 0.358197/1726.636890; 0.358132/1726.947859; 0.358405/1725.632429 | 0.599096/1032.347555; 0.598519/1033.342785; 0.598232/1033.838529 | 0.403653/1532.193554; 0.403765/1531.770437; 0.404069/1530.618015 | 0.720329/858.601126; 0.703928/878.605271; 0.728155/849.373129 |

</details>

**Derived performance summary (median of three sweeps)**

| Tokens | CuteDSL W4A4 ms | CuteDSL W4A16 ms | TRTLLM NVFP4 ms | TRTLLM BF16 ms | W4A16 vs TRTLLM NVFP4 speedup | W4A16 vs TRTLLM BF16 speedup |
| --- | --- | --- | --- | --- | --- | --- |
| 1 | 0.041985 | 0.040161 | 0.032192 | 0.043809 | 0.802× | 1.091× |
| 2 | 0.051505 | 0.046273 | 0.042353 | 0.070001 | 0.915× | 1.513× |
| 4 | 0.068433 | 0.060305 | 0.055824 | 0.103538 | 0.926× | 1.717× |
| 8 | 0.083649 | 0.073713 | 0.066001 | 0.137298 | 0.895× | 1.863× |
| 16 | 0.093057 | 0.084001 | 0.076961 | 0.167987 | 0.916× | 2.000× |
| 32 | 0.123938 | 0.112017 | 0.107073 | 0.258467 | 0.956× | 2.307× |
| 64 | 0.150594 | 0.139155 | 0.131697 | 0.333637 | 0.946× | 2.398× |
| 128 | 0.158274 | 0.144066 | 0.138690 | 0.354116 | 0.963× | 2.458× |
| 256 | 0.163250 | 0.149058 | 0.144530 | 0.368277 | 0.970× | 2.471× |
| 512 | 0.168433 | 0.154146 | 0.153314 | 0.374277 | 0.995× | 2.428× |
| 1024 | 0.177826 | 0.171875 | 0.298196 | 0.383301 | 1.735× | 2.230× |
| 2048 | 0.196227 | 0.219714 | 0.304564 | 0.411430 | 1.386× | 1.873× |
| 4096 | 0.246596 | 0.339637 | 0.315493 | 0.464102 | 0.929× | 1.366× |
| 8192 | 0.358197 | 0.598519 | 0.403765 | 0.720329 | 0.675× | 1.204× |

W4A16 speedup range across token counts — TRTLLM NVFP4: 0.675–1.735×; TRTLLM BF16: 1.091–2.471×.

### GLM-5 — Deterministic RL configuration

<details>
<summary>Complete raw results — three sweeps</summary>

| Tokens | CuteDSL W4A4 | CuteDSL W4A16 | TRTLLM NVFP4 | TRTLLM BF16 |
| --- | --- | --- | --- | --- |
| 1 | 0.052848/1.428564; 0.047585/1.586581; 0.047457/1.590861 | 0.039793/1.897279; 0.040321/1.872434; 0.039745/1.899570 | 0.034688/2.176472; 0.033920/2.225718; 0.033905/2.226768 | 0.047009/1.606039; 0.043585/1.732189; 0.047089/1.603310 |
| 2 | 0.056289/2.682495; 0.056225/2.685548; 0.056609/2.667331 | 0.044897/3.363141; 0.045056/3.351236; 0.044896/3.363216 | 0.044416/3.399524; 0.048992/3.082033; 0.044465/3.395854 | 0.069985/2.157533; 0.069633/2.168439; 0.069633/2.168439 |
| 4 | 0.073425/4.112903; 0.073537/4.106639; 0.073489/4.109321 | 0.057409/5.260323; 0.057665/5.237016; 0.057345/5.266194 | 0.057280/5.272124; 0.057473/5.254511; 0.057601/5.242789 | 0.105169/2.871472; 0.102913/2.934419; 0.102977/2.932596 |
| 8 | 0.088721/6.807630; 0.088721/6.807592; 0.088673/6.811315 | 0.071249/8.477028; 0.071088/8.496227; 0.070161/8.608483 | 0.067249/8.981245; 0.067329/8.970574; 0.067936/8.890358 | 0.136945/4.410366; 0.137042/4.407276; 0.137442/4.394434 |
| 16 | 0.097585/12.378474; 0.097329/12.411096; 0.097617/12.374416 | 0.080496/15.006361; 0.080177/15.066161; 0.080194/15.063061 | 0.078497/15.388608; 0.078561/15.376169; 0.078417/15.404307 | 0.167506/7.211440; 0.168115/7.185338; 0.167955/7.192183 |
| 32 | 0.129346/18.678030; 0.129954/18.590571; 0.129410/18.668720 | 0.110961/21.772687; 0.109697/22.023566; 0.110386/21.886101 | 0.109473/22.068630; 0.109649/22.033106; 0.108833/22.198406 | 0.258771/9.336128; 0.258514/9.345409; 0.258564/9.343602 |
| 64 | 0.159026/30.383951; 0.159282/30.335022; 0.159379/30.316750 | 0.135842/35.569676; 0.136225/35.469411; 0.135906/35.552795 | 0.133585/36.170379; 0.133969/36.066703; 0.133602/36.165912 | 0.333076/14.506736; 0.333892/14.471282; 0.333733/14.478155 |
| 128 | 0.164818/58.632409; 0.164866/58.615339; 0.164690/58.677979 | 0.141362/68.361445; 0.141489/68.299601; 0.141346/68.368942 | 0.140657/68.703599; 0.140418/68.820781; 0.140546/68.758104 | 0.353317/27.351331; 0.352852/27.387336; 0.352981/27.377327 |
| 256 | 0.172706/111.908983; 0.172802/111.846812; 0.172802/111.846812 | 0.145202/133.107116; 0.145346/132.975241; 0.145394/132.930883 | 0.146914/131.555555; 0.147842/130.729785; 0.147106/131.383851 | 0.368277/52.480549; 0.368260/52.482900; 0.368709/52.418989 |
| 512 | 0.178658/216.361460; 0.178786/216.206558; 0.178738/216.264015 | 0.150274/257.228168; 0.150722/256.464444; 0.150210/257.337765 | 0.155298/248.906655; 0.155234/249.009274; 0.155586/248.445912 | 0.374500/103.216838; 0.375252/103.009992; 0.374501/103.216562 |
| 1024 | 0.191810/403.052038; 0.192162/402.313732; 0.192147/402.345139 | 0.165922/465.938280; 0.165618/466.794942; 0.165746/466.433044 | 0.304036/254.277162; 0.295700/261.445864; 0.303316/254.880756 | 0.383012/201.845661; 0.381845/202.462809; 0.383300/201.694264 |
| 2048 | 0.218274/708.370317; 0.218050/709.096391; 0.217874/709.669202 | 0.210338/735.096952; 0.210067/736.043522; 0.210291/735.261246 | 0.311172/496.891824; 0.310531/497.916709; 0.312005/495.566002 | 0.411988/375.298880; 0.411268/375.956366; 0.411782/375.487540 |
| 4096 | 0.283011/1092.668126; 0.282915/1093.038894; 0.283171/1092.052665 | 0.301460/1025.799925; 0.301539/1025.529476; 0.301364/1026.126695 | 0.325748/949.315561; 0.325604/949.735400; 0.325508/950.015500 | 0.464757/665.374190; 0.463734/666.843446; 0.464135/666.267311 |
| 8192 | 0.424917/1455.520232; 0.424918/1455.516807; 0.424902/1455.571616 | 0.527815/1171.766389; 0.528631/1169.956530; 0.538119/1149.327037 | 0.429653/1439.476253; 0.423013/1462.071593; 0.425270/1454.313772 | 0.700280/883.182226; 0.714664/865.407087; 0.707483/874.191645 |

</details>

**Derived performance summary (median of three sweeps)**

| Tokens | CuteDSL W4A4 ms | CuteDSL W4A16 ms | TRTLLM NVFP4 ms | TRTLLM BF16 ms | W4A16 vs TRTLLM NVFP4 speedup | W4A16 vs TRTLLM BF16 speedup |
| --- | --- | --- | --- | --- | --- | --- |
| 1 | 0.047585 | 0.039793 | 0.033920 | 0.047009 | 0.852× | 1.181× |
| 2 | 0.056289 | 0.044897 | 0.044465 | 0.069633 | 0.990× | 1.551× |
| 4 | 0.073489 | 0.057409 | 0.057473 | 0.102977 | 1.001× | 1.794× |
| 8 | 0.088721 | 0.071088 | 0.067329 | 0.137042 | 0.947× | 1.928× |
| 16 | 0.097585 | 0.080194 | 0.078497 | 0.167955 | 0.979× | 2.094× |
| 32 | 0.129410 | 0.110386 | 0.109473 | 0.258564 | 0.992× | 2.342× |
| 64 | 0.159282 | 0.135906 | 0.133602 | 0.333733 | 0.983× | 2.456× |
| 128 | 0.164818 | 0.141362 | 0.140546 | 0.352981 | 0.994× | 2.497× |
| 256 | 0.172802 | 0.145346 | 0.147106 | 0.368277 | 1.012× | 2.534× |
| 512 | 0.178738 | 0.150274 | 0.155298 | 0.374501 | 1.033× | 2.492× |
| 1024 | 0.192147 | 0.165746 | 0.303316 | 0.383012 | 1.830× | 2.311× |
| 2048 | 0.218050 | 0.210291 | 0.311172 | 0.411782 | 1.480× | 1.958× |
| 4096 | 0.283011 | 0.301460 | 0.325604 | 0.464135 | 1.080× | 1.540× |
| 8192 | 0.424917 | 0.528631 | 0.425270 | 0.707483 | 0.804× | 1.338× |

W4A16 speedup range across token counts — TRTLLM NVFP4: 0.804–1.830×; TRTLLM BF16: 1.181–2.534×.

### Kimi K3 (native SiTU) — Inference per-tensor

<details>
<summary>Complete raw results — three sweeps</summary>

| Tokens | CuteDSL W4A4 | CuteDSL W4A16 | TRTLLM NVFP4 |
| --- | --- | --- | --- |
| 1 | 0.023104/5.718515; 0.023072/5.726447; 0.022897/5.770339 | 0.024944/5.296688; 0.024960/5.293292; 0.024976/5.289795 | 0.022560/5.856409; 0.022528/5.864727; 0.023041/5.734151 |
| 2 | 0.039905/6.621755; 0.039680/6.659303; 0.039953/6.613883 | 0.044321/5.961985; 0.044225/5.974927; 0.044320/5.962053 | 0.033568/7.871817; 0.033552/7.875453; 0.033520/7.883089 |
| 4 | 0.072497/7.289713; 0.072577/7.281677; 0.072577/7.281677 | 0.075169/7.030588; 0.076225/6.933189; 0.075425/7.006726 | 0.065121/8.115390; 0.063409/8.334566; 0.064593/8.181727 |
| 8 | 0.102674/10.294375; 0.102737/10.288012; 0.102641/10.297634 | 0.103489/10.213304; 0.103618/10.200638; 0.103153/10.246522 | 0.087569/12.070077; 0.087969/12.015262; 0.087457/12.085466 |
| 16 | 0.138066/15.311060; 0.138098/15.307457; 0.138146/15.302194 | 0.138546/15.257959; 0.138610/15.250914; 0.138642/15.247394 | 0.119826/17.641731; 0.119777/17.648874; 0.119938/17.625183 |
| 32 | 0.202786/20.848816; 0.203091/20.817557; 0.202994/20.827453 | 0.205635/20.560014; 0.205507/20.572820; 0.205699/20.553617 | 0.179250/23.586379; 0.179266/23.584208; 0.179362/23.571585 |
| 64 | 0.264835/31.928245; 0.265108/31.895367; 0.265139/31.891637 | 0.270787/31.226451; 0.271364/31.160054; 0.270867/31.217170 | 0.239779/35.264626; 0.239668/35.281033; 0.239267/35.340088 |
| 128 | 0.328468/51.485709; 0.328645/51.458137; 0.328308/51.510879 | 0.331653/50.991425; 0.332245/50.900491; 0.332325/50.888238 | 0.301363/56.116490; 0.301683/56.056873; 0.301589/56.074531 |
| 256 | 0.363493/93.049570; 0.362709/93.250698; 0.363061/93.160288 | 0.371924/90.940266; 0.371557/91.030091; 0.371460/91.053739 | 0.336837/100.413160; 0.337877/100.104232; 0.336260/100.585312 |
| 512 | 0.369637/183.006102; 0.369030/183.307120; 0.369413/183.116823 | 0.386085/175.209436; 0.386118/175.194688; 0.385957/175.267543 | 0.348692/193.998529; 0.349637/193.474465; 0.349989/193.279603 |
| 1024 | 0.373572/362.156344; 0.372934/362.776393; 0.373093/362.621303 | 0.416549/324.791249; 0.416230/325.040170; 0.416166/325.090156 | 0.961229/140.748500; 0.960030/140.924211; 0.960349/140.877326 |
| 2048 | 0.383829/704.957916; 0.383622/705.337388; 0.383781/705.045168 | 0.456583/592.626611; 0.457031/592.045047; 0.457767/591.093799 | 0.980141/276.065462; 0.979182/276.335696; 0.979038/276.376482 |
| 4096 | 0.410597/1317.997646; 0.411110/1316.354595; 0.410757/1317.482649 | 0.662440/816.928143; 0.647034/836.380001; 0.646825/836.649603 | 0.957405/565.242378; 0.957181/565.374657; 0.956238/565.932500 |
| 8192 | 0.538903/2008.396232; 0.539992/2004.347766; 0.540423/2002.747398 | 1.379730/784.452140; 1.134193/954.274765; 1.193008/907.229255 | 0.852667/1269.348712; 0.852813/1269.131402; 0.854221/1267.040253 |

</details>

**Derived performance summary (median of three sweeps)**

| Tokens | CuteDSL W4A4 ms | CuteDSL W4A16 ms | TRTLLM NVFP4 ms | W4A16 vs TRTLLM NVFP4 speedup |
| --- | --- | --- | --- | --- |
| 1 | 0.023072 | 0.024960 | 0.022560 | 0.904× |
| 2 | 0.039905 | 0.044320 | 0.033552 | 0.757× |
| 4 | 0.072577 | 0.075425 | 0.064593 | 0.856× |
| 8 | 0.102674 | 0.103489 | 0.087569 | 0.846× |
| 16 | 0.138098 | 0.138610 | 0.119826 | 0.864× |
| 32 | 0.202994 | 0.205635 | 0.179266 | 0.872× |
| 64 | 0.265108 | 0.270867 | 0.239668 | 0.885× |
| 128 | 0.328468 | 0.332245 | 0.301589 | 0.908× |
| 256 | 0.363061 | 0.371557 | 0.336837 | 0.907× |
| 512 | 0.369413 | 0.386085 | 0.349637 | 0.906× |
| 1024 | 0.373093 | 0.416230 | 0.960349 | 2.307× |
| 2048 | 0.383781 | 0.457031 | 0.979182 | 2.142× |
| 4096 | 0.410757 | 0.647034 | 0.957181 | 1.479× |
| 8192 | 0.539992 | 1.193008 | 0.852813 | 0.715× |

W4A16 speedup range across token counts — TRTLLM NVFP4: 0.715–2.307×.

### Kimi K3 (native SiTU) — Inference per-token

<details>
<summary>Complete raw results — three sweeps</summary>

| Tokens | CuteDSL W4A4 | CuteDSL W4A16 |
| --- | --- | --- |
| 1 | 0.033937/3.893170; 0.033856/3.902427; 0.033905/3.896845 | 0.025056/5.273011; 0.025184/5.246211; 0.025184/5.246211 |
| 2 | 0.056192/4.702427; 0.055984/4.719898; 0.056289/4.694407 | 0.044449/5.944817; 0.044033/6.000980; 0.043584/6.062802 |
| 4 | 0.093905/5.627870; 0.093810/5.633569; 0.093825/5.632638 | 0.074928/7.053155; 0.074209/7.121539; 0.074305/7.112338 |
| 8 | 0.134066/7.883942; 0.133858/7.896163; 0.133954/7.890534 | 0.104209/10.142738; 0.104146/10.148922; 0.104465/10.117883 |
| 16 | 0.174003/12.148844; 0.174979/12.081045; 0.174082/12.143261 | 0.139665/15.135712; 0.140114/15.087209; 0.139329/15.172158 |
| 32 | 0.242019/17.469118; 0.242980/17.400062; 0.243155/17.387504 | 0.206259/20.497863; 0.205555/20.568016; 0.206707/20.453437 |
| 64 | 0.308147/27.440530; 0.308036/27.450418; 0.307924/27.460402 | 0.270915/31.211697; 0.271363/31.160111; 0.271267/31.171196 |
| 128 | 0.375125/45.082129; 0.375525/45.034169; 0.375557/45.030272 | 0.332436/50.871247; 0.332197/50.907846; 0.332804/50.814995 |
| 256 | 0.411524/82.189195; 0.411446/82.204976; 0.411701/82.153860 | 0.371557/91.030213; 0.371813/90.967415; 0.372293/90.850130 |
| 512 | 0.424165/159.479766; 0.424405/159.389393; 0.423349/159.786972 | 0.387461/174.587210; 0.387333/174.644905; 0.387109/174.745963 |
| 1024 | 0.441302/306.573782; 0.441862/306.184894; 0.442021/306.074410 | 0.415733/325.428748; 0.416389/324.915661; 0.416870/324.541541 |
| 2048 | 0.478630/565.327998; 0.479543/564.251672; 0.478982/564.911953 | 0.456086/593.271751; 0.461190/586.705999; 0.456694/592.481924 |
| 4096 | 0.549462/984.900479; 0.549592/984.669303; 0.549111/985.530041 | 0.681177/794.457064; 0.663321/815.843128; 0.666665/811.750848 |
| 8192 | 0.820138/1319.693879; 0.821148/1318.071479; 0.819963/1319.976339 | 1.395395/775.645711; 1.372707/788.464956; 1.157968/934.681924 |

</details>

**Derived performance summary (median of three sweeps)**

| Tokens | CuteDSL W4A4 ms | CuteDSL W4A16 ms |
| --- | --- | --- |
| 1 | 0.033905 | 0.025184 |
| 2 | 0.056192 | 0.044033 |
| 4 | 0.093825 | 0.074305 |
| 8 | 0.133954 | 0.104209 |
| 16 | 0.174082 | 0.139665 |
| 32 | 0.242980 | 0.206259 |
| 64 | 0.308036 | 0.271267 |
| 128 | 0.375525 | 0.332436 |
| 256 | 0.411524 | 0.371813 |
| 512 | 0.424165 | 0.387333 |
| 1024 | 0.441862 | 0.416389 |
| 2048 | 0.478982 | 0.456694 |
| 4096 | 0.549462 | 0.666665 |
| 8192 | 0.820138 | 1.372707 |

TRTLLM speedups are unavailable: native SiTU kernels support neither BF16 nor NVFP4 per-token scaling.

### Kimi K3 (native SiTU) — Deterministic RL configuration

<details>
<summary>Complete raw results — three sweeps</summary>

| Tokens | CuteDSL W4A4 | CuteDSL W4A16 |
| --- | --- | --- |
| 1 | 0.037025/3.568415; 0.037057/3.565334; 0.036993/3.571502 | 0.025825/5.115995; 0.025168/5.249442; 0.025856/5.109861 |
| 2 | 0.063200/4.180998; 0.063681/4.149450; 0.063713/4.147366 | 0.044672/5.915140; 0.044353/5.957684; 0.044352/5.957818 |
| 4 | 0.103569/5.102707; 0.103218/5.120084; 0.103218/5.120084 | 0.074096/7.132352; 0.075073/7.039579; 0.073809/7.160134 |
| 8 | 0.145649/7.256905; 0.146562/7.211723; 0.146610/7.209362 | 0.102433/10.318544; 0.104370/10.127141; 0.104353/10.128742 |
| 16 | 0.186546/11.331946; 0.187971/11.246039; 0.188050/11.241315 | 0.137954/15.323491; 0.139490/15.154701; 0.139378/15.166879 |
| 32 | 0.256978/16.452187; 0.257076/16.445980; 0.256419/16.488086 | 0.205058/20.617866; 0.205587/20.564814; 0.205251/20.598479 |
| 64 | 0.322084/26.253142; 0.322884/26.188095; 0.322964/26.181568 | 0.269123/31.419525; 0.269123/31.419525; 0.268948/31.440028 |
| 128 | 0.389940/43.369323; 0.390645/43.290998; 0.390246/43.335372 | 0.333668/50.683415; 0.333876/50.651840; 0.333812/50.661551 |
| 256 | 0.429413/78.765355; 0.427638/79.092380; 0.428053/79.015514 | 0.375733/90.018477; 0.374037/90.426529; 0.373957/90.445873 |
| 512 | 0.444006/152.353200; 0.443462/152.540265; 0.443061/152.677980 | 0.392325/172.422698; 0.390437/173.256244; 0.390629/173.171086 |
| 1024 | 0.470117/287.782246; 0.469606/288.095701; 0.469766/287.997577 | 0.421669/320.847560; 0.421285/321.139631; 0.421094/321.286056 |
| 2048 | 0.520502/519.849952; 0.520663/519.688704; 0.520695/519.657764 | 0.467029/579.370125; 0.462583/584.939221; 0.463302/584.031452 |
| 4096 | 0.630568/858.219699; 0.632584/855.484614; 0.630952/857.697383 | 0.669480/808.337634; 0.671946/805.371685; 0.652424/829.468972 |
| 8192 | 0.913452/1184.880824; 0.912989/1185.481058; 0.913388/1184.963199 | 1.143407/946.584863; 1.163777/930.016454; 1.175152/921.014268 |

</details>

**Derived performance summary (median of three sweeps)**

| Tokens | CuteDSL W4A4 ms | CuteDSL W4A16 ms |
| --- | --- | --- |
| 1 | 0.037025 | 0.025825 |
| 2 | 0.063681 | 0.044353 |
| 4 | 0.103218 | 0.074096 |
| 8 | 0.146562 | 0.104353 |
| 16 | 0.187971 | 0.139378 |
| 32 | 0.256978 | 0.205251 |
| 64 | 0.322884 | 0.269123 |
| 128 | 0.390246 | 0.333812 |
| 256 | 0.428053 | 0.374037 |
| 512 | 0.443462 | 0.390629 |
| 1024 | 0.469766 | 0.421285 |
| 2048 | 0.520663 | 0.463302 |
| 4096 | 0.630952 | 0.669480 |
| 8192 | 0.913388 | 1.163777 |

TRTLLM speedups are unavailable: native SiTU kernels support neither BF16 nor NVFP4 per-token scaling.

## 🔍 Related Issues

- Follow-up to merged [#4985](https://github.com/flashinfer-ai/flashinfer/pull/4985), which added the TRTLLM BF16 comparison.
- Earlier W4A16 implementation and recipe reference: [#4048](https://github.com/flashinfer-ai/flashinfer/pull/4048).

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

Validation summary revision: `a2b23d27c43379a78561f5d5c4c6bc7d0bd49786`. Measured performance revision: `a2b23d27c43379a78561f5d5c4c6bc7d0bd49786`.

- **Preset, unsupported-mode, printing and file-scoped pre-commit checks: passed**, tested `a2b23d27c43379a78561f5d5c4c6bc7d0bd49786`. CPU-only regression checks; pre-commit targets only the changed benchmark file.

<details>
<summary>Preset, unsupported-mode, printing and file-scoped pre-commit checks: command and complete output</summary>

```bash
python3 validate_model_config_ast.py
(cd flashinfer && pre-commit run --files benchmarks/bench_moe_deepseek.py)
```

```text
$ python3 /Users/ziangli/playground/projects/flashinfer-glm5-kimi-k3-moe-benchmark/validate_model_config_ast.py
PASS deepseek-v3: exact preset, default backend eligibility, EP8 and TP2 -> TP1 reset
PASS glm5: exact preset, default backend eligibility, EP8 and TP2 -> TP1 reset
PASS kimi-k3: exact preset, default backend eligibility, EP8 and TP2 -> TP1 reset
PASS explicit expert override does not mutate presets or subsequent DeepSeek defaults
PASS Kimi K3 rejects unsupported TRTLLM BF16: backend selection
PASS Kimi K3 rejects unsupported TRTLLM BF16: benchmark backend
PASS Kimi K3 rejects unsupported TRTLLM BF16: profiler backend
PASS exact TRTLLM eligibility for all three presets in per-tensor and per-token modes
PASS Kimi K3 rejects unsupported per-token TRTLLM NVFP4 before GPU work: backend selection
PASS Kimi K3 rejects unsupported per-token TRTLLM NVFP4 before GPU work: benchmark backend
PASS Kimi K3 rejects unsupported per-token TRTLLM NVFP4 before GPU work: profiler backend
PASS Kimi K3 rejects unsupported per-token TRTLLM NVFP4 before GPU work: direct TRTLLM helper
PASS CLI backend and profiler selections refuse SiTU per-token TRTLLM NVFP4 before GPU detection
PASS glm5: allocate outside timed closure, live native routing inputs, full expert range and two replay copies
PASS kimi-k3: allocate outside timed closure, live native routing inputs, full expert range and two replay copies
PASS original DeepSeek fused routing API receives unchanged arguments
PASS default Kimi K3 verbose benchmark per_token=False returns every result and prints only supported backend CSV rows
PASS default Kimi K3 verbose benchmark per_token=True returns every result and prints only supported backend CSV rows
PASS default DeepSeek verbose benchmark retains its legacy table and returns every result
PASS Kimi K3 CLI reports supported backend scope and per-token SiTU omission accurately
PASS all CPU-only AST checks; GPU math, kernel support and performance not tested here
$ pre-commit run --files benchmarks/bench_moe_deepseek.py
check for added large files..............................................Passed
check for case conflicts.................................................Passed
check for merge conflicts................................................Passed
check for broken symlinks............................(no files to check)Skipped
fix end of files.........................................................Passed
mixed line ending........................................................Passed
fix requirements.txt.................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
Tabs remover.............................................................Passed
CRLF end-lines remover...................................................Passed
clang-format.........................................(no files to check)Skipped
mypy.................................................(no files to check)Skipped
ruff check...............................................................Passed
ruff format..............................................................Passed
experimental test scope selftest.....................(no files to check)Skipped
$ git diff --check
```

</details>

- **Supported GPU numerical and graph cases: passed**, tested `1fe7e28c1ecdc0e53123bec4d9377a64f0f80d23`. 31 supported cases and 18 routing endpoints passed; the shared per-token process then failed on the explicitly excluded K3 TRTLLM combination. Later source edits add eligibility guards and fix printing. Complete case metrics are below; full process logs and the exact harness are in the evidence bundle.

<details>
<summary>Supported GPU numerical and graph cases: command and complete output</summary>

```bash
# Run from the evidence directory, with the FlashInfer clone in ./flashinfer.
# The numerical evidence below was collected at this revision.
git -C flashinfer checkout 1fe7e28c1ecdc0e53123bec4d9377a64f0f80d23
export CUDA_VISIBLE_DEVICES=0 MAX_JOBS=16
python3 validate_model_benchmarks.py --recipe inference-per-tensor --output validation-inference-per-tensor.json
# This shared process records six GLM-5 passes before the documented native K3 failure.
python3 validate_model_benchmarks.py --recipe inference-per-token --output validation-inference-per-token.json
python3 validate_model_benchmarks.py --recipe inference-per-token --models kimi-k3 --backends cute-w4a4 cute-w4a16 --output validation-inference-per-token-kimi-k3-cute.json
python3 validate_model_benchmarks.py --recipe deterministic-rl --models glm5 --output validation-deterministic-rl-glm5.json
python3 validate_model_benchmarks.py --recipe deterministic-rl --models kimi-k3 --backends cute-w4a4 cute-w4a16 --output validation-deterministic-rl-kimi-k3-cute.json
# Return to the performance revision for the sweeps.
git -C flashinfer checkout a2b23d27c43379a78561f5d5c4c6bc7d0bd49786
```

Numerical validation used source `1fe7e28c1ecdc0e53123bec4d9377a64f0f80d23` and unchanged harness SHA256 `a8938a7ac42a632ec0663a17f4b176d043ae49caa32fbf2b4b2b2e8606ee793a`. All31 supported cases,18 routing endpoints and93 graph replays passed, including all10 exact RL cases. Autotuning was disabled for these reduced-dimension checks.

Validation-only K3 stress inputs use hidden states×40 and FC2 weights×0.25; benchmark inputs remain unchanged. Initial random-routing cutoff/rounding disagreements and an unnormalized atomic-finalize repeat difference are retained in the evidence bundle. Final tolerances were not relaxed. The unsupported K3 native per-token attempt is excluded from the31 passes. Native NVFP4 controls compare identical prepared operands, not an independent quantized reference.

## Complete case metrics

Each case uses32 tokens, H256/I512, offset0, global/local experts256/32 and top8 for GLM-5 or896/112 and top16 for Kimi K3. Groups1/1 and route scales2.5/1.0; SiTU4/25 only for Kimi. GLM has31 local routes and Kimi69. All outputs were finite BF16. Reference fraction is governed by the unchanged97% threshold, rtol0.5 or the listed magnitude-scaled atol. BF16 dense reference uses0.03 relative/absolute. Direct controls and non-exact inference repeats use0.03 relative/absolute.

| Recipe | Model | Backend | API | Direct max abs | Ref mean abs | Ref max abs | Ref atol | Wrong SwiGLU mean abs | Ref fraction | Replays | Exact repeats |
|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---|
| inference-per-tensor | GLM-5 | CuTe DSL W4A4 | functional | 0.0 | 0.0001714375102892518 | — | 0.05 | — | 1.0 | 3 | False |
| inference-per-tensor | GLM-5 | CuTe DSL W4A16 | functional | 0.0 | 1.5013637494121213e-05 | — | 0.05 | — | 1.0 | 3 | False |
| inference-per-tensor | GLM-5 | TRTLLM NVFP4 | functional | 0.0 | — | — | — | — | — | 3 | True |
| inference-per-tensor | GLM-5 | TRTLLM BF16 | functional | 0.0 | — | 0.0001220703125 | 0.03 | — | — | 3 | True |
| inference-per-tensor | GLM-5 | CuTe DSL W4A4 | wrapper | 0.0 | 0.0001714375102892518 | — | 0.05 | — | 1.0 | 3 | False |
| inference-per-tensor | GLM-5 | CuTe DSL W4A16 | wrapper | 0.0 | 1.5013637494121213e-05 | — | 0.05 | — | 1.0 | 3 | False |
| inference-per-tensor | Kimi K3 | CuTe DSL W4A4 | functional | 0.03125 | 0.014876585453748703 | — | 0.9627599716186523 | 0.6398165822029114 | 1.0 | 3 | False |
| inference-per-tensor | Kimi K3 | CuTe DSL W4A16 | functional | 0.015625 | 0.0013970485888421535 | — | 0.9630039632320404 | 0.6339031457901001 | 1.0 | 3 | False |
| inference-per-tensor | Kimi K3 | TRTLLM NVFP4 | functional | 0.0 | — | — | — | — | — | 3 | True |
| inference-per-tensor | Kimi K3 | CuTe DSL W4A4 | wrapper | 0.015625 | 0.014890478923916817 | — | 0.9627599716186523 | 0.6398178935050964 | 1.0 | 3 | False |
| inference-per-tensor | Kimi K3 | CuTe DSL W4A16 | wrapper | 0.03125 | 0.0013893507421016693 | — | 0.9630039632320404 | 0.6339240074157715 | 1.0 | 3 | False |
| inference-per-token | GLM-5 | CuTe DSL W4A4 | functional | 0.0 | 1.0569760888756718e-05 | — | 0.05 | — | 1.0 | 3 | False |
| inference-per-token | GLM-5 | CuTe DSL W4A16 | functional | 0.0 | 1.5013637494121213e-05 | — | 0.05 | — | 1.0 | 3 | False |
| inference-per-token | GLM-5 | TRTLLM NVFP4 | functional | 0.0 | — | — | — | — | — | 3 | True |
| inference-per-token | GLM-5 | TRTLLM BF16 | functional | 0.0 | — | 0.0001220703125 | 0.03 | — | — | 3 | True |
| inference-per-token | GLM-5 | CuTe DSL W4A4 | wrapper | 0.0 | 1.0569760888756718e-05 | — | 0.05 | — | 1.0 | 3 | False |
| inference-per-token | GLM-5 | CuTe DSL W4A16 | wrapper | 0.0 | 1.5013637494121213e-05 | — | 0.05 | — | 1.0 | 3 | False |
| inference-per-token | Kimi K3 | CuTe DSL W4A4 | functional | 0.015625 | 0.0011092256754636765 | — | 0.9655836224555969 | 0.647232174873352 | 1.0 | 3 | False |
| inference-per-token | Kimi K3 | CuTe DSL W4A16 | functional | 0.015625 | 0.0013928955886512995 | — | 0.9630039632320404 | 0.633931040763855 | 1.0 | 3 | False |
| inference-per-token | Kimi K3 | CuTe DSL W4A4 | wrapper | 0.03125 | 0.001098404172807932 | — | 0.9655836224555969 | 0.6472175121307373 | 1.0 | 3 | False |
| inference-per-token | Kimi K3 | CuTe DSL W4A16 | wrapper | 0.015625 | 0.0013879274483770132 | — | 0.9630039632320404 | 0.6339304447174072 | 1.0 | 3 | False |
| deterministic-rl | GLM-5 | CuTe DSL W4A4 | functional | 0.0 | 1.198070549435215e-05 | — | 0.05 | — | 1.0 | 3 | True |
| deterministic-rl | GLM-5 | CuTe DSL W4A16 | functional | 0.0 | 1.6585512639721856e-05 | — | 0.05 | — | 1.0 | 3 | True |
| deterministic-rl | GLM-5 | TRTLLM NVFP4 | functional | 0.0 | — | — | — | — | — | 3 | True |
| deterministic-rl | GLM-5 | TRTLLM BF16 | functional | 0.0 | — | 0.0001220703125 | 0.03 | — | — | 3 | True |
| deterministic-rl | GLM-5 | CuTe DSL W4A4 | wrapper | 0.0 | 1.198070549435215e-05 | — | 0.05 | — | 1.0 | 3 | True |
| deterministic-rl | GLM-5 | CuTe DSL W4A16 | wrapper | 0.0 | 1.6585512639721856e-05 | — | 0.05 | — | 1.0 | 3 | True |
| deterministic-rl | Kimi K3 | CuTe DSL W4A4 | functional | 0.0 | 0.0009637976763769984 | — | 0.9622988104820251 | 0.6402673125267029 | 1.0 | 3 | True |
| deterministic-rl | Kimi K3 | CuTe DSL W4A16 | functional | 0.0 | 0.0012526029022410512 | — | 0.9642719328403473 | 0.6330076456069946 | 1.0 | 3 | True |
| deterministic-rl | Kimi K3 | CuTe DSL W4A4 | wrapper | 0.0 | 0.0009637976763769984 | — | 0.9622988104820251 | 0.6402673125267029 | 1.0 | 3 | True |
| deterministic-rl | Kimi K3 | CuTe DSL W4A16 | wrapper | 0.0 | 0.0012526029022410512 | — | 0.9642719328403473 | 0.6330076456069946 | 1.0 | 3 | True |

## Complete routing endpoint checks

All checks passed exact expert-set comparison and rtol=atol=1e-6 for the native BF16 route weights widened toFP32; two separated logit levels avoid cutoff ambiguity. Selected unbiased probabilities are uniform despite nonuniform correction bias. These checks allocate routing-only hidden width256, not expert weights.

| Recipe | Model | Tokens | Global experts | Top-k | Selected weight | Result |
|---|---|---:|---:|---:|---:|---|
| deterministic-rl | GLM-5 | 1 | 256 | 8 | 0.3125 | PASS |
| deterministic-rl | GLM-5 | 32 | 256 | 8 | 0.3125 | PASS |
| deterministic-rl | GLM-5 | 8192 | 256 | 8 | 0.3125 | PASS |
| deterministic-rl | Kimi K3 | 1 | 896 | 16 | 0.0625 | PASS |
| deterministic-rl | Kimi K3 | 32 | 896 | 16 | 0.0625 | PASS |
| deterministic-rl | Kimi K3 | 8192 | 896 | 16 | 0.0625 | PASS |
| inference-per-tensor | GLM-5 | 1 | 256 | 8 | 0.3125 | PASS |
| inference-per-tensor | GLM-5 | 32 | 256 | 8 | 0.3125 | PASS |
| inference-per-tensor | GLM-5 | 8192 | 256 | 8 | 0.3125 | PASS |
| inference-per-tensor | Kimi K3 | 1 | 896 | 16 | 0.0625 | PASS |
| inference-per-tensor | Kimi K3 | 32 | 896 | 16 | 0.0625 | PASS |
| inference-per-tensor | Kimi K3 | 8192 | 896 | 16 | 0.0625 | PASS |
| inference-per-token | GLM-5 | 1 | 256 | 8 | 0.3125 | PASS |
| inference-per-token | GLM-5 | 32 | 256 | 8 | 0.3125 | PASS |
| inference-per-token | GLM-5 | 8192 | 256 | 8 | 0.3125 | PASS |
| inference-per-token | Kimi K3 | 1 | 896 | 16 | 0.0625 | PASS |
| inference-per-token | Kimi K3 | 32 | 896 | 16 | 0.0625 | PASS |
| inference-per-token | Kimi K3 | 8192 | 896 | 16 | 0.0625 | PASS |


</details>

- **Pinned TRTLLM SiTU manifest coverage audit: passed**, tested `a2b23d27c43379a78561f5d5c4c6bc7d0bd49786`. All 6,846 entries parsed and both checksum levels verified: zero SiTU per-token-scaling or BF16-output candidates.

<details>
<summary>Pinned TRTLLM SiTU manifest coverage audit: command and complete output</summary>

```bash
python3 audit_trtllm_situ_manifest.py
```

```text
{
  "artifact_url": "https://edge.urm.nvidia.com/artifactory/sw-kernelinferencelibrary-public-generic-local/1d145b82ac60add55ea213863523f12d63005651/batched_gemm-09795a1-31ee4e5/",
  "checksums_sha256": "e071273ce357ee3e8d40ce905dac03d2a6078f6c5869ca3b7d1f1d146643f009",
  "metainfo_sha256": "f85800a2f9bf8e8ff61ccb82ea5d83e34dab850465aa9db0eb8f2d8522920299",
  "manifest_entries": 6846,
  "fused_situ_entries": 588,
  "situ_entries_by_arch": {
    "Sm100f": 294,
    "Sm107a": 294
  },
  "situ_any_per_token_scaling_entries": 0,
  "situ_bf16_output_entries": 0,
  "nvfp4_situ_entries_by_arch": {
    "Sm100f": 74,
    "Sm107a": 74
  },
  "nvfp4_situ_tile_n_values": [
    8,
    16,
    32,
    64,
    128,
    192,
    256
  ],
  "positive_control_nvfp4_swiglu_per_token_entries": 424,
  "positive_control_blackwell_nvfp4_swiglu_per_token_bf16_output_entries": 142,
  "nvfp4_situ_example": {
    "line": 8609,
    "name": "bmm_E2m1_E2m1E2m1_Fp32_Ab16_Bb16_Cb16_t128x8x512u2_s5_et128x8_m128x8x64_c1x1x1_rM_TN_transOut_schedS_biasFp32M_bN_ldgsts_ldgstsSf_rgTma_clmp_siTuGlu_dynB_sm100f",
    "mDtypeA": 17826818,
    "mDtypeB": 17826818,
    "mDtypeC": 17826818,
    "mTileN": 8,
    "mTransposeMmaOutput": 1,
    "mUsePerTokenSfA": 0,
    "mUsePerTokenSfB": 0,
    "mActType": 2,
    "mFusedAct": 1,
    "arch": "Sm100f"
  }
}
PASS: all pinned manifest entries parsed; SiTU has no per-token row-scale or BF16-output candidate at any tile/architecture
```

</details>

- **Full-shape autotuned output checks: passed**, tested `a2b23d27c43379a78561f5d5c4c6bc7d0bd49786`. All seven cases use full model dimensions and 8,192 tokens, matching the performance API, autotuning and included initial quantization. All seven direct controls and eager repeats, and all21 graph replays, match exactly.

<details>
<summary>Full-shape autotuned output checks: command and complete output</summary>

```bash
# Follow the evidence bundle README to clone the pinned source and restore the harness layout.
for group in glm5-rl kimi-k3-rl kimi-k3-inference-per-tensor; do
  CUDA_VISIBLE_DEVICES=0 FLASHINFER_DISABLE_VERSION_CHECK=1 python3 -u validate_full_shape_outputs.py --repo ./flashinfer --group "$group" --output "artifacts/validation-full-shape-$group.json" >"artifacts/validation-full-shape-$group.log" 2>&1
done
```

### Full-shape output checks

All **7 cases passed**, with **21 exact CUDA graph replays** and three independent separated-logit routing endpoint checks at **8,192 tokens**. Source: `a2b23d27c43379a78561f5d5c4c6bc7d0bd49786`. CuTe uses the wrapper API; TRTLLM uses its functional APIs. All cases run real pre-warm autotuning and include initial activation quantization in the checked runner.

Published H/I, global expert counts/top-k and EP8 locality use the unchanged benchmark seed42 inputs. The numerical validation's SiTU stress multipliers are not applied. Random routing is checked against a direct native canonical-router prepared-operand control; its copy/ABI adapter matches exactly. Independent PyTorch routing checks use separated endpoint logits to avoid the previously documented random cutoff/rounding differences.

| Model | Recipe | Backend | API | Direct control max absolute error | Finite/API | Exact eager repeat | Exact graph replays |
| --- | --- | --- | --- | ---: | --- | --- | ---: |
| GLM-5 | Deterministic RL | CuteDSL W4A4 | Wrapper | 0 | Pass | Pass | 3 |
| GLM-5 | Deterministic RL | CuteDSL W4A16 | Wrapper | 0 | Pass | Pass | 3 |
| GLM-5 | Deterministic RL | TRTLLM NVFP4 | Functional | 0 | Pass | Pass | 3 |
| GLM-5 | Deterministic RL | TRTLLM BF16 | Functional | 0 | Pass | Pass | 3 |
| Kimi K3 (SiTU) | Deterministic RL | CuteDSL W4A4 | Wrapper | 0 | Pass | Pass | 3 |
| Kimi K3 (SiTU) | Deterministic RL | CuteDSL W4A16 | Wrapper | 0 | Pass | Pass | 3 |
| Kimi K3 (SiTU) | Inference per-tensor | TRTLLM NVFP4 | Functional | 0 | Pass | Pass | 3 |

Direct prepared-operand controls retain `rtol=atol=0.03`; eager and graph replay comparisons require exact values. Every compared output must match the explicitly finite initial output, so NaN/Inf fail. These checks do not run dense/quantized numerical references, establish cross-precision parity or model accuracy, check every autotuner candidate, or establish end-to-end training determinism. CUTLASS is excluded; unsupported Kimi K3 native BF16 and per-token NVFP4 remain excluded.

Full-shape helper SHA-256: `ddeab882e30505f62f2556bc66ae521b0b1d14f743cacae3466ada2717e314ca`. Original numerical harness SHA-256: `a8938a7ac42a632ec0663a17f4b176d043ae49caa32fbf2b4b2b2e8606ee793a` (unchanged31,014 bytes). Complete raw JSON/logs and hashes are retained in the accompanying summary provenance.


</details>

**Validation limits:**

- No CUTLASS validation or timing was run. The new CUTLASS activation forwarding remains untested.
- Reduced-dimension numerical checks and isolated routed-core timings do not establish full-model accuracy or training determinism.
- TRTLLM BF16 lacks SiTU; TRTLLM NVFP4 lacks SiTU with per-token activation scaling. These unsupported cells have no performance results.

The complete repository test suite and `pre-commit run --all-files` are not claimed; their template checkboxes remain unchecked.

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

Please review the model presets, native SiTU forwarding, and routing/timing boundary. This draft adds benchmark coverage and evidence; it does not implement new expert kernels. The devbox and its compilation caches are retained for additional performance work.
