### PR TITLE
docs: clarify max_seq_len numerical behavior

### DIFF
--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -3518,14 +3518,15 @@ def trtllm_batch_decode_with_kv_cache(
         Host-side upper bound on the sequence lengths in ``kv_cache``. It must be at
         least ``max(seq_lens)``.
 
-        For the ``trtllm-gen`` backend, this value participates in kernel selection,
-        including the KV split and reduction strategy. Consequently, different valid
-        upper bounds can change the floating-point accumulation order, and their
-        outputs are not guaranteed to be bitwise identical (although they remain
-        numerically equivalent within the documented dtype tolerances). Because CUDA
-        Graph capture freezes this host value, use the same ``max_seq_len`` in eager
-        execution and graph capture when bitwise reproducibility between them is
-        required.
+        On devices supported by the ``trtllm-gen`` backend (compute capability major
+        10), this value participates in kernel selection, including tile size, the KV
+        split, and reduction strategy. Different valid upper bounds can therefore
+        introduce extra work and change the floating-point accumulation order. Their
+        outputs are not guaranteed to be bitwise identical, but remain numerically
+        equivalent within the tolerances exercised by the supported SM10x test
+        matrix. Because CUDA Graph capture freezes this host value, use the same
+        ``max_seq_len`` in eager execution and graph capture when bitwise
+        reproducibility between them is required.
 
     bmm1_scale : Union[float, torch.Tensor]
         fused scale for bmm1 input.

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -3515,7 +3515,17 @@ def trtllm_batch_decode_with_kv_cache(
         order, only the final selected page of a row may be partially filled.
 
     max_seq_len : int
-        max sequence length for kv_cache
+        Host-side upper bound on the sequence lengths in ``kv_cache``. It must be at
+        least ``max(seq_lens)``.
+
+        For the ``trtllm-gen`` backend, this value participates in kernel selection,
+        including the KV split and reduction strategy. Consequently, different valid
+        upper bounds can change the floating-point accumulation order, and their
+        outputs are not guaranteed to be bitwise identical (although they remain
+        numerically equivalent within the documented dtype tolerances). Because CUDA
+        Graph capture freezes this host value, use the same ``max_seq_len`` in eager
+        execution and graph capture when bitwise reproducibility between them is
+        required.
 
     bmm1_scale : Union[float, torch.Tensor]
         fused scale for bmm1 input.


### PR DESCRIPTION
## Summary

- clarify that max_seq_len is a host-side upper bound for KV sequence lengths
- document that the TRT-LLM backend uses this hint for KV split, reduction, and kernel selection
- explain the resulting floating-point reproducibility contract and how to keep eager and CUDA Graph execution bitwise aligned

## Testing

- ruff format --check flashinfer/decode.py
- ruff check flashinfer/decode.py
- git diff --check
- reproduced the reported hint-dependent BF16 output on B200/SM100 with current main; all paths remained within expected numerical tolerance

Fixes #4647


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded `max_seq_len` documentation for batch decoding with a KV cache on `trtllm-gen` devices with compute capability major 10.
  * Clarified its effects on tile size, KV splitting, reduction strategy, extra work, accumulation order, and numerical equivalence.
  * Documented the requirement to use the same value during eager execution and CUDA Graph capture for bitwise reproducibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->