### PR TITLE
build: raise the nvidia-cudnn-frontend floor to 1.29.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ nccl-extensions>=0.1.0
 nccl4py>=0.4.1
 ninja
 numpy
-nvidia-cudnn-frontend>=1.25.0
+nvidia-cudnn-frontend>=1.29.0
 nvidia-cutlass-dsl>=4.6.2a0
 nvidia-ml-py
 packaging>=24.2

--- a/scripts/build_in_container.sh
+++ b/scripts/build_in_container.sh
@@ -140,7 +140,7 @@ if [[ -n "${CUDA_EXTRA_DEPENDENCY_OUTPUT}" ]]; then
 fi
 uv pip install --python "${VENV}/bin/python" \
     numpy einops ninja nvidia-ml-py click requests tabulate tqdm \
-    "${CUDA_EXTRA_DEPENDENCIES[@]}" "nvidia-cudnn-frontend>=1.13.0" \
+    "${CUDA_EXTRA_DEPENDENCIES[@]}" "nvidia-cudnn-frontend>=1.29.0" \
     "cuda-tile>=1.4.0" "cuda-python>=13.0" \
     "nccl-extensions>=0.1.0" "nccl4py>=0.4.1" \
     "nvidia-nccl-cu13>=2.30.7"   # B200 NCCL-EP needs >=2.30.7; load this first on LD_LIBRARY_PATH


### PR DESCRIPTION
## Summary

Re-lands the `nvidia-cudnn-frontend` floor bump that was reverted in #5159, this time at **1.29.0**, which fixes the breakage that forced the revert.

## Background: why #5131 was reverted

#5131 raised the floor `1.25.0` → `1.28.0` and broke `JIT Unittest (H100)` on `main` (#5157, 134 failed nodes, blocking every PR). Frontend 1.28 began enforcing a constraint 1.27 did not:

> `cudnnGraphNotSupportedError: For cuDNN version below 9.26.0, a non-ragged Stats output must be a packed BHSD tensor.`

FlashInfer declares the LSE/Stats tensor token-major (`flashinfer/cudnn/prefill.py:586`), which is not packed BHSD, and CI runs backend `nvidia-cudnn-cu12` **9.24.0.43** — below the 9.26.0 cutoff. #5159 reverted the floor to `>=1.25.0`.

## Why 1.29.0 resolves it

[NVIDIA/cudnn-frontend#1023](https://github.com/NVIDIA/cudnn-frontend/pull/1023) — *"sdpa: accept any Stats output layout on the forward (drop the pre-9.26 packed-BHSD guard)"* — lowered the forward threshold from `9.26.0` to `9.12.0`. It merged 2026-09-12, before v1.29.0 was tagged.

Backend 9.24 is above 9.12, so the token-major Stats declaration is now accepted as-is, with no change needed to `prefill.py`.

Verified directly against the published wheel rather than the tag:

```console
$ strings nvidia_cudnn_frontend-1.29.0/cudnn/_compiled_module*.so | grep 'non-ragged Stats'
For cuDNN version below 9.26.0, a non-ragged Stats input of sdpa_backward must be a packed BHSD tensor.
For cuDNN version below 9.12.0, a non-ragged Stats output must be a packed BHSD tensor.
```

The guard that still reads 9.26.0 is on the backward Stats **input** (`sdpa_backward`), which the failing prefill tests do not exercise.

## Why raise the floor at all

The declared floor sits below what shipped code already requires. `_cudnn_supports_direct_seqlens` gates fp8 / mixed-dtype prefill on frontend `(1, 27)`:

```python
if mixed or (dtype in (torch.float8_e4m3fn, torch.float8_e5m2)):
    min_backend, min_frontend = 92500, (1, 27)
```

while `requirements.txt` asked only for `>=1.25.0`. On a resolved 1.25 or 1.26 that check returns `False` and the token-unit direct path is silently skipped — no error, no warning. Since the frontend exposes no capability query, the declared floor is the only place that information can live.

## Also: `scripts/build_in_container.sh`

It carried an independent and much staler `nvidia-cudnn-frontend>=1.13.0` for the same package; this moves it to 1.29.0 so the two agree. CodeRabbit flagged the same inconsistency on #5131.

This is not incidental — **it is what makes this PR testable.** `SKIP_CI_PATTERNS` (`.github/workflows/pr-test.yml:53`) includes `\.txt$`, which matches `requirements.txt`. A requirements-only change is classified as docs/config and skips the entire GPU suite, which is why #5131 reported green without ever running a test (see @aleozlx's addendum on #5157). Touching a `.sh` file means the suite actually runs here.

Independently of this PR, narrowing `\.txt$` so dependency manifests are never skipped looks worth doing — a dependency-floor bump is the change most likely to alter the runtime environment under every test, and currently the one change guaranteed not to be tested.

## Relationship to #5161

#5161 (packed LSE declared as ragged Stats) fixes the same symptom from the FlashInfer side and remains worthwhile on its own merits — it also repairs `return_lse` on the wrapper path. The two are independent: this PR clears #5157 by moving past the frontend version that introduced the guard, and needs no code change. They should not conflict.

## Test plan

`run-ci` applied so the H100 suite runs. The nodes to watch are the ones that failed in #5157:

- `tests/attention/test_cudnn_prefill_token_indptr.py` (133 nodes)
- `tests/attention/test_cudnn_graph_cache_key.py` (1 node)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum required version of the NVIDIA cuDNN frontend dependency to 1.29.0 for installations and container builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->