### PR TITLE
Fix automatic CUB top-k dispatch for short inputs

### DIFF
--- a/flashinfer/topk.py
+++ b/flashinfer/topk.py
@@ -646,7 +646,9 @@ def can_use_clusters_topk(algo, device, deterministic, tie_break, dsa_graph_safe
     return (algo is None or algo == "clusters") and not deterministic and cap[0] == 10
 
 
-def can_use_cub_topk(algo, input_tensor, tie_break, deterministic, sorted_output=False):
+def can_use_cub_topk(
+    algo, input_tensor, k, tie_break, deterministic, sorted_output=False
+):
     """Whether the CUB (DeviceBatchedTopK) backend can serve this call."""
 
     # CUB returns unsorted results and has no reproducible-ordering mode, so
@@ -658,6 +660,9 @@ def can_use_cub_topk(algo, input_tensor, tie_break, deterministic, sorted_output
     if input_tensor.dtype not in (torch.float32, torch.float16, torch.bfloat16):
         return False
     d = input_tensor.size(1)
+    # Preserve native short-row padding in auto mode; forced CUB keeps its shape error.
+    if algo is None and k > d:
+        return False
     if d > (1 << 21):
         return False  # DeviceBatchedTopK per-segment limit
     # Pre-SM90 devices only have the single-block backend (d <= 8192) and no
@@ -960,7 +965,7 @@ def top_k(
     )
 
     if can_use_cub_topk(
-        algo, input, tie_break, deterministic, sorted
+        algo, input, k, tie_break, deterministic, sorted
     ) and is_cub_topk_beneficial(
         algo,
         batch_size,
@@ -1219,7 +1224,7 @@ def top_k_page_table_transform(
     )
 
     if can_use_cub_topk(
-        algo, input, tie_break, deterministic
+        algo, input, k, tie_break, deterministic
     ) and is_cub_page_table_transform_beneficial(
         algo,
         input.size(0),
@@ -1398,7 +1403,7 @@ def top_k_ragged_transform(
     )
 
     if can_use_cub_topk(
-        algo, input, tie_break, deterministic
+        algo, input, k, tie_break, deterministic
     ) and is_cub_ragged_transform_beneficial(
         algo,
         input.size(0),

--- a/tests/utils/test_topk.py
+++ b/tests/utils/test_topk.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import os
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -3205,8 +3206,167 @@ def test_topk_clusters_ragged_transform(num_rows, seq_len, k, dtype):
 # ===================== CUB DeviceBatchedTopK backend Tests =====================
 # The CUB backend serves top_k_page_table_transform through the dispatcher, so the general
 # transform test grid above already exercises it (and the "cub" entries in the algorithm
-# parametrizations force it explicitly). The tests here cover only what is unique to the
-# CUB backend: its lengths <= 0 semantics and its binding-level workspace contract.
+# parametrizations force it explicitly). The tests here cover CUB dispatch boundaries,
+# its lengths <= 0 semantics, and its binding-level workspace contract.
+
+
+@pytest.mark.parametrize("api", ["top_k", "page_table", "ragged"])
+@pytest.mark.parametrize(
+    "tie_break",
+    [flashinfer.TopKTieBreak.SMALL, flashinfer.TopKTieBreak.LARGE],
+    ids=["small", "large"],
+)
+@pytest.mark.parametrize(
+    ("width", "k"),
+    [(64, 2048), (4096, 2048), (64, 64)],
+    ids=["short_width", "normal_width", "equal_width"],
+)
+def test_cub_auto_physical_width_dispatch(api, tie_break, width, k, set_topk_algo):
+    """Auto must preserve native padding without disabling eligible CUB calls."""
+    _require_cub_tie_break_support()
+    if k > width and not can_implement_filtered_topk():
+        pytest.skip("Filtered top-k not supported on this device")
+    set_topk_algo("auto")
+    num_rows, page_size = 4, 64
+    scores = torch.zeros((num_rows, width), device="cuda", dtype=torch.float32)
+    lengths = torch.full((num_rows,), width, device="cuda", dtype=torch.int32)
+    offsets = torch.arange(1, num_rows + 1, device="cuda", dtype=torch.int32) * 10000
+    page_table = (
+        torch.arange(num_rows * (width // page_size), device="cuda", dtype=torch.int32)
+        .flip(0)
+        .reshape(num_rows, -1)
+        + 100
+    )
+    out = torch.empty((num_rows, k), device="cuda", dtype=torch.int32)
+    raw = torch.empty_like(out)
+    output_pointers = out.data_ptr(), raw.data_ptr()
+    kwargs = dict(tie_break=tie_break, dsa_graph_safe=True)
+
+    def run():
+        if api == "top_k":
+            return flashinfer.top_k(scores, k, **kwargs)
+        if api == "page_table":
+            result = flashinfer.top_k_page_table_transform(
+                scores,
+                page_table,
+                lengths,
+                k,
+                page_size=page_size,
+                out=out,
+                out_raw_indices=raw,
+                **kwargs,
+            )
+            return (result,)
+        return (
+            flashinfer.top_k_ragged_transform(scores, offsets, lengths, k, **kwargs),
+        )
+
+    def check(result):
+        indices = result[-1]
+        assert indices.shape == (num_rows, k)
+        assert indices.dtype == (torch.int64 if api == "top_k" else torch.int32)
+        if api == "top_k":
+            assert result[0].shape == indices.shape
+            assert result[0].dtype == scores.dtype
+        if api == "page_table":
+            assert (indices.data_ptr(), raw.data_ptr()) == output_pointers
+        for row in range(num_rows):
+            length = width if api == "top_k" else lengths[row].item()
+            valid = min(k, length)
+            row_scores = scores[row, :length]
+            # Stable sorting establishes exact boundary selection for both tie modes.
+            if tie_break == flashinfer.TopKTieBreak.SMALL:
+                expected = torch.argsort(row_scores, descending=True, stable=True)[
+                    :valid
+                ]
+            else:
+                expected = (
+                    length
+                    - 1
+                    - torch.argsort(row_scores.flip(0), descending=True, stable=True)[
+                        :valid
+                    ]
+                )
+            if api == "page_table":
+                _assert_unordered_indices_match(raw[row, :valid], expected)
+                assert torch.all(raw[row, valid:] == -1)
+                expected = page_table[row, expected // page_size] * page_size + (
+                    expected % page_size
+                )
+                raw_valid = raw[row, :valid].long()
+                assert torch.equal(
+                    indices[row, :valid],
+                    page_table[row, raw_valid // page_size] * page_size
+                    + raw_valid % page_size,
+                )
+            elif api == "ragged":
+                expected = expected + offsets[row]
+            else:
+                assert torch.equal(
+                    result[0][row, :valid], scores[row, indices[row, :valid]]
+                )
+                assert torch.all(result[0][row, valid:] == 0)
+            _assert_unordered_indices_match(indices[row, :valid], expected)
+            assert torch.all(indices[row, valid:] == -1)
+
+    module = flashinfer.topk.get_topk_module()
+    query_name = {
+        "top_k": "cub_topk_workspace_size",
+        "page_table": "cub_topk_page_table_transform_workspace_size",
+        "ragged": "cub_topk_ragged_transform_workspace_size",
+    }[api]
+    with patch.object(module, query_name, wraps=getattr(module, query_name)) as query:
+        check(run())
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            run()
+        torch.cuda.current_stream().wait_stream(stream)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            captured = run()
+        graph.replay()
+        torch.cuda.synchronize()
+        check(captured)
+
+        # Capture full rows, then change both selection and mapping inputs in place.
+        # Shrinking to partial/empty rows must overwrite previously valid output slots.
+        scores[:, 1::2] = 1
+        lengths.copy_(
+            torch.tensor(
+                [width, min(width - 1, k), width // 4 if width > k else width // 2, 0],
+                device="cuda",
+                dtype=torch.int32,
+            )
+        )
+        page_table.add_(1000)
+        offsets.add_(1000)
+        graph.replay()
+        torch.cuda.synchronize()
+        check(captured)
+        check(run())
+        assert query.called == (k <= width)
+
+
+@pytest.mark.parametrize("api", ["top_k", "page_table", "ragged"])
+def test_cub_forced_short_width(api, set_topk_algo):
+    """Explicit CUB retains its existing physical-width validation."""
+    _require_cub_tie_break_support()
+    set_topk_algo("cub")
+    scores = torch.zeros((4, 64), device="cuda")
+    lengths = torch.full((4,), 64, device="cuda", dtype=torch.int32)
+    kwargs = dict(tie_break=flashinfer.TopKTieBreak.LARGE, dsa_graph_safe=True)
+    with pytest.raises(RuntimeError, match="0 < top_k <= d"):
+        if api == "top_k":
+            flashinfer.top_k(scores, 2048, **kwargs)
+        elif api == "page_table":
+            page_table = torch.ones((4, 1), device="cuda", dtype=torch.int32)
+            flashinfer.top_k_page_table_transform(
+                scores, page_table, lengths, 2048, page_size=64, **kwargs
+            )
+        else:
+            offsets = torch.zeros_like(lengths)
+            flashinfer.top_k_ragged_transform(scores, offsets, lengths, 2048, **kwargs)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

@humansand

Fix automatic CUB selection when the requested `k` exceeds the physical score
width. A four-row FP32 DSA call with width 64, `k=2048`, and
`dsa_graph_safe=True` could select CUB and fail in its workspace query:

```text
cub_topk requires 0 < top_k <= d, got top_k=2048, d=64
```

- **Change:** pass `k` into the shared `can_use_cub_topk` gate from `top_k`,
  `top_k_page_table_transform`, and `top_k_ragged_transform`. With
  `FLASHINFER_TOPK_ALGO` unset, `k > input.size(1)` now declines CUB before its
  workspace query. Public API signatures and C++ code are unchanged.
- **Resulting behavior:** the DSA graph-safe / explicit tie-break cases use
  the existing filtered native backend. Valid positions are selected and the
  remaining suffix is padded: index `-1` / value `0` for plain top-k, and
  index `-1` for paged/ragged transforms. Page translation and ragged offsets
  apply only to valid indices.
- **Preserved contracts:** an otherwise eligible explicit
  `FLASHINFER_TOPK_ALGO=cub` request still reaches CUB's existing shape
  validation. Normal eligible automatic CUB calls, the `k == width` boundary,
  CUB's short logical rows, and existing dtype, architecture,
  sorted/deterministic and benefit gates remain unchanged. The guard uses
  physical width; it does not read device-resident `lengths`.
- **Scope:** no kernel, workspace growth, input padding, index postprocessing,
  or performance claim. This does not extend the filtered native limit beyond
  `k=2048` or establish that every native/cluster configuration accepts
  `k > width`.

## 🔍 Related Issues

- [SGLang W4A16 MegaMoE integration and serving validation (#39210)](https://github.com/sgl-project/sglang/pull/39210): the startup failure motivated this follow-up. Its published GLM benchmark used FlashInfer `083a9fd39e7ddda43a8b912ef50f7a13390287f9` with explicit `FLASHINFER_TOPK_ALGO=default`, before this fix. Those measurements do not validate or benchmark the new automatic-dispatch guard.
- [CUB top-k backend (#4442)](https://github.com/flashinfer-ai/flashinfer/pull/4442): existing backend and dispatch policy extended by this shape check.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

Checks were scoped to the two changed files with `pre-commit run --files`
rather than `--all-files`. The first run formatted `flashinfer/topk.py`; the
second run and the subsequent commit hook passed all applicable checks.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).


**Validation:** all 21 new regressions and 122 selected existing controls pass
on the fixed source, with zero errors or skips. Restoring only the parent
Python dispatcher produces the six expected CUB shape failures. All phases
use the identical native JIT binary and unchanged regression test file.
The full-suite checkbox remains unchecked because validation was scoped to
these cases.

- **Base:** `488ffbd9fe4455c3b4c3030cf668b5603c6698e4`.
- **Tested PR revision:** `62ff0a1751a537af89e5e2353ea1ca72954ba165`.
- **Selected standalone image:** `nvcr.io/nvidia/pytorch:26.05-py3`
  (CUDA 13.2.1.009); resolved digest
  `sha256:222d8b18e671be5c3ef91cb41727a2572a0b23f59ded6c39f373a96946f6f2ba`.
- **Verified environment:** c2 node `hu-pdx-10`, GPU 0 of eight NVIDIA B300
  SXM6 AC devices (SM103), driver 590.48.01; Python 3.12.3, CUDA compiler
  13.2.78. Image Torch `2.12.0a0+5aff3928d8.nv26.05` / CUDA 13.2 is retained
  with its original module path. FlashInfer reports version 0.7.0 from the
  source checkout; added packages are apache-tvm-ffi 0.1.11, pytest 8.4.2,
  iniconfig 2.3.0 and pluggy 1.6.0. Ninja 1.13.0 and CUDA Python/bindings
  13.2.0 remain from the image.
- **Native module identity:** no `flashinfer-cubin` or `flashinfer-jit-cache`
  distribution is installed, and top-k has no AOT library. A fresh SM103a
  native top-k JIT build from the clean base produced a 21,139,440-byte module,
  SHA256 `06b44eb1709cbe1a25706d267b29b1dc783b5bdfe21db65c0ff1780cafa1af21`;
  all 13 expected native exports were verified, including the three CUB
  workspace queries. The fixed commit changes no native source.
- **Baseline setup smoke:** at the clean base, all three APIs passed exact
  selected-set checks for four FP32 rows, width 4096 / `k=2048`, descending
  and all-equal scores, SMALL/LARGE ties, eager execution and CUDA graph
  replay; paged selection used page size 64. This covers already-valid CUB
  inputs. The initial smoke harness omitted `page_size=64` and was stopped
  before GPU smoke calls; the corrected harness reused the identical fresh
  native build. This setup correction changed no FlashInfer source.
- **Environment scope:** image CuTe DSL 4.4.2, cuTile 1.3.0 and cuDNN frontend
  1.23.0 were retained. They do not satisfy the current package's general
  requirements for those unrelated paths; this validation is limited to
  native top-k, with no CuTe, cuTile, cuDNN or MoE EP kernel claim.
- **New regressions:** all three APIs, physical width 64 / `k=2048`, both
  SMALL/LARGE ties, eager and CUDA graph replay after in-place score/metadata
  changes; exact selected sets, padding and index translation. Paged outputs
  additionally check caller-provided buffer addresses.
- **Controls:** eligible automatic CUB at width 4096 / `k=2048` with its actual
  workspace-query path observed, `k == width`, short/empty logical rows, and
  preserved forced-CUB rejection. Existing compact-page graph replay,
  tie-break, deterministic, workspace and CUB nonpositive-length checks are
  separate controls. Sorted-output gating is unchanged by source inspection;
  the selected GPU controls do not include `sorted=True`. Native negative-length
  behavior is outside this fix.

Reproduction setup inside the selected image, preserving its Torch installation:

```bash
set -euo pipefail
TASK_ROOT="$PWD/flashinfer-cub-topk-short-input"
PR_SOURCE_URL="https://github.com/zianglih/flashinfer.git"
BASE_COMMIT="488ffbd9fe4455c3b4c3030cf668b5603c6698e4"
TESTED_COMMIT="62ff0a1751a537af89e5e2353ea1ca72954ba165"
mkdir -p "$TASK_ROOT"
cd "$TASK_ROOT"
python -m venv --system-site-packages .venv
source .venv/bin/activate
git clone --filter=blob:none --no-checkout "$PR_SOURCE_URL" flashinfer
cd flashinfer
git fetch --depth=1 origin "$BASE_COMMIT"
git fetch --depth=1 origin "$TESTED_COMMIT"
git checkout --detach "$TESTED_COMMIT"
git submodule update --init --depth=1 \
  3rdparty/cutlass 3rdparty/cccl 3rdparty/spdlog
python -m pip install --no-deps \
  apache-tvm-ffi==0.1.11 pytest==8.4.2 iniconfig==2.3.0 pluggy==1.6.0
BUILD_NVEP=0 BUILD_NIXL_EP=0 BUILD_NCCL_EP=0 \
  python -m pip install --no-deps --no-build-isolation -e .
export PYTHONPATH="$TASK_ROOT/flashinfer"
export CUDA_VISIBLE_DEVICES=0
export FLASHINFER_WORKSPACE_BASE="$TASK_ROOT/cache"
export FLASHINFER_CUDA_ARCH_LIST=10.3a
export FLASHINFER_NVCC_THREADS=4 NVCC_THREADS=4 MAX_JOBS=4 OMP_NUM_THREADS=4
export PYTHONUNBUFFERED=1
unset FLASHINFER_TOPK_ALGO
mkdir -p "$TASK_ROOT/artifacts"
```

The base comparison keeps the new regression test file at the fixed commit,
restores only `flashinfer/topk.py` from the base, then restores the identical
fixed dispatcher. The native module is built from the base and reused across
all three test phases:

```bash
# Build the same native source on the clean base before testing the Python fix.
git checkout --detach "$BASE_COMMIT"
python - <<'BUILD'
import hashlib
from flashinfer.jit.topk import gen_topk_module
from flashinfer.topk import get_topk_module

spec = gen_topk_module()
assert not spec.is_aot
native = spec.build_and_load()
expected_exports = (
    "can_implement_filtered_topk", "cub_topk", "cub_topk_workspace_size",
    "cub_topk_page_table_transform", "cub_topk_page_table_transform_workspace_size",
    "cub_topk_ragged_transform", "cub_topk_ragged_transform_workspace_size",
    "fast_topk_clusters_exact", "fast_topk_clusters_exact_page_table_transform",
    "fast_topk_clusters_exact_ragged_transform", "radix_topk",
    "radix_topk_page_table_transform", "radix_topk_ragged_transform",
)
assert all(hasattr(native, name) for name in expected_exports)
get_topk_module()
print("Native module SHA256:", hashlib.sha256(spec.jit_library_path.read_bytes()).hexdigest())
BUILD
git checkout --detach "$TESTED_COMMIT"
NATIVE_LIB="$TASK_ROOT/cache/.cache/flashinfer/0.7.0/103a/cached_ops/topk/topk.so"
NATIVE_SHA_BEFORE=$(sha256sum "$NATIVE_LIB" | cut -d ' ' -f 1)

cp flashinfer/topk.py "$TASK_ROOT/artifacts/topk-fixed.py"
trap 'cp "$TASK_ROOT/artifacts/topk-fixed.py" flashinfer/topk.py' EXIT
git show "$BASE_COMMIT:flashinfer/topk.py" > flashinfer/topk.py
set +e
python -m pytest -q tests/utils/test_topk.py \
  -k 'cub_auto_physical_width_dispatch and short_width' \
  --junitxml="$TASK_ROOT/artifacts/parent-regression.xml" \
  > "$TASK_ROOT/artifacts/parent-regression.log" 2>&1
PARENT_EXIT=$?
set -e
cp "$TASK_ROOT/artifacts/topk-fixed.py" flashinfer/topk.py
trap - EXIT
test "$PARENT_EXIT" -eq 1

python -m pytest -q tests/utils/test_topk.py \
  -k 'cub_auto_physical_width_dispatch or cub_forced_short_width' \
  --junitxml="$TASK_ROOT/artifacts/fixed-regression.xml" \
  > "$TASK_ROOT/artifacts/fixed-regression.log" 2>&1
python -m pytest -q tests/utils/test_topk.py \
  -k 'compact_pages_cuda_graph_replay or cub_transform_nonpositive_lengths or tie_break_modes or cub_transform_workspace_paths or top_k_deterministic_trivial_k_equals_length_by_algo' \
  --junitxml="$TASK_ROOT/artifacts/existing-controls.xml" \
  > "$TASK_ROOT/artifacts/existing-controls.log" 2>&1

test "$(sha256sum "$NATIVE_LIB" | cut -d ' ' -f 1)" = "$NATIVE_SHA_BEFORE"
test -z "$(git status --porcelain)"
python - "$TASK_ROOT/artifacts" <<'VERIFY'
from pathlib import Path
import sys
import xml.etree.ElementTree as ET

root = Path(sys.argv[1])
for name, count, failures in (
    ("parent-regression", 6, 6),
    ("fixed-regression", 21, 0),
    ("existing-controls", 122, 0),
):
    cases = ET.parse(root / f"{name}.xml").getroot().findall(".//testcase")
    failed = [case for case in cases if case.find("failure") is not None]
    assert len(cases) == count and len(failed) == failures
    assert not any(case.find("error") is not None or case.find("skipped") is not None for case in cases)
    assert all("cub_topk requires 0 < top_k <= d" in case.find("failure").text for case in failed)
    print(name, "tests:", count, "expected failures:", failures, "errors: 0, skipped: 0")
VERIFY
```

The captured source hashes confirm the intended comparison:

| File / phase | SHA256 |
|---|---|
| Parent `flashinfer/topk.py` | `0b6e8d04d14317d55f4536a42b0e6d0dfdfec55ef86c9038c79fbcb6e5dd3dd1` |
| Fixed `flashinfer/topk.py`, both passing phases | `9fc4a304ba06483143048f48b5dc7c1d3402c7c1f6cebf78c9c80358b03d8665` |
| `tests/utils/test_topk.py`, all phases | `89f9d48087e01c180686128d61bd7718699ab4f73e0ff3c8224ca9497b841c2c` |

Final remote verification found the fixed checkout clean and the native module
SHA256 unchanged from the baseline smoke. These are correctness tests, not
kernel performance measurements. The full top-k suite and other GPU
architectures were not run.

| Phase | Passed | Expected failures | Errors | Skipped | Pytest duration (s) |
|---|---:|---:|---:|---:|---:|
| Parent dispatcher + new short-width tests | 0 | 6 | 0 | 0 | 4.39 |
| Fixed dispatcher + new regressions | 21 | 0 | 0 | 0 | 4.20 |
| Fixed dispatcher + existing controls | 122 | 0 | 0 | 0 | 4.42 |

Complete raw pytest stdout, including the expected parent failures:

<details>
<summary>Parent dispatcher: all six expected failures</summary>

```text
FFFFFF                                                                   [100%]
=================================== FAILURES ===================================
________ test_cub_auto_physical_width_dispatch[short_width-small-top_k] ________

api = 'top_k', tie_break = TopKTieBreak.SMALL, width = 64, k = 2048
set_topk_algo = <function set_topk_algo.<locals>._set_algo at 0x75dc95e34900>

    @pytest.mark.parametrize("api", ["top_k", "page_table", "ragged"])
    @pytest.mark.parametrize(
        "tie_break",
        [flashinfer.TopKTieBreak.SMALL, flashinfer.TopKTieBreak.LARGE],
        ids=["small", "large"],
    )
    @pytest.mark.parametrize(
        ("width", "k"),
        [(64, 2048), (4096, 2048), (64, 64)],
        ids=["short_width", "normal_width", "equal_width"],
    )
    def test_cub_auto_physical_width_dispatch(api, tie_break, width, k, set_topk_algo):
        """Auto must preserve native padding without disabling eligible CUB calls."""
        _require_cub_tie_break_support()
        if k > width and not can_implement_filtered_topk():
            pytest.skip("Filtered top-k not supported on this device")
        set_topk_algo("auto")
        num_rows, page_size = 4, 64
        scores = torch.zeros((num_rows, width), device="cuda", dtype=torch.float32)
        lengths = torch.full((num_rows,), width, device="cuda", dtype=torch.int32)
        offsets = torch.arange(1, num_rows + 1, device="cuda", dtype=torch.int32) * 10000
        page_table = (
            torch.arange(num_rows * (width // page_size), device="cuda", dtype=torch.int32)
            .flip(0)
            .reshape(num_rows, -1)
            + 100
        )
        out = torch.empty((num_rows, k), device="cuda", dtype=torch.int32)
        raw = torch.empty_like(out)
        output_pointers = out.data_ptr(), raw.data_ptr()
        kwargs = dict(tie_break=tie_break, dsa_graph_safe=True)
    
        def run():
            if api == "top_k":
                return flashinfer.top_k(scores, k, **kwargs)
            if api == "page_table":
                result = flashinfer.top_k_page_table_transform(
                    scores,
                    page_table,
                    lengths,
                    k,
                    page_size=page_size,
                    out=out,
                    out_raw_indices=raw,
                    **kwargs,
                )
                return (result,)
            return (
                flashinfer.top_k_ragged_transform(scores, offsets, lengths, k, **kwargs),
            )
    
        def check(result):
            indices = result[-1]
            assert indices.shape == (num_rows, k)
            assert indices.dtype == (torch.int64 if api == "top_k" else torch.int32)
            if api == "top_k":
                assert result[0].shape == indices.shape
                assert result[0].dtype == scores.dtype
            if api == "page_table":
                assert (indices.data_ptr(), raw.data_ptr()) == output_pointers
            for row in range(num_rows):
                length = width if api == "top_k" else lengths[row].item()
                valid = min(k, length)
                row_scores = scores[row, :length]
                # Stable sorting establishes exact boundary selection for both tie modes.
                if tie_break == flashinfer.TopKTieBreak.SMALL:
                    expected = torch.argsort(row_scores, descending=True, stable=True)[
                        :valid
                    ]
                else:
                    expected = (
                        length
                        - 1
                        - torch.argsort(row_scores.flip(0), descending=True, stable=True)[
                            :valid
                        ]
                    )
                if api == "page_table":
                    _assert_unordered_indices_match(raw[row, :valid], expected)
                    assert torch.all(raw[row, valid:] == -1)
                    expected = page_table[row, expected // page_size] * page_size + (
                        expected % page_size
                    )
                    raw_valid = raw[row, :valid].long()
                    assert torch.equal(
                        indices[row, :valid],
                        page_table[row, raw_valid // page_size] * page_size
                        + raw_valid % page_size,
                    )
                elif api == "ragged":
                    expected = expected + offsets[row]
                else:
                    assert torch.equal(
                        result[0][row, :valid], scores[row, indices[row, :valid]]
                    )
                    assert torch.all(result[0][row, valid:] == 0)
                _assert_unordered_indices_match(indices[row, :valid], expected)
                assert torch.all(indices[row, valid:] == -1)
    
        module = flashinfer.topk.get_topk_module()
        query_name = {
            "top_k": "cub_topk_workspace_size",
            "page_table": "cub_topk_page_table_transform_workspace_size",
            "ragged": "cub_topk_ragged_transform_workspace_size",
        }[api]
        with patch.object(module, query_name, wraps=getattr(module, query_name)) as query:
>           check(run())
                  ^^^^^

tests/utils/test_topk.py:3319: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/utils/test_topk.py:3247: in run
    return flashinfer.top_k(scores, k, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
flashinfer/topk.py:978: in top_k
    workspace_bytes = topk_module.cub_topk_workspace_size(input, k, int(tie_break))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.12/unittest/mock.py:1134: in __call__
    return self._mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.12/unittest/mock.py:1138: in _mock_call
    return self._execute_mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.12/unittest/mock.py:1211: in _execute_mock_call
    return self._mock_wraps(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python/tvm_ffi/cython/function.pxi:968: in tvm_ffi.core.Function.__call__
    ???
<unknown>:0: in __tvm_ffi_cub_topk_workspace_size
    ???
<unknown>:0: in cub_topk_workspace_size(tvm::ffi::TensorView, long, long)
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   TVM_FFI_ICHECK(top_k > 0 && top_k <= max_len)
E   RuntimeError: Check failed: (top_k > 0 && top_k <= max_len) is false: cub_topk requires 0 < top_k <= d, got top_k=2048, d=64

csrc/cub_topk.cu:454: RuntimeError
_____ test_cub_auto_physical_width_dispatch[short_width-small-page_table] ______

api = 'page_table', tie_break = TopKTieBreak.SMALL, width = 64, k = 2048
set_topk_algo = <function set_topk_algo.<locals>._set_algo at 0x75dc95e327a0>

    @pytest.mark.parametrize("api", ["top_k", "page_table", "ragged"])
    @pytest.mark.parametrize(
        "tie_break",
        [flashinfer.TopKTieBreak.SMALL, flashinfer.TopKTieBreak.LARGE],
        ids=["small", "large"],
    )
    @pytest.mark.parametrize(
        ("width", "k"),
        [(64, 2048), (4096, 2048), (64, 64)],
        ids=["short_width", "normal_width", "equal_width"],
    )
    def test_cub_auto_physical_width_dispatch(api, tie_break, width, k, set_topk_algo):
        """Auto must preserve native padding without disabling eligible CUB calls."""
        _require_cub_tie_break_support()
        if k > width and not can_implement_filtered_topk():
            pytest.skip("Filtered top-k not supported on this device")
        set_topk_algo("auto")
        num_rows, page_size = 4, 64
        scores = torch.zeros((num_rows, width), device="cuda", dtype=torch.float32)
        lengths = torch.full((num_rows,), width, device="cuda", dtype=torch.int32)
        offsets = torch.arange(1, num_rows + 1, device="cuda", dtype=torch.int32) * 10000
        page_table = (
            torch.arange(num_rows * (width // page_size), device="cuda", dtype=torch.int32)
            .flip(0)
            .reshape(num_rows, -1)
            + 100
        )
        out = torch.empty((num_rows, k), device="cuda", dtype=torch.int32)
        raw = torch.empty_like(out)
        output_pointers = out.data_ptr(), raw.data_ptr()
        kwargs = dict(tie_break=tie_break, dsa_graph_safe=True)
    
        def run():
            if api == "top_k":
                return flashinfer.top_k(scores, k, **kwargs)
            if api == "page_table":
                result = flashinfer.top_k_page_table_transform(
                    scores,
                    page_table,
                    lengths,
                    k,
                    page_size=page_size,
                    out=out,
                    out_raw_indices=raw,
                    **kwargs,
                )
                return (result,)
            return (
                flashinfer.top_k_ragged_transform(scores, offsets, lengths, k, **kwargs),
            )
    
        def check(result):
            indices = result[-1]
            assert indices.shape == (num_rows, k)
            assert indices.dtype == (torch.int64 if api == "top_k" else torch.int32)
            if api == "top_k":
                assert result[0].shape == indices.shape
                assert result[0].dtype == scores.dtype
            if api == "page_table":
                assert (indices.data_ptr(), raw.data_ptr()) == output_pointers
            for row in range(num_rows):
                length = width if api == "top_k" else lengths[row].item()
                valid = min(k, length)
                row_scores = scores[row, :length]
                # Stable sorting establishes exact boundary selection for both tie modes.
                if tie_break == flashinfer.TopKTieBreak.SMALL:
                    expected = torch.argsort(row_scores, descending=True, stable=True)[
                        :valid
                    ]
                else:
                    expected = (
                        length
                        - 1
                        - torch.argsort(row_scores.flip(0), descending=True, stable=True)[
                            :valid
                        ]
                    )
                if api == "page_table":
                    _assert_unordered_indices_match(raw[row, :valid], expected)
                    assert torch.all(raw[row, valid:] == -1)
                    expected = page_table[row, expected // page_size] * page_size + (
                        expected % page_size
                    )
                    raw_valid = raw[row, :valid].long()
                    assert torch.equal(
                        indices[row, :valid],
                        page_table[row, raw_valid // page_size] * page_size
                        + raw_valid % page_size,
                    )
                elif api == "ragged":
                    expected = expected + offsets[row]
                else:
                    assert torch.equal(
                        result[0][row, :valid], scores[row, indices[row, :valid]]
                    )
                    assert torch.all(result[0][row, valid:] == 0)
                _assert_unordered_indices_match(indices[row, :valid], expected)
                assert torch.all(indices[row, valid:] == -1)
    
        module = flashinfer.topk.get_topk_module()
        query_name = {
            "top_k": "cub_topk_workspace_size",
            "page_table": "cub_topk_page_table_transform_workspace_size",
            "ragged": "cub_topk_ragged_transform_workspace_size",
        }[api]
        with patch.object(module, query_name, wraps=getattr(module, query_name)) as query:
>           check(run())
                  ^^^^^

tests/utils/test_topk.py:3319: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/utils/test_topk.py:3249: in run
    result = flashinfer.top_k_page_table_transform(
flashinfer/api_logging.py:2348: in _auto_dump_wrapper
    return _inner(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^
flashinfer/topk.py:1236: in top_k_page_table_transform
    workspace_bytes = topk_module.cub_topk_page_table_transform_workspace_size(
/usr/lib/python3.12/unittest/mock.py:1134: in __call__
    return self._mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.12/unittest/mock.py:1138: in _mock_call
    return self._execute_mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.12/unittest/mock.py:1211: in _execute_mock_call
    return self._mock_wraps(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python/tvm_ffi/cython/function.pxi:968: in tvm_ffi.core.Function.__call__
    ???
<unknown>:0: in __tvm_ffi_cub_topk_page_table_transform_workspace_size
    ???
<unknown>:0: in cub_topk_page_table_transform_workspace_size(tvm::ffi::TensorView, tvm::ffi::TensorView, long, long, bool, bool)
    ???
<unknown>:0: in (anonymous namespace)::CheckCUBTopKArgs(tvm::ffi::TensorView const&, tvm::ffi::TensorView const&, long, long)
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   TVM_FFI_ICHECK(top_k > 0 && top_k <= max_len)
E   RuntimeError: Check failed: (top_k > 0 && top_k <= max_len) is false: cub_topk requires 0 < top_k <= d, got top_k=2048, d=64

csrc/cub_topk.cu:454: RuntimeError
_______ test_cub_auto_physical_width_dispatch[short_width-small-ragged] ________

api = 'ragged', tie_break = TopKTieBreak.SMALL, width = 64, k = 2048
set_topk_algo = <function set_topk_algo.<locals>._set_algo at 0x75dc95da80e0>

    @pytest.mark.parametrize("api", ["top_k", "page_table", "ragged"])
    @pytest.mark.parametrize(
        "tie_break",
        [flashinfer.TopKTieBreak.SMALL, flashinfer.TopKTieBreak.LARGE],
        ids=["small", "large"],
    )
    @pytest.mark.parametrize(
        ("width", "k"),
        [(64, 2048), (4096, 2048), (64, 64)],
        ids=["short_width", "normal_width", "equal_width"],
    )
    def test_cub_auto_physical_width_dispatch(api, tie_break, width, k, set_topk_algo):
        """Auto must preserve native padding without disabling eligible CUB calls."""
        _require_cub_tie_break_support()
        if k > width and not can_implement_filtered_topk():
            pytest.skip("Filtered top-k not supported on this device")
        set_topk_algo("auto")
        num_rows, page_size = 4, 64
        scores = torch.zeros((num_rows, width), device="cuda", dtype=torch.float32)
        lengths = torch.full((num_rows,), width, device="cuda", dtype=torch.int32)
        offsets = torch.arange(1, num_rows + 1, device="cuda", dtype=torch.int32) * 10000
        page_table = (
            torch.arange(num_rows * (width // page_size), device="cuda", dtype=torch.int32)
            .flip(0)
            .reshape(num_rows, -1)
            + 100
        )
        out = torch.empty((num_rows, k), device="cuda", dtype=torch.int32)
        raw = torch.empty_like(out)
        output_pointers = out.data_ptr(), raw.data_ptr()
        kwargs = dict(tie_break=tie_break, dsa_graph_safe=True)
    
        def run():
            if api == "top_k":
                return flashinfer.top_k(scores, k, **kwargs)
            if api == "page_table":
                result = flashinfer.top_k_page_table_transform(
                    scores,
                    page_table,
                    lengths,
                    k,
                    page_size=page_size,
                    out=out,
                    out_raw_indices=raw,
                    **kwargs,
                )
                return (result,)
            return (
                flashinfer.top_k_ragged_transform(scores, offsets, lengths, k, **kwargs),
            )
    
        def check(result):
            indices = result[-1]
            assert indices.shape == (num_rows, k)
            assert indices.dtype == (torch.int64 if api == "top_k" else torch.int32)
            if api == "top_k":
                assert result[0].shape == indices.shape
                assert result[0].dtype == scores.dtype
            if api == "page_table":
                assert (indices.data_ptr(), raw.data_ptr()) == output_pointers
            for row in range(num_rows):
                length = width if api == "top_k" else lengths[row].item()
                valid = min(k, length)
                row_scores = scores[row, :length]
                # Stable sorting establishes exact boundary selection for both tie modes.
                if tie_break == flashinfer.TopKTieBreak.SMALL:
                    expected = torch.argsort(row_scores, descending=True, stable=True)[
                        :valid
                    ]
                else:
                    expected = (
                        length
                        - 1
                        - torch.argsort(row_scores.flip(0), descending=True, stable=True)[
                            :valid
                        ]
                    )
                if api == "page_table":
                    _assert_unordered_indices_match(raw[row, :valid], expected)
                    assert torch.all(raw[row, valid:] == -1)
                    expected = page_table[row, expected // page_size] * page_size + (
                        expected % page_size
                    )
                    raw_valid = raw[row, :valid].long()
                    assert torch.equal(
                        indices[row, :valid],
                        page_table[row, raw_valid // page_size] * page_size
                        + raw_valid % page_size,
                    )
                elif api == "ragged":
                    expected = expected + offsets[row]
                else:
                    assert torch.equal(
                        result[0][row, :valid], scores[row, indices[row, :valid]]
                    )
                    assert torch.all(result[0][row, valid:] == 0)
                _assert_unordered_indices_match(indices[row, :valid], expected)
                assert torch.all(indices[row, valid:] == -1)
    
        module = flashinfer.topk.get_topk_module()
        query_name = {
            "top_k": "cub_topk_workspace_size",
            "page_table": "cub_topk_page_table_transform_workspace_size",
            "ragged": "cub_topk_ragged_transform_workspace_size",
        }[api]
        with patch.object(module, query_name, wraps=getattr(module, query_name)) as query:
>           check(run())
                  ^^^^^

tests/utils/test_topk.py:3319: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/utils/test_topk.py:3261: in run
    flashinfer.top_k_ragged_transform(scores, offsets, lengths, k, **kwargs),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
flashinfer/api_logging.py:2348: in _auto_dump_wrapper
    return _inner(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^
flashinfer/topk.py:1415: in top_k_ragged_transform
    workspace_bytes = topk_module.cub_topk_ragged_transform_workspace_size(
/usr/lib/python3.12/unittest/mock.py:1134: in __call__
    return self._mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.12/unittest/mock.py:1138: in _mock_call
    return self._execute_mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.12/unittest/mock.py:1211: in _execute_mock_call
    return self._mock_wraps(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python/tvm_ffi/cython/function.pxi:968: in tvm_ffi.core.Function.__call__
    ???
<unknown>:0: in __tvm_ffi_cub_topk_ragged_transform_workspace_size
    ???
<unknown>:0: in cub_topk_ragged_transform_workspace_size(tvm::ffi::TensorView, tvm::ffi::TensorView, long, long, bool)
    ???
<unknown>:0: in (anonymous namespace)::CheckCUBTopKArgs(tvm::ffi::TensorView const&, tvm::ffi::TensorView const&, long, long)
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   TVM_FFI_ICHECK(top_k > 0 && top_k <= max_len)
E   RuntimeError: Check failed: (top_k > 0 && top_k <= max_len) is false: cub_topk requires 0 < top_k <= d, got top_k=2048, d=64

csrc/cub_topk.cu:454: RuntimeError
________ test_cub_auto_physical_width_dispatch[short_width-large-top_k] ________

api = 'top_k', tie_break = TopKTieBreak.LARGE, width = 64, k = 2048
set_topk_algo = <function set_topk_algo.<locals>._set_algo at 0x75dc95e33600>

    @pytest.mark.parametrize("api", ["top_k", "page_table", "ragged"])
    @pytest.mark.parametrize(
        "tie_break",
        [flashinfer.TopKTieBreak.SMALL, flashinfer.TopKTieBreak.LARGE],
        ids=["small", "large"],
    )
    @pytest.mark.parametrize(
        ("width", "k"),
        [(64, 2048), (4096, 2048), (64, 64)],
        ids=["short_width", "normal_width", "equal_width"],
    )
    def test_cub_auto_physical_width_dispatch(api, tie_break, width, k, set_topk_algo):
        """Auto must preserve native padding without disabling eligible CUB calls."""
        _require_cub_tie_break_support()
        if k > width and not can_implement_filtered_topk():
            pytest.skip("Filtered top-k not supported on this device")
        set_topk_algo("auto")
        num_rows, page_size = 4, 64
        scores = torch.zeros((num_rows, width), device="cuda", dtype=torch.float32)
        lengths = torch.full((num_rows,), width, device="cuda", dtype=torch.int32)
        offsets = torch.arange(1, num_rows + 1, device="cuda", dtype=torch.int32) * 10000
        page_table = (
            torch.arange(num_rows * (width // page_size), device="cuda", dtype=torch.int32)
            .flip(0)
            .reshape(num_rows, -1)
            + 100
        )
        out = torch.empty((num_rows, k), device="cuda", dtype=torch.int32)
        raw = torch.empty_like(out)
        output_pointers = out.data_ptr(), raw.data_ptr()
        kwargs = dict(tie_break=tie_break, dsa_graph_safe=True)
    
        def run():
            if api == "top_k":
                return flashinfer.top_k(scores, k, **kwargs)
            if api == "page_table":
                result = flashinfer.top_k_page_table_transform(
                    scores,
                    page_table,
                    lengths,
                    k,
                    page_size=page_size,
                    out=out,
                    out_raw_indices=raw,
                    **kwargs,
                )
                return (result,)
            return (
                flashinfer.top_k_ragged_transform(scores, offsets, lengths, k, **kwargs),
            )
    
        def check(result):
            indices = result[-1]
            assert indices.shape == (num_rows, k)
            assert indices.dtype == (torch.int64 if api == "top_k" else torch.int32)
            if api == "top_k":
                assert result[0].shape == indices.shape
                assert result[0].dtype == scores.dtype
            if api == "page_table":
                assert (indices.data_ptr(), raw.data_ptr()) == output_pointers
            for row in range(num_rows):
                length = width if api == "top_k" else lengths[row].item()
                valid = min(k, length)
                row_scores = scores[row, :length]
                # Stable sorting establishes exact boundary selection for both tie modes.
                if tie_break == flashinfer.TopKTieBreak.SMALL:
                    expected = torch.argsort(row_scores, descending=True, stable=True)[
                        :valid
                    ]
                else:
                    expected = (
                        length
                        - 1
                        - torch.argsort(row_scores.flip(0), descending=True, stable=True)[
                            :valid
                        ]
                    )
                if api == "page_table":
                    _assert_unordered_indices_match(raw[row, :valid], expected)
                    assert torch.all(raw[row, valid:] == -1)
                    expected = page_table[row, expected // page_size] * page_size + (
                        expected % page_size
                    )
                    raw_valid = raw[row, :valid].long()
                    assert torch.equal(
                        indices[row, :valid],
                        page_table[row, raw_valid // page_size] * page_size
                        + raw_valid % page_size,
                    )
                elif api == "ragged":
                    expected = expected + offsets[row]
                else:
                    assert torch.equal(
                        result[0][row, :valid], scores[row, indices[row, :valid]]
                    )
                    assert torch.all(result[0][row, valid:] == 0)
                _assert_unordered_indices_match(indices[row, :valid], expected)
                assert torch.all(indices[row, valid:] == -1)
    
        module = flashinfer.topk.get_topk_module()
        query_name = {
            "top_k": "cub_topk_workspace_size",
            "page_table": "cub_topk_page_table_transform_workspace_size",
            "ragged": "cub_topk_ragged_transform_workspace_size",
        }[api]
        with patch.object(module, query_name, wraps=getattr(module, query_name)) as query:
>           check(run())
                  ^^^^^

tests/utils/test_topk.py:3319: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/utils/test_topk.py:3247: in run
    return flashinfer.top_k(scores, k, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
flashinfer/topk.py:978: in top_k
    workspace_bytes = topk_module.cub_topk_workspace_size(input, k, int(tie_break))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.12/unittest/mock.py:1134: in __call__
    return self._mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.12/unittest/mock.py:1138: in _mock_call
    return self._execute_mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.12/unittest/mock.py:1211: in _execute_mock_call
    return self._mock_wraps(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python/tvm_ffi/cython/function.pxi:968: in tvm_ffi.core.Function.__call__
    ???
<unknown>:0: in __tvm_ffi_cub_topk_workspace_size
    ???
<unknown>:0: in cub_topk_workspace_size(tvm::ffi::TensorView, long, long)
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   TVM_FFI_ICHECK(top_k > 0 && top_k <= max_len)
E   RuntimeError: Check failed: (top_k > 0 && top_k <= max_len) is false: cub_topk requires 0 < top_k <= d, got top_k=2048, d=64

csrc/cub_topk.cu:454: RuntimeError
_____ test_cub_auto_physical_width_dispatch[short_width-large-page_table] ______

api = 'page_table', tie_break = TopKTieBreak.LARGE, width = 64, k = 2048
set_topk_algo = <function set_topk_algo.<locals>._set_algo at 0x75dc95e360c0>

    @pytest.mark.parametrize("api", ["top_k", "page_table", "ragged"])
    @pytest.mark.parametrize(
        "tie_break",
        [flashinfer.TopKTieBreak.SMALL, flashinfer.TopKTieBreak.LARGE],
        ids=["small", "large"],
    )
    @pytest.mark.parametrize(
        ("width", "k"),
        [(64, 2048), (4096, 2048), (64, 64)],
        ids=["short_width", "normal_width", "equal_width"],
    )
    def test_cub_auto_physical_width_dispatch(api, tie_break, width, k, set_topk_algo):
        """Auto must preserve native padding without disabling eligible CUB calls."""
        _require_cub_tie_break_support()
        if k > width and not can_implement_filtered_topk():
            pytest.skip("Filtered top-k not supported on this device")
        set_topk_algo("auto")
        num_rows, page_size = 4, 64
        scores = torch.zeros((num_rows, width), device="cuda", dtype=torch.float32)
        lengths = torch.full((num_rows,), width, device="cuda", dtype=torch.int32)
        offsets = torch.arange(1, num_rows + 1, device="cuda", dtype=torch.int32) * 10000
        page_table = (
            torch.arange(num_rows * (width // page_size), device="cuda", dtype=torch.int32)
            .flip(0)
            .reshape(num_rows, -1)
            + 100
        )
        out = torch.empty((num_rows, k), device="cuda", dtype=torch.int32)
        raw = torch.empty_like(out)
        output_pointers = out.data_ptr(), raw.data_ptr()
        kwargs = dict(tie_break=tie_break, dsa_graph_safe=True)
    
        def run():
            if api == "top_k":
                return flashinfer.top_k(scores, k, **kwargs)
            if api == "page_table":
                result = flashinfer.top_k_page_table_transform(
                    scores,
                    page_table,
                    lengths,
                    k,
                    page_size=page_size,
                    out=out,
                    out_raw_indices=raw,
                    **kwargs,
                )
                return (result,)
            return (
                flashinfer.top_k_ragged_transform(scores, offsets, lengths, k, **kwargs),
            )
    
        def check(result):
            indices = result[-1]
            assert indices.shape == (num_rows, k)
            assert indices.dtype == (torch.int64 if api == "top_k" else torch.int32)
            if api == "top_k":
                assert result[0].shape == indices.shape
                assert result[0].dtype == scores.dtype
            if api == "page_table":
                assert (indices.data_ptr(), raw.data_ptr()) == output_pointers
            for row in range(num_rows):
                length = width if api == "top_k" else lengths[row].item()
                valid = min(k, length)
                row_scores = scores[row, :length]
                # Stable sorting establishes exact boundary selection for both tie modes.
                if tie_break == flashinfer.TopKTieBreak.SMALL:
                    expected = torch.argsort(row_scores, descending=True, stable=True)[
                        :valid
                    ]
                else:
                    expected = (
                        length
                        - 1
                        - torch.argsort(row_scores.flip(0), descending=True, stable=True)[
                            :valid
                        ]
                    )
                if api == "page_table":
                    _assert_unordered_indices_match(raw[row, :valid], expected)
                    assert torch.all(raw[row, valid:] == -1)
                    expected = page_table[row, expected // page_size] * page_size + (
                        expected % page_size
                    )
                    raw_valid = raw[row, :valid].long()
                    assert torch.equal(
                        indices[row, :valid],
                        page_table[row, raw_valid // page_size] * page_size
                        + raw_valid % page_size,
                    )
                elif api == "ragged":
                    expected = expected + offsets[row]
                else:
                    assert torch.equal(
                        result[0][row, :valid], scores[row, indices[row, :valid]]
                    )
                    assert torch.all(result[0][row, valid:] == 0)
                _assert_unordered_indices_match(indices[row, :valid], expected)
                assert torch.all(indices[row, valid:] == -1)
    
        module = flashinfer.topk.get_topk_module()
        query_name = {
            "top_k": "cub_topk_workspace_size",
            "page_table": "cub_topk_page_table_transform_workspace_size",
            "ragged": "cub_topk_ragged_transform_workspace_size",
        }[api]
        with patch.object(module, query_name, wraps=getattr(module, query_name)) as query:
>           check(run())
                  ^^^^^

tests/utils/test_topk.py:3319: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/utils/test_topk.py:3249: in run
    result = flashinfer.top_k_page_table_transform(
flashinfer/api_logging.py:2348: in _auto_dump_wrapper
    return _inner(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^
flashinfer/topk.py:1236: in top_k_page_table_transform
    workspace_bytes = topk_module.cub_topk_page_table_transform_workspace_size(
/usr/lib/python3.12/unittest/mock.py:1134: in __call__
    return self._mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.12/unittest/mock.py:1138: in _mock_call
    return self._execute_mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.12/unittest/mock.py:1211: in _execute_mock_call
    return self._mock_wraps(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python/tvm_ffi/cython/function.pxi:968: in tvm_ffi.core.Function.__call__
    ???
<unknown>:0: in __tvm_ffi_cub_topk_page_table_transform_workspace_size
    ???
<unknown>:0: in cub_topk_page_table_transform_workspace_size(tvm::ffi::TensorView, tvm::ffi::TensorView, long, long, bool, bool)
    ???
<unknown>:0: in (anonymous namespace)::CheckCUBTopKArgs(tvm::ffi::TensorView const&, tvm::ffi::TensorView const&, long, long)
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   TVM_FFI_ICHECK(top_k > 0 && top_k <= max_len)
E   RuntimeError: Check failed: (top_k > 0 && top_k <= max_len) is false: cub_topk requires 0 < top_k <= d, got top_k=2048, d=64

csrc/cub_topk.cu:454: RuntimeError
_______ test_cub_auto_physical_width_dispatch[short_width-large-ragged] ________

api = 'ragged', tie_break = TopKTieBreak.LARGE, width = 64, k = 2048
set_topk_algo = <function set_topk_algo.<locals>._set_algo at 0x75dc95da96c0>

    @pytest.mark.parametrize("api", ["top_k", "page_table", "ragged"])
    @pytest.mark.parametrize(
        "tie_break",
        [flashinfer.TopKTieBreak.SMALL, flashinfer.TopKTieBreak.LARGE],
        ids=["small", "large"],
    )
    @pytest.mark.parametrize(
        ("width", "k"),
        [(64, 2048), (4096, 2048), (64, 64)],
        ids=["short_width", "normal_width", "equal_width"],
    )
    def test_cub_auto_physical_width_dispatch(api, tie_break, width, k, set_topk_algo):
        """Auto must preserve native padding without disabling eligible CUB calls."""
        _require_cub_tie_break_support()
        if k > width and not can_implement_filtered_topk():
            pytest.skip("Filtered top-k not supported on this device")
        set_topk_algo("auto")
        num_rows, page_size = 4, 64
        scores = torch.zeros((num_rows, width), device="cuda", dtype=torch.float32)
        lengths = torch.full((num_rows,), width, device="cuda", dtype=torch.int32)
        offsets = torch.arange(1, num_rows + 1, device="cuda", dtype=torch.int32) * 10000
        page_table = (
            torch.arange(num_rows * (width // page_size), device="cuda", dtype=torch.int32)
            .flip(0)
            .reshape(num_rows, -1)
            + 100
        )
        out = torch.empty((num_rows, k), device="cuda", dtype=torch.int32)
        raw = torch.empty_like(out)
        output_pointers = out.data_ptr(), raw.data_ptr()
        kwargs = dict(tie_break=tie_break, dsa_graph_safe=True)
    
        def run():
            if api == "top_k":
                return flashinfer.top_k(scores, k, **kwargs)
            if api == "page_table":
                result = flashinfer.top_k_page_table_transform(
                    scores,
                    page_table,
                    lengths,
                    k,
                    page_size=page_size,
                    out=out,
                    out_raw_indices=raw,
                    **kwargs,
                )
                return (result,)
            return (
                flashinfer.top_k_ragged_transform(scores, offsets, lengths, k, **kwargs),
            )
    
        def check(result):
            indices = result[-1]
            assert indices.shape == (num_rows, k)
            assert indices.dtype == (torch.int64 if api == "top_k" else torch.int32)
            if api == "top_k":
                assert result[0].shape == indices.shape
                assert result[0].dtype == scores.dtype
            if api == "page_table":
                assert (indices.data_ptr(), raw.data_ptr()) == output_pointers
            for row in range(num_rows):
                length = width if api == "top_k" else lengths[row].item()
                valid = min(k, length)
                row_scores = scores[row, :length]
                # Stable sorting establishes exact boundary selection for both tie modes.
                if tie_break == flashinfer.TopKTieBreak.SMALL:
                    expected = torch.argsort(row_scores, descending=True, stable=True)[
                        :valid
                    ]
                else:
                    expected = (
                        length
                        - 1
                        - torch.argsort(row_scores.flip(0), descending=True, stable=True)[
                            :valid
                        ]
                    )
                if api == "page_table":
                    _assert_unordered_indices_match(raw[row, :valid], expected)
                    assert torch.all(raw[row, valid:] == -1)
                    expected = page_table[row, expected // page_size] * page_size + (
                        expected % page_size
                    )
                    raw_valid = raw[row, :valid].long()
                    assert torch.equal(
                        indices[row, :valid],
                        page_table[row, raw_valid // page_size] * page_size
                        + raw_valid % page_size,
                    )
                elif api == "ragged":
                    expected = expected + offsets[row]
                else:
                    assert torch.equal(
                        result[0][row, :valid], scores[row, indices[row, :valid]]
                    )
                    assert torch.all(result[0][row, valid:] == 0)
                _assert_unordered_indices_match(indices[row, :valid], expected)
                assert torch.all(indices[row, valid:] == -1)
    
        module = flashinfer.topk.get_topk_module()
        query_name = {
            "top_k": "cub_topk_workspace_size",
            "page_table": "cub_topk_page_table_transform_workspace_size",
            "ragged": "cub_topk_ragged_transform_workspace_size",
        }[api]
        with patch.object(module, query_name, wraps=getattr(module, query_name)) as query:
>           check(run())
                  ^^^^^

tests/utils/test_topk.py:3319: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/utils/test_topk.py:3261: in run
    flashinfer.top_k_ragged_transform(scores, offsets, lengths, k, **kwargs),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
flashinfer/api_logging.py:2348: in _auto_dump_wrapper
    return _inner(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^
flashinfer/topk.py:1415: in top_k_ragged_transform
    workspace_bytes = topk_module.cub_topk_ragged_transform_workspace_size(
/usr/lib/python3.12/unittest/mock.py:1134: in __call__
    return self._mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.12/unittest/mock.py:1138: in _mock_call
    return self._execute_mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.12/unittest/mock.py:1211: in _execute_mock_call
    return self._mock_wraps(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python/tvm_ffi/cython/function.pxi:968: in tvm_ffi.core.Function.__call__
    ???
<unknown>:0: in __tvm_ffi_cub_topk_ragged_transform_workspace_size
    ???
<unknown>:0: in cub_topk_ragged_transform_workspace_size(tvm::ffi::TensorView, tvm::ffi::TensorView, long, long, bool)
    ???
<unknown>:0: in (anonymous namespace)::CheckCUBTopKArgs(tvm::ffi::TensorView const&, tvm::ffi::TensorView const&, long, long)
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   TVM_FFI_ICHECK(top_k > 0 && top_k <= max_len)
E   RuntimeError: Check failed: (top_k > 0 && top_k <= max_len) is false: cub_topk requires 0 < top_k <= d, got top_k=2048, d=64

csrc/cub_topk.cu:454: RuntimeError
- generated xml file: /hai-workspace/flashinfer-cub-topk-short-input/artifacts/parent-regression.xml -
=========================== short test summary info ============================
FAILED tests/utils/test_topk.py::test_cub_auto_physical_width_dispatch[short_width-small-top_k]
FAILED tests/utils/test_topk.py::test_cub_auto_physical_width_dispatch[short_width-small-page_table]
FAILED tests/utils/test_topk.py::test_cub_auto_physical_width_dispatch[short_width-small-ragged]
FAILED tests/utils/test_topk.py::test_cub_auto_physical_width_dispatch[short_width-large-top_k]
FAILED tests/utils/test_topk.py::test_cub_auto_physical_width_dispatch[short_width-large-page_table]
FAILED tests/utils/test_topk.py::test_cub_auto_physical_width_dispatch[short_width-large-ragged]
6 failed, 1661 deselected in 4.39s
```

</details>

<details>
<summary>Fixed dispatcher: all 21 new tests</summary>

```text
.....................                                                    [100%]
- generated xml file: /hai-workspace/flashinfer-cub-topk-short-input/artifacts/fixed-regression.xml -
21 passed, 1646 deselected in 4.20s
```

</details>

<details>
<summary>Fixed dispatcher: all 122 selected existing controls</summary>

```text
........................................................................ [ 59%]
..................................................                       [100%]
- generated xml file: /hai-workspace/flashinfer-cub-topk-short-input/artifacts/existing-controls.xml -
122 passed, 1545 deselected in 4.42s
```

</details>

Recorded static validation for the final two-file change passed every applicable
configured hook. This is separate from the GPU regression results above.
The following reproduces the confirmed two-file invocation with a project-local
cache path:

```bash
PRE_COMMIT_HOME="$TASK_ROOT/.cache/pre-commit" pre-commit run --files \
  flashinfer/topk.py tests/utils/test_topk.py
```

```text
check for added large files..............................................Passed
check for case conflicts.................................................Passed
check for merge conflicts................................................Passed
check for broken symlinks............................(no files to check)Skipped
fix end of files.........................................................Passed
mixed line ending........................................................Passed
fix requirements.txt.................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
Tabs remover.............................................................Passed
CRLF end-lines remover...................................................Passed
clang-format.........................................(no files to check)Skipped
mypy.....................................................................Passed
ruff check...............................................................Passed
ruff format..............................................................Passed
experimental test scope selftest.....................(no files to check)Skipped
```

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

Please check that the shared gate receives `k` at all three call sites and
changes only automatic eligibility for an oversized physical shape. Forced
CUB and short logical-row handling intentionally retain their prior contract.

The earlier SGLang image's incompatible top-k AOT export surface was a separate
setup issue. This PR does not modify AOT loading or repair stale binary caches.
