### PR TITLE
Fused MoE: Fuse combine into GEMM2 epilogue

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
@@ -40,6 +40,7 @@ from cutlass.cute.nvgpu import cpasync, tcgen05
 
 from .utils import (
     blk_copy,
+    blk_copy_peer,
     blk_reduce_bf16,
     blk_reduce_fp16,
     blk_reduce_fp32,
@@ -313,6 +314,23 @@ if not hasattr(cutlass, "__version__"):
     cutlass.utils.StaticPersistentTileScheduler._get_cluster_work_idx_with_fastdivmod = hooked_get_cluster_work_idx_with_fastdivmod
 
 
+# Peer-scatter metadata packing.
+#
+# In peer-scatter mode the meta warp must hand the epilogue two values per row
+# instead of one: the rank that owns the token, and the row this route occupies
+# inside that rank's combine buffer. Both are packed into the existing int32
+# `sMetaTokenIdx` slot rather than staged through a third smem array, because a
+# third array would grow `meta_smem_bytes` in `_compute_stages` and could cost
+# the default (non-peer) path a pipeline stage for a feature it never uses.
+# The row keeps the low bits so the packed value stays positive in int32; the
+# host validates that both fields fit (see the caller in
+# flashinfer/fused_moe/cute_dsl/blockscaled_contiguous_grouped_gemm_finalize_fusion.py).
+PEER_DST_ROW_BITS = 24
+PEER_DST_ROW_LIMIT = 1 << PEER_DST_ROW_BITS
+PEER_DST_ROW_MASK = PEER_DST_ROW_LIMIT - 1
+PEER_DST_RANK_LIMIT = 1 << (31 - PEER_DST_ROW_BITS)
+
+
 class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
     """This class implements batched matrix multiplication (C = A x SFA x B x SFB) with support for various data types
     and architectural features specific to Blackwell GPUs with persistent tile scheduling and warp specialization.
@@ -367,6 +385,8 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         enable_pdl: bool = True,
         use_a_per_token_scale: bool = False,
         use_fused_finalize: bool = True,
+        use_peer_scatter: bool = False,
+        peer_release_fence: bool = False,
     ):
         """Initializes the configuration for a Blackwell blockscaled dense GEMM kernel.
 
@@ -390,6 +410,18 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         self.enable_pdl = enable_pdl
         self.use_a_per_token_scale = use_a_per_token_scale
         self.use_fused_finalize = use_fused_finalize
+        self.use_peer_scatter = use_peer_scatter
+        self.peer_release_fence = peer_release_fence
+        if peer_release_fence and not use_peer_scatter:
+            raise ValueError(
+                "peer_release_fence only has meaning with use_peer_scatter=True."
+            )
+        if use_peer_scatter and use_fused_finalize:
+            # Peer scatter gives every (token, k_slot) route its own
+            # destination slot on the owning rank, so the epilogue must use the
+            # plain non-accumulating store and the routing-weight reduction
+            # must happen later, on that rank.
+            raise ValueError("use_peer_scatter requires use_fused_finalize=False.")
         self.acc_dtype = cutlass.Float32
         self.use_2cta_instrs = mma_tiler_mn[0] == 256
         self.cluster_shape_mn = cluster_shape_mn
@@ -647,6 +679,9 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         permuted_idx_to_expanded_idx: cute.Tensor,
         token_final_scales: cute.Tensor,
         a_per_token_scale: Optional[cute.Tensor],
+        peer_addresses: Optional[cute.Tensor] = None,
+        token_dst_rank: Optional[cute.Tensor] = None,
+        token_dst_local_idx: Optional[cute.Tensor] = None,
         epilogue_op: cutlass.Constexpr = lambda x: x,
     ):
         """Execute the GEMM operation in steps:
@@ -683,6 +718,15 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         :type token_final_scales: cute.Tensor
         :param a_per_token_scale: Optional per-row scale for operand A, shape (permuted_m,)
         :type a_per_token_scale: Optional[cute.Tensor]
+        :param peer_addresses: Peer combine-buffer base addresses, shape (world_size,), int64.
+            Required when use_peer_scatter is set; entry ``r`` is the address of
+            rank ``r``'s combine buffer in this process' address space, as
+            produced by ``SymmetricBuffer.rendezvous(materialize_peer_addresses=True)``.
+        :type peer_addresses: Optional[cute.Tensor]
+        :param token_dst_rank: Owning rank per token, shape (num_tokens,), int32
+        :type token_dst_rank: Optional[cute.Tensor]
+        :param token_dst_local_idx: Token index within its owning rank, shape (num_tokens,), int32
+        :type token_dst_local_idx: Optional[cute.Tensor]
         :param epilogue_op: Optional elementwise lambda function to apply to the output tensor
         :type epilogue_op: cutlass.Constexpr
         :raises TypeError: If input data types are incompatible with the MMA instruction.
@@ -974,6 +1018,9 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             permuted_idx_to_expanded_idx,
             token_final_scales,
             a_per_token_scale,
+            peer_addresses,
+            token_dst_rank,
+            token_dst_local_idx,
             self.cluster_layout_vmnk,
             self.cluster_layout_sfb_vmnk,
             self.a_smem_layout_staged,
@@ -1062,6 +1109,9 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         permuted_idx_to_expanded_idx: cute.Tensor,
         token_final_scales: cute.Tensor,
         a_per_token_scale: Optional[cute.Tensor],
+        peer_addresses: Optional[cute.Tensor],
+        token_dst_rank: Optional[cute.Tensor],
+        token_dst_local_idx: Optional[cute.Tensor],
         cluster_layout_vmnk: cute.Layout,
         cluster_layout_sfb_vmnk: cute.Layout,
         a_smem_layout_staged: cute.ComposedLayout,
@@ -1996,6 +2046,17 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                     if cutlass.const_expr(not self.use_fused_finalize):
                         token_scale = self.final_scale_dtype(1.0)
                         output_idx = safe_idx
+                    if cutlass.const_expr(self.use_peer_scatter):
+                        # Retarget the row at the slot this route owns on the
+                        # rank that owns the token. Both lookups use gather_tok
+                        # for the same reason token_final_scales does above:
+                        # padding rows may carry out-of-range garbage, and
+                        # gather_tok clamps them to token 0 branchlessly.
+                        output_idx = (
+                            token_dst_rank[gather_tok] * PEER_DST_ROW_LIMIT
+                            + token_dst_local_idx[gather_tok] * topK
+                            + topk_idx
+                        )
                     if cutlass.const_expr(self.use_a_per_token_scale):
                         token_scale = cutlass.Float32(token_scale) * cutlass.Float32(
                             a_per_token_scale[permuted_row]
@@ -2188,16 +2249,42 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                         reduce_token_idx = sMetaTokenIdx[
                             (reduce_row, meta_consumer_state.index)
                         ]
-                        scatter_out_offset = cute.domain_offset(
-                            (reduce_token_idx, coord_n, 0), out
-                        )
+                        scatter_out_offset = None
+                        if cutlass.const_expr(not self.use_peer_scatter):
+                            scatter_out_offset = cute.domain_offset(
+                                (reduce_token_idx, coord_n, 0), out
+                            )
                         valid_copy_size = cutlass.Int32(
                             valid_columns * (self.out_dtype.width // 8)
                         )
                         # is_valid_tensor_alignment requires each output row to
                         # end on a 16-byte boundary, matching the bulk-copy
                         # instruction's size and address requirements.
-                        if cutlass.const_expr(not self.use_fused_finalize):
+                        if cutlass.const_expr(self.use_peer_scatter):
+                            # Here sMetaTokenIdx holds a packed (dst_rank,
+                            # dst_row) pair rather than a local row, so aim the
+                            # same bulk copy at the owning rank's combine
+                            # buffer instead of the local `out`. The peer
+                            # buffer is symmetric, so it shares `out`'s row
+                            # length and element type.
+                            dst_rank = reduce_token_idx // PEER_DST_ROW_LIMIT
+                            dst_row = reduce_token_idx & cutlass.Int32(
+                                PEER_DST_ROW_MASK
+                            )
+                            peer_base = cute.arch.load(
+                                (peer_addresses.iterator + dst_rank).llvm_ptr,
+                                cutlass.Int64,
+                            )
+                            peer_elem_offset = cutlass.Int64(dst_row) * cutlass.Int64(
+                                out.shape[1]
+                            ) + cutlass.Int64(coord_n)
+                            blk_copy_peer(
+                                peer_base
+                                + peer_elem_offset * (self.out_dtype.width // 8),
+                                sC[reduce_row, None, 0],
+                                valid_copy_size,
+                            )
+                        elif cutlass.const_expr(not self.use_fused_finalize):
                             blk_copy(
                                 scatter_out_offset,
                                 sC[reduce_row, None, 0],
@@ -2245,6 +2332,35 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                 )
                 tile_info_pipeline.consumer_release(tile_info_consumer_state)
                 tile_info_consumer_state.advance()
+
+            if cutlass.const_expr(self.peer_release_fence):
+                # Make this CTA's peer writes visible before the kernel ends.
+                #
+                # Ordering matters, and the drain is the load-bearing half. The
+                # per-tile wait above uses read=True, which only guarantees sC
+                # can be recycled -- the bulk copies may still be in flight to
+                # the peer. This one is cumulative over every group this thread
+                # committed, so a single wait here drains them all; there is no
+                # need to pay it per tile, and by this point every tile but the
+                # last has had the rest of the loop to land.
+                cute.arch.cp_async_bulk_wait_group(0)
+                # A fence before the drain would order nothing: cp.async.bulk
+                # completion is tracked by the async-group counter, not by the
+                # memory model.
+                #
+                # Every epilogue thread fences, because fence.acq_rel.sys (what
+                # __threadfence_system lowers to) orders only the writes of the
+                # thread that executes it, and each of them issued its own
+                # stores. The alternative idiom is bar.sync followed by a fence
+                # on a single thread, which covers the CTA by transitivity
+                # through the barrier's CTA-scope ordering; that is what the
+                # TRT-LLM MoE dispatch kernel does. It is cheaper by one fence
+                # per thread, but it exists to guard a flag store made by that
+                # one thread, and this kernel signals nothing in-kernel -- the
+                # signal is the kernel ending -- so there is no single thread
+                # to privilege here.
+                cute.arch.fence_acq_rel_sys()
+
             #
             # Dealloc the tensor memory buffer
             #
@@ -2896,6 +3012,14 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         max_active_clusters: cutlass.Constexpr,
         stream: cuda.CUstream,
         epilogue_op: cutlass.Constexpr = lambda x: x,
+        # Peer-scatter inputs. Only passed by callers that set
+        # use_peer_scatter; left None/0 otherwise so the default path compiles
+        # exactly as before.
+        peer_addresses_ptr: Optional[cute.Pointer] = None,
+        token_dst_rank_ptr: Optional[cute.Pointer] = None,
+        token_dst_local_idx_ptr: Optional[cute.Pointer] = None,
+        world_size: cutlass.Constexpr = 0,
+        peer_rows: cutlass.Constexpr = 0,
     ):
         scale_k = k // scaling_vector_size
         num_tiles = m // tile_size
@@ -2918,7 +3042,13 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             ),
         )
         output_rows = num_tokens
-        if cutlass.const_expr(not self.use_fused_finalize):
+        if cutlass.const_expr(self.use_peer_scatter):
+            # `c` is this rank's own symmetric combine buffer. The epilogue
+            # never stores through it in peer-scatter mode -- every store goes
+            # through the peer table, including this rank's own entry -- so it
+            # is read only for its column count and element type.
+            output_rows = peer_rows
+        elif cutlass.const_expr(not self.use_fused_finalize):
             output_rows = num_tokens * top_k
         c = cute.make_tensor(
             c_ptr, layout=cute.make_ordered_layout((output_rows, n, 1), order=(1, 0, 2))
@@ -2946,6 +3076,23 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             if cutlass.const_expr(a_per_token_scale_ptr is not None)
             else None
         )
+        peer_addresses = (
+            cute.make_tensor(peer_addresses_ptr, layout=cute.make_layout((world_size,)))
+            if cutlass.const_expr(peer_addresses_ptr is not None)
+            else None
+        )
+        token_dst_rank = (
+            cute.make_tensor(token_dst_rank_ptr, layout=cute.make_layout((num_tokens,)))
+            if cutlass.const_expr(token_dst_rank_ptr is not None)
+            else None
+        )
+        token_dst_local_idx = (
+            cute.make_tensor(
+                token_dst_local_idx_ptr, layout=cute.make_layout((num_tokens,))
+            )
+            if cutlass.const_expr(token_dst_local_idx_ptr is not None)
+            else None
+        )
 
         return self(
             a,
@@ -2962,6 +3109,9 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             permuted_idx_to_expanded_idx=permuted_idx_to_expanded_idx,
             token_final_scales=token_final_scales,
             a_per_token_scale=a_per_token_scale,
+            peer_addresses=peer_addresses,
+            token_dst_rank=token_dst_rank,
+            token_dst_local_idx=token_dst_local_idx,
             epilogue_op=epilogue_op,
         )
 

--- a/flashinfer/fused_moe/cute_dsl/blackwell/utils.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/utils.py
@@ -183,6 +183,39 @@ def blk_copy(dst_gemm, src_smem, size, loc=None, ip=None):
 
 
 @dsl_user_op
+def blk_copy_peer(dst_addr, src_smem, size, loc=None, ip=None):
+    """Bulk-copy one output row to a raw 64-bit global address.
+
+    Identical instruction to :func:`blk_copy`; the only difference is that the
+    destination is passed as an already-computed byte address instead of being
+    read off a tensor iterator. That lets the caller name memory belonging to a
+    peer GPU, whose base pointer is only known at runtime (see
+    ``SymmetricBuffer.peer_addresses`` in
+    ``flashinfer/comm/mnnvl_cutedsl/symmetric_buffer.py``), rather than a
+    compile-time-known ``out`` tensor.
+
+    Peer memory is ordinary mapped global memory here, so no reduction variant
+    is needed: the MoE peer-scatter path gives every ``(token, k_slot)`` route
+    its own destination slot and therefore has exactly one writer per row.
+    """
+    llvm.inline_asm(
+        None,
+        [
+            dst_addr.ir_value(loc=loc, ip=ip),
+            src_smem.iterator.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            size.ir_value(loc=loc, ip=ip),
+        ],
+        "cp.async.bulk.global.shared::cta.bulk_group [$0], [$1], $2;",
+        "l,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
 def blk_reduce_bf16(dst_gemm, src_smem, size, loc=None, ip=None):
     llvm.inline_asm(
         None,

--- a/flashinfer/fused_moe/cute_dsl/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
@@ -41,6 +41,7 @@ Key features:
 """
 
 import functools
+import os
 import warnings
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -61,6 +62,8 @@ from flashinfer.cute_dsl.utils import (
 
 # Import the Blackwell (SM100) kernel implementation
 from .blackwell.blockscaled_contiguous_grouped_gemm_finalize_fusion import (
+    PEER_DST_RANK_LIMIT,
+    PEER_DST_ROW_LIMIT,
     Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel,
 )
 
@@ -180,6 +183,54 @@ def create_finalize_fusion_tensors(
 _finalize_kernel_cache: Dict[Tuple, Any] = {}
 
 
+def _peer_scatter_sync_checks_enabled(device: torch.device) -> bool:
+    """Whether to run the device-synchronizing peer-destination bounds check.
+
+    Off by default: the check reads token_dst_local_idx back to the host, which
+    would sync on every forward. Follow the same opt-in switch the MLA wrapper
+    uses (`_validate_dsv4_sync_checks` in flashinfer/mla/_core.py), and never
+    sync during CUDA graph capture.
+    """
+    if os.environ.get("FLASHINFER_VALIDATE_INPUTS", "0") in ("0", ""):
+        return False
+    if device.type == "cuda":
+        with torch.cuda.device(device):
+            if torch.cuda.is_current_stream_capturing():
+                return False
+    return True
+
+
+def _peer_wrapper_kwargs(
+    use_peer_scatter: bool,
+    peer_addresses_ptr,
+    token_dst_rank_ptr,
+    token_dst_local_idx_ptr,
+    *,
+    world_size: Optional[int] = None,
+    peer_rows: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Build the peer-scatter keyword arguments for the Blackwell wrapper.
+
+    Returns an empty dict when peer scatter is off, so the default path
+    traces and launches the wrapper with exactly the arguments it used before
+    this feature existed. ``world_size``/``peer_rows`` are compile-time only:
+    pass them at the ``cute.compile`` site and omit them at the launch site,
+    the same way ``tile_size`` and ``max_active_clusters`` are handled.
+    """
+    if not use_peer_scatter:
+        return {}
+    kwargs: Dict[str, Any] = {
+        "peer_addresses_ptr": peer_addresses_ptr,
+        "token_dst_rank_ptr": token_dst_rank_ptr,
+        "token_dst_local_idx_ptr": token_dst_local_idx_ptr,
+    }
+    if world_size is not None:
+        kwargs["world_size"] = world_size
+    if peer_rows is not None:
+        kwargs["peer_rows"] = peer_rows
+    return kwargs
+
+
 def _get_compiled_finalize_kernel(
     # Problem dimensions (runtime parameters - NOT in cache key)
     seq_len: int,
@@ -201,6 +252,9 @@ def _get_compiled_finalize_kernel(
     num_tiles_ptr,
     token_scales_ptr,
     a_per_token_scale_ptr,
+    peer_addresses_ptr,
+    token_dst_rank_ptr,
+    token_dst_local_idx_ptr,
     max_active_clusters: int,
     stream,
     # Tactic parameters (compile-time - IN cache key)
@@ -222,6 +276,14 @@ def _get_compiled_finalize_kernel(
     enable_pdl: bool = True,
     use_a_per_token_scale: bool = False,
     use_fused_finalize: bool = True,
+    # Peer-scatter (cross-GPU combine fused into the epilogue). world_size and
+    # peer_rows are compile-time: both are fixed by the symmetric-memory
+    # allocation for the lifetime of the process, so baking them keeps the peer
+    # table and the combine-buffer view statically shaped.
+    use_peer_scatter: bool = False,
+    world_size: int = 0,
+    peer_rows: int = 0,
+    peer_release_fence: bool = False,
 ):
     """Get or compile the grouped GEMM with finalize fusion kernel.
 
@@ -257,9 +319,19 @@ def _get_compiled_finalize_kernel(
         enable_pdl,
         use_a_per_token_scale,
         use_fused_finalize,
+        use_peer_scatter,
+        world_size,
+        peer_rows,
+        peer_release_fence,
     )
 
     if cache_key not in _finalize_kernel_cache:
+        if is_rubin and use_peer_scatter:
+            raise NotImplementedError(
+                "use_peer_scatter is not supported by the Rubin (SM107) "
+                "finalize grouped GEMM kernel: its wrapper has no peer-address "
+                "parameters."
+            )
         if is_rubin:
             if use_a_per_token_scale:
                 raise NotImplementedError(
@@ -307,6 +379,8 @@ def _get_compiled_finalize_kernel(
                 enable_pdl=enable_pdl,
                 use_a_per_token_scale=use_a_per_token_scale,
                 use_fused_finalize=use_fused_finalize,
+                use_peer_scatter=use_peer_scatter,
+                peer_release_fence=peer_release_fence,
             )
             wrapper_fn = gemm_bw.wrapper
 
@@ -346,6 +420,16 @@ def _get_compiled_finalize_kernel(
             scaling_vector_size=sf_vec_size,
             max_active_clusters=max_active_clusters,
             stream=stream,
+            # Keyword-only, and omitted entirely when peer scatter is off, so
+            # the default path traces exactly the signature it did before.
+            **_peer_wrapper_kwargs(
+                use_peer_scatter,
+                peer_addresses_ptr,
+                token_dst_rank_ptr,
+                token_dst_local_idx_ptr,
+                world_size=world_size,
+                peer_rows=peer_rows,
+            ),
         )
 
         _finalize_kernel_cache[cache_key] = compiled_gemm
@@ -381,6 +465,10 @@ def blockscaled_contiguous_grouped_gemm_finalize_fusion(
     mma_inst_shape: Optional[Tuple[int, int, int]] = None,
     enable_pdl: bool = True,
     use_fused_finalize: bool = True,
+    peer_addresses: Optional[torch.Tensor] = None,
+    token_dst_rank: Optional[torch.Tensor] = None,
+    token_dst_local_idx: Optional[torch.Tensor] = None,
+    peer_release_fence: bool = False,
 ) -> torch.Tensor:
     """Blockscaled contiguous grouped GEMM for MoE GEMM2 workloads.
 
@@ -417,13 +505,39 @@ def blockscaled_contiguous_grouped_gemm_finalize_fusion(
         sm_count: Number of SMs to use. Default: max available.
         use_fused_finalize: Use atomic fused finalize; otherwise write expanded
              rows for deterministic reduction. Default: True.
+        peer_addresses: Optional peer combine-buffer base addresses, shape
+             ``(world_size,)``, int64, on device. Passing it turns on
+             peer-scatter mode: instead of storing to the local ``out``, the
+             epilogue stores each ``(token, k_slot)`` row into the combine
+             buffer of the rank that owns the token, at tile granularity and
+             overlapped with this kernel's own compute. Entry ``r`` must be the
+             address of rank ``r``'s combine buffer in this process' address
+             space, as produced by
+             ``SymmetricBuffer.rendezvous(materialize_peer_addresses=True)``.
+             Requires ``use_fused_finalize=False`` and is Blackwell-only.
+        token_dst_rank: Owning rank per token, shape ``(seq_len,)``, int32.
+             Required with ``peer_addresses``.
+        token_dst_local_idx: Token index within its owning rank, shape
+             ``(seq_len,)``, int32. Required with ``peer_addresses``.
+        peer_release_fence: Drain the outstanding bulk copies and issue a
+             system-scope release fence once per CTA before GEMM2 exits, so
+             that the kernel cannot finish until its peer writes have landed.
+             Without it, ordering rests on kernel completion alone. Only
+             meaningful with ``peer_addresses``.
 
     Returns:
         out: Output tensor with dtype out_dtype. The shape is ``(seq_len, n)``
-             in fused mode and ``(seq_len * topk, n)`` otherwise.
+             in fused mode and ``(seq_len * topk, n)`` otherwise. In
+             peer-scatter mode this is the caller-provided local combine
+             buffer, which the kernel does not write through directly -- every
+             store goes through ``peer_addresses``, including this rank's own
+             entry.
 
     Notes:
         - A caller-provided fused output must be zero-initialized.
+        - Peer-scatter mode needs no zero-initialization: every
+          ``(token, k_slot)`` slot has exactly one writer across the whole
+          world, because exactly one rank owns the expert for that route.
         - Call create_finalize_fusion_tensors() to create permuted_idx_to_expanded_idx and token_final_scales.
         - Supports SM100/SM103, plus W4A4 on SM107 with Rubin tactic parameters.
         - Deterministic mode requires a separate ``moe_unpermute`` call.
@@ -496,6 +610,96 @@ def blockscaled_contiguous_grouped_gemm_finalize_fusion(
                 f"a_per_token_scale must have shape ({permuted_m},), "
                 f"got {tuple(a_per_token_scale.shape)}"
             )
+
+    use_peer_scatter = peer_addresses is not None
+    world_size = 0
+    if use_peer_scatter:
+        if use_fused_finalize:
+            raise ValueError(
+                "peer_addresses requires use_fused_finalize=False: peer "
+                "scatter gives every (token, k_slot) route its own destination "
+                "slot on the owning rank, so the epilogue writes with the "
+                "plain non-accumulating store and the routing-weight reduction "
+                "runs afterwards on that rank."
+            )
+        if peer_release_fence and use_fused_finalize:
+            raise ValueError("peer_release_fence requires use_fused_finalize=False")
+        if token_dst_rank is None or token_dst_local_idx is None:
+            raise ValueError(
+                "peer_addresses requires both token_dst_rank and token_dst_local_idx"
+            )
+        if out is None:
+            raise ValueError(
+                "peer_addresses requires an explicit out: it must be this "
+                "rank's symmetric combine buffer, not a fresh allocation"
+            )
+        for name, tensor, dtype, shape in (
+            ("peer_addresses", peer_addresses, torch.int64, None),
+            ("token_dst_rank", token_dst_rank, torch.int32, (seq_len,)),
+            ("token_dst_local_idx", token_dst_local_idx, torch.int32, (seq_len,)),
+        ):
+            if tensor.device.type != "cuda":
+                raise ValueError(f"{name} must be on CUDA device")
+            if tensor.dtype != dtype:
+                raise ValueError(f"{name} must have dtype {dtype}, got {tensor.dtype}")
+            if not tensor.is_contiguous():
+                raise ValueError(f"{name} must be contiguous")
+            if shape is not None and tuple(tensor.shape) != shape:
+                raise ValueError(
+                    f"{name} must have shape {shape}, got {tuple(tensor.shape)}"
+                )
+        if peer_addresses.dim() != 1:
+            raise ValueError(
+                f"peer_addresses must be 1-D (world_size,), got "
+                f"{tuple(peer_addresses.shape)}"
+            )
+        world_size = peer_addresses.shape[0]
+        # The epilogue packs (destination rank, destination row) into the one
+        # int32 metadata slot the meta warp already stages per row, so both
+        # fields must fit. See the PEER_DST_* constants in the Blackwell kernel.
+        if world_size > PEER_DST_RANK_LIMIT:
+            raise ValueError(
+                f"peer scatter supports at most {PEER_DST_RANK_LIMIT} ranks, "
+                f"got world_size={world_size}"
+            )
+        if out.shape[0] > PEER_DST_ROW_LIMIT:
+            raise ValueError(
+                f"peer scatter supports combine buffers of at most "
+                f"{PEER_DST_ROW_LIMIT} rows, got {out.shape[0]}"
+            )
+        # The epilogue stores to peer_addresses[dst_rank] + (dst_local_idx *
+        # topk + k) * n without any device-side bounds check, so an
+        # out-of-range destination map writes into unrelated memory on another
+        # GPU. Peer buffers are symmetric, hence out.shape[0] bounds every
+        # rank. This costs a device sync, so it is opt-in.
+        if _peer_scatter_sync_checks_enabled(out.device):
+            max_rank = int(token_dst_rank.max().item()) if seq_len else -1
+            max_local = int(token_dst_local_idx.max().item()) if seq_len else -1
+            min_idx = (
+                min(
+                    int(token_dst_rank.min().item()),
+                    int(token_dst_local_idx.min().item()),
+                )
+                if seq_len
+                else 0
+            )
+            if min_idx < 0:
+                raise ValueError(
+                    "token_dst_rank and token_dst_local_idx must be "
+                    f"non-negative, got minimum {min_idx}"
+                )
+            if max_rank >= world_size:
+                raise ValueError(
+                    f"token_dst_rank must be < world_size={world_size}, got "
+                    f"maximum {max_rank}"
+                )
+            max_row = max_local * topk + topk - 1
+            if max_row >= out.shape[0]:
+                raise ValueError(
+                    f"token_dst_local_idx={max_local} with topk={topk} needs "
+                    f"combine-buffer row {max_row}, but the buffer has only "
+                    f"{out.shape[0]} rows"
+                )
 
     # Check compute capability
     major, minor = get_compute_capability(a.device)
@@ -574,7 +778,14 @@ def blockscaled_contiguous_grouped_gemm_finalize_fusion(
             f"cluster_shape_mn={cluster_shape_mn}, shape=({permuted_m}, {n}, {k}, {num_experts})"
         )
 
-    output_rows = seq_len if use_fused_finalize else seq_len * topk
+    if use_peer_scatter:
+        # `out` is this rank's symmetric combine buffer. Its row count is the
+        # per-rank slot count (identical on every rank by construction), not
+        # seq_len * topk, because it is indexed by the OWNING rank's local
+        # token index rather than by this rank's gathered token index.
+        output_rows = out.shape[0]
+    else:
+        output_rows = seq_len if use_fused_finalize else seq_len * topk
 
     # Atomic fused finalize requires zero-initialized output.
     if out is None:
@@ -653,6 +864,24 @@ def blockscaled_contiguous_grouped_gemm_finalize_fusion(
     else:
         a_per_token_scale_ptr = None
 
+    if use_peer_scatter:
+        peer_addresses_ptr = make_ptr(
+            cutlass.Int64,
+            peer_addresses.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=8,
+        )
+        token_dst_rank_ptr = make_ptr(
+            cutlass.Int32, token_dst_rank.data_ptr(), cute.AddressSpace.gmem
+        )
+        token_dst_local_idx_ptr = make_ptr(
+            cutlass.Int32, token_dst_local_idx.data_ptr(), cute.AddressSpace.gmem
+        )
+    else:
+        peer_addresses_ptr = None
+        token_dst_rank_ptr = None
+        token_dst_local_idx_ptr = None
+
     # Get CUDA stream
     torch_stream = torch.cuda.current_stream()
     stream = cuda.CUstream(torch_stream.cuda_stream)
@@ -676,6 +905,9 @@ def blockscaled_contiguous_grouped_gemm_finalize_fusion(
         num_tiles_ptr=num_tiles_ptr,
         token_scales_ptr=token_scales_ptr,
         a_per_token_scale_ptr=a_per_token_scale_ptr,
+        peer_addresses_ptr=peer_addresses_ptr,
+        token_dst_rank_ptr=token_dst_rank_ptr,
+        token_dst_local_idx_ptr=token_dst_local_idx_ptr,
         max_active_clusters=max_active_clusters,
         stream=stream,
         sf_vec_size=sf_vec_size,
@@ -693,6 +925,10 @@ def blockscaled_contiguous_grouped_gemm_finalize_fusion(
         enable_pdl=enable_pdl,
         use_fused_finalize=use_fused_finalize,
         use_a_per_token_scale=use_a_per_token_scale,
+        use_peer_scatter=use_peer_scatter,
+        world_size=world_size,
+        peer_rows=output_rows if use_peer_scatter else 0,
+        peer_release_fence=peer_release_fence,
     )
 
     # Execute kernel with runtime parameters.
@@ -722,6 +958,14 @@ def blockscaled_contiguous_grouped_gemm_finalize_fusion(
         seq_len,
         topk,
         stream=stream,
+        # world_size/peer_rows are compile-time and are deliberately absent
+        # here, exactly like tile_size and max_active_clusters.
+        **_peer_wrapper_kwargs(
+            use_peer_scatter,
+            peer_addresses_ptr,
+            token_dst_rank_ptr,
+            token_dst_local_idx_ptr,
+        ),
     )
 
     return out

--- a/flashinfer/fused_moe/cute_dsl/fused_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/fused_moe.py
@@ -50,6 +50,7 @@ Example (Wrapper API with CUDA Graph):
     >>> g.replay()
 """
 
+import functools
 from typing import Any, Dict, Optional, Tuple
 
 import warnings
@@ -235,6 +236,15 @@ def _moe_core_impl(
     swiglu_limit: float = DEFAULT_SWIGLU_LIMIT,
     situ_beta: Optional[float] = None,
     situ_linear_beta: Optional[float] = None,
+    # Cross-GPU peer-scatter combine (Blackwell only). Passing peer_addresses
+    # makes GEMM2 write each (token, k_slot) row straight into the combine
+    # buffer of the rank that owns the token, at tile granularity and
+    # overlapped with GEMM2's own compute, instead of into a local buffer.
+    peer_addresses: Optional[torch.Tensor] = None,
+    token_dst_rank: Optional[torch.Tensor] = None,
+    token_dst_local_idx: Optional[torch.Tensor] = None,
+    combine_buffer: Optional[torch.Tensor] = None,
+    peer_release_fence: bool = False,
 ) -> torch.Tensor:
     """Core MoE implementation shared by functional and wrapper APIs.
 
@@ -456,8 +466,26 @@ def _moe_core_impl(
         )
 
     # Atomic finalize requires a zeroed token output. Deterministic finalize
-    # writes each route to a unique expanded row.
-    if use_fused_finalize:
+    # writes each route to a unique expanded row. Peer scatter writes each
+    # route to a unique slot in the owning rank's combine buffer, so it needs
+    # no local buffer and no zeroing: exactly one rank owns the expert for a
+    # given route, so every slot has exactly one writer across the world.
+    use_peer_scatter = peer_addresses is not None
+    if use_peer_scatter:
+        if use_fused_finalize:
+            raise ValueError(
+                "peer_addresses requires use_fused_finalize=False: the "
+                "routing-weight reduction must run after the peer writes "
+                "land, on the rank that owns each token."
+            )
+        if combine_buffer is None:
+            raise ValueError(
+                "peer_addresses requires combine_buffer: this rank's own "
+                "symmetric combine buffer, shaped "
+                "(max_tokens_per_rank * top_k, hidden_size)"
+            )
+        gemm2_output = combine_buffer
+    elif use_fused_finalize:
         if use_async_memset:
             with torch.cuda.stream(aux_stream):
                 main_event.wait()
@@ -499,7 +527,20 @@ def _moe_core_impl(
         cluster_shape_mn=gemm2_cluster_shape_mn,
         enable_pdl=enable_pdl,
         use_fused_finalize=use_fused_finalize,
+        peer_addresses=peer_addresses,
+        token_dst_rank=token_dst_rank,
+        token_dst_local_idx=token_dst_local_idx,
+        peer_release_fence=peer_release_fence,
     )
+
+    if use_peer_scatter:
+        # The routing-weight reduction is deliberately NOT done here. GEMM2's
+        # writes landed in other ranks' memory, so the caller must first wait
+        # for every rank's GEMM2 to complete -- a barrier on the process group
+        # backing the symmetric memory -- and only then reduce over top_k on
+        # the rank that owns each token. Return the raw per-slot buffer for
+        # that step.
+        return combine_buffer
 
     # Step 4: Deterministic routing-weight reduction
     if not use_fused_finalize:
@@ -1076,9 +1117,24 @@ def _cute_dsl_fused_moe_impl(
     swiglu_limit: float = DEFAULT_SWIGLU_LIMIT,
     situ_beta: Optional[float] = None,
     situ_linear_beta: Optional[float] = None,
+    # Peer-scatter inputs. These are bound with functools.partial before the
+    # runner is built rather than appended to the autotuner's positional
+    # `inputs` list, because they are per-call context and not something the
+    # autotuner tunes over -- and because appending to `inputs` would shift the
+    # hardcoded tensor indices in CuteDslFusedMoERunner.tuning_config.
+    peer_addresses: Optional[torch.Tensor] = None,
+    token_dst_rank: Optional[torch.Tensor] = None,
+    token_dst_local_idx: Optional[torch.Tensor] = None,
+    combine_buffer: Optional[torch.Tensor] = None,
+    peer_release_fence: bool = False,
 ) -> torch.Tensor:
     """Internal implementation called by auto-tuner for functional API."""
     return _moe_core_impl(
+        peer_addresses=peer_addresses,
+        token_dst_rank=token_dst_rank,
+        token_dst_local_idx=token_dst_local_idx,
+        combine_buffer=combine_buffer,
+        peer_release_fence=peer_release_fence,
         x=x,
         x_sf=x_sf,
         token_selected_experts=token_selected_experts,
@@ -1152,6 +1208,11 @@ def cute_dsl_fused_moe(
     quant_mode: str = "w4a4",
     per_token_scale: Optional[torch.Tensor] = None,
     tactic: Optional[Tuple] = None,
+    peer_addresses: Optional[torch.Tensor] = None,
+    token_dst_rank: Optional[torch.Tensor] = None,
+    token_dst_local_idx: Optional[torch.Tensor] = None,
+    combine_buffer: Optional[torch.Tensor] = None,
+    peer_release_fence: bool = False,
 ) -> torch.Tensor:
     r"""Run a fused MoE forward pass using CuTe-DSL block-scaled kernels.
 
@@ -1241,6 +1302,24 @@ def cute_dsl_fused_moe(
     _require_cute_dsl_arch_for(x.device, native_only=True)
     activation, _ = normalize_cute_dsl_moe_activation_type(activation_type)
     quant_mode = _canonicalize_quant_mode(quant_mode)
+
+    if peer_addresses is not None:
+        # Peer scatter is wired only through CuteDslFusedMoERunner (the
+        # w4a4/w4a8 path); CuteDslFusedMoEW4A16Runner has no peer parameters,
+        # so accepting them here would silently drop the cross-GPU combine.
+        if quant_mode == "w4a16":
+            raise NotImplementedError(
+                "peer_addresses is not supported with quant_mode='w4a16'"
+            )
+        # Autotuning replays GEMM2 once per candidate tactic. In peer-scatter
+        # mode each replay writes into other ranks' combine buffers, so tune
+        # with peer scatter off and reuse the chosen tactic here.
+        if tactic is None and AutoTuner.get().is_tuning_mode:
+            raise RuntimeError(
+                "peer_addresses cannot be combined with an active autotune() "
+                "context: profiling replays would write into peer memory. "
+                "Tune without peer_addresses, then pass the resulting tactic."
+            )
     validate_cute_dsl_moe_situ_config(activation, situ_beta, situ_linear_beta)
 
     if quant_mode == "w4a8":
@@ -1270,7 +1349,18 @@ def cute_dsl_fused_moe(
     if quant_mode in ("w4a4", "w4a8"):
         use_per_token_activation = per_token_scale is not None
         runner = CuteDslFusedMoERunner(
-            forward_impl=_cute_dsl_fused_moe_impl,
+            forward_impl=(
+                _cute_dsl_fused_moe_impl
+                if peer_addresses is None
+                else functools.partial(
+                    _cute_dsl_fused_moe_impl,
+                    peer_addresses=peer_addresses,
+                    token_dst_rank=token_dst_rank,
+                    token_dst_local_idx=token_dst_local_idx,
+                    combine_buffer=combine_buffer,
+                    peer_release_fence=peer_release_fence,
+                )
+            ),
             num_experts=num_experts,
             top_k=top_k,
             num_local_experts=num_local_experts,
@@ -1406,6 +1496,11 @@ def cute_dsl_fused_moe_nvfp4(
     *,
     quant_mode: str = "w4a4",
     per_token_scale: Optional[torch.Tensor] = None,
+    peer_addresses: Optional[torch.Tensor] = None,
+    token_dst_rank: Optional[torch.Tensor] = None,
+    token_dst_local_idx: Optional[torch.Tensor] = None,
+    combine_buffer: Optional[torch.Tensor] = None,
+    peer_release_fence: bool = False,
 ) -> torch.Tensor:
     r"""Run a fused MoE forward pass using the CuTe-DSL NVFP4 kernels.
 
@@ -1452,6 +1547,11 @@ def cute_dsl_fused_moe_nvfp4(
         situ_linear_beta,
         quant_mode=quant_mode,
         per_token_scale=per_token_scale,
+        peer_addresses=peer_addresses,
+        token_dst_rank=token_dst_rank,
+        token_dst_local_idx=token_dst_local_idx,
+        combine_buffer=combine_buffer,
+        peer_release_fence=peer_release_fence,
     )
 
 

--- a/flashinfer/fused_moe/cute_dsl/moe_utils.py
+++ b/flashinfer/fused_moe/cute_dsl/moe_utils.py
@@ -17,7 +17,7 @@ limitations under the License.
 import functools
 import math
 from enum import IntEnum
-from typing import Dict, Optional, Tuple, Union
+from typing import Dict, NamedTuple, Optional, Sequence, Tuple, Union
 
 import torch
 
@@ -250,6 +250,194 @@ def moe_permute(
         enable_pdl,
         _get_cuda_stream_ptr(),
     )
+
+
+def build_peer_scatter_destination_map(
+    sizes: Sequence[int],
+    device: Union[torch.device, str],
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Expand an all-gather ``sizes`` vector into a per-token destination map.
+
+    ``all_gather``/``all_gatherv`` concatenates each rank's rows in rank order,
+    so a row of the gathered activation tensor belongs to exactly one source
+    rank and its index within that rank is fully determined by ``sizes``. The
+    map is therefore a pure function of ``sizes``: nothing is derived inside
+    the GEMM2 kernel and nothing is searched at runtime.
+
+    Args:
+        sizes: Number of tokens contributed by each rank, in rank order.
+            Its length is the world size and ``sum(sizes)`` is the gathered
+            token count, i.e. the ``num_tokens`` GEMM2 sees.
+        device: CUDA device for the returned tensors.
+
+    Returns:
+        ``(token_dst_rank, token_dst_local_idx)``, both int32 of shape
+        ``(sum(sizes),)``: the rank that owns each gathered token, and that
+        token's index within its owning rank. Pass both to
+        :func:`~flashinfer.fused_moe.cute_dsl.fused_moe.cute_dsl_fused_moe`
+        alongside ``peer_addresses``.
+    """
+    counts = [int(size) for size in sizes]
+    if any(count < 0 for count in counts):
+        raise ValueError(f"sizes must be non-negative, got {counts}")
+    if not counts:
+        raise ValueError("sizes must name at least one rank")
+
+    # Built on the host and copied once. This is per-forward setup, not a hot
+    # path, and a rank-order loop on device would be world_size tiny launches.
+    ranks = torch.arange(len(counts), dtype=torch.int32)
+    token_dst_rank = torch.repeat_interleave(ranks, torch.tensor(counts))
+    token_dst_local_idx = torch.cat(
+        [torch.arange(count, dtype=torch.int32) for count in counts]
+        + [torch.empty(0, dtype=torch.int32)]
+    )
+    return token_dst_rank.to(device), token_dst_local_idx.to(device)
+
+
+class PeerCombineBuffer(NamedTuple):
+    """A symmetric combine buffer plus the peer table GEMM2 scatters through."""
+
+    tensor: torch.Tensor
+    peer_addresses: torch.Tensor
+    handle: object  # keeps the rendezvous mapping alive; do not drop it
+    source: str  # which API produced the table, for diagnostics
+
+
+def allocate_peer_combine_buffer(
+    shape: Sequence[int],
+    dtype: torch.dtype,
+    device: Union[torch.device, str],
+    group: "torch.distributed.ProcessGroup",
+) -> PeerCombineBuffer:
+    """Allocate the symmetric combine buffer and its ``[world_size]`` peer table.
+
+    This is a collective call: every rank in ``group`` must reach it with the
+    same ``shape`` and ``dtype``.
+
+    Prefers :class:`~flashinfer.comm.mnnvl_cutedsl.symmetric_buffer.SymmetricBuffer`.
+    That path needs a PyTorch exposing ``_symmetric_memory.get_backend`` and
+    ``handle.get_remote_tensor``; older builds (for example the torch 2.8 in
+    NGC ``pytorch:25.08``) expose ``handle.get_buffer`` instead, so fall back to
+    driving the rendezvous handle directly. Both routes produce the same thing:
+    a ``[world_size]`` int64 tensor whose entry ``r`` holds the address of rank
+    ``r``'s buffer in this process' address space, which is exactly what the
+    ``peer_addresses`` argument of the GEMM2 finalize kernel consumes.
+
+    Args:
+        shape: Buffer shape, ``(rows, hidden_size)``. Identical on every rank.
+        dtype: Buffer element type, matching the MoE output dtype.
+        device: CUDA device to allocate on.
+        group: Process group spanning the ranks that scatter into each other.
+
+    Returns:
+        A :class:`PeerCombineBuffer`. Keep it alive for as long as the kernel
+        may write through it: dropping it unmaps the peer memory.
+    """
+    import torch.distributed as dist
+    import torch.distributed._symmetric_memory as symm_mem
+
+    from ...comm.mnnvl_cutedsl.symmetric_buffer import SymmetricBuffer
+    from ...comm.torch_symmetric_memory import _enable_symm_mem_for_group
+
+    world_size = dist.get_world_size(group)
+    try:
+        buffer = SymmetricBuffer.allocate(
+            shape, dtype, torch.device(device), group, materialize_peer_addresses=True
+        )
+        return PeerCombineBuffer(
+            buffer.tensor,
+            buffer.peer_addresses,
+            buffer._handle,
+            "SymmetricBuffer.allocate",
+        )
+    except AttributeError:
+        # This PyTorch predates the APIs SymmetricBuffer needs; fall through.
+        pass
+
+    _enable_symm_mem_for_group(group.group_name)
+    tensor = symm_mem.empty(tuple(shape), dtype=dtype, device=device)
+    handle = symm_mem.rendezvous(tensor, group)
+    addresses = [
+        handle.get_buffer(peer, tuple(shape), dtype).data_ptr()
+        for peer in range(world_size)
+    ]
+    if not all(addresses):
+        raise RuntimeError("symmetric peer mapping is unavailable")
+    if len(set(addresses)) != world_size:
+        raise RuntimeError(f"peer addresses are not distinct: {addresses}")
+    peer_addresses = torch.tensor(addresses, dtype=torch.int64, device=tensor.device)
+    return PeerCombineBuffer(
+        tensor, peer_addresses, handle, "symm_mem.rendezvous + handle.get_buffer"
+    )
+
+
+def peer_scatter_local_reduce(
+    combine_buffer: torch.Tensor,
+    topk_scales: torch.Tensor,
+    num_local_tokens: int,
+    top_k: int,
+    output: Optional[torch.Tensor] = None,
+    enable_pdl: bool = False,
+) -> torch.Tensor:
+    """Reduce a peer-scatter combine buffer over ``top_k`` on the owning rank.
+
+    This is the ``local_reduce`` half of the ``p2p+local_reduce`` design: after
+    every rank's GEMM2 has landed its peer writes -- which the caller must
+    guarantee with a barrier on the process group backing the symmetric memory
+    -- the rank that owns a token holds all ``top_k`` of its partial results in
+    its own ``combine_buffer`` and applies the routing weights here.
+
+    Every slot is written exactly once, by whichever rank owns the expert for
+    that route, so no masking is needed and the identity index map below is
+    always fully valid.
+
+    Args:
+        combine_buffer: This rank's symmetric combine buffer, shape
+            ``(rows, hidden_size)`` with ``rows >= num_local_tokens * top_k``,
+            laid out as ``local_token_idx * top_k + k_slot``.
+        topk_scales: Routing weights for this rank's own tokens, shape
+            ``(num_local_tokens, top_k)``.
+        num_local_tokens: Number of tokens this rank owns.
+        top_k: Experts routed to per token.
+        output: Optional destination, shape ``(num_local_tokens, hidden_size)``.
+        enable_pdl: Forwarded to :func:`moe_unpermute`.
+
+    Returns:
+        The reduced output, shape ``(num_local_tokens, hidden_size)``.
+    """
+    hidden_size = combine_buffer.shape[-1]
+    expected_rows = num_local_tokens * top_k
+    if combine_buffer.shape[0] < expected_rows:
+        raise ValueError(
+            f"combine_buffer must have at least {expected_rows} rows for "
+            f"num_local_tokens={num_local_tokens} and top_k={top_k}, got "
+            f"{combine_buffer.shape[0]}"
+        )
+    if tuple(topk_scales.shape) != (num_local_tokens, top_k):
+        raise ValueError(
+            f"topk_scales must have shape ({num_local_tokens}, {top_k}), got "
+            f"{tuple(topk_scales.shape)}"
+        )
+    if output is None:
+        output = torch.empty(
+            (num_local_tokens, hidden_size),
+            dtype=combine_buffer.dtype,
+            device=combine_buffer.device,
+        )
+    identity_map = torch.arange(
+        expected_rows, dtype=torch.int32, device=combine_buffer.device
+    ).view(num_local_tokens, top_k)
+    moe_unpermute(
+        permuted_input=combine_buffer[:expected_rows],
+        output=output,
+        expanded_idx_to_permuted_idx=identity_map,
+        topk_scales=topk_scales,
+        num_tokens=num_local_tokens,
+        top_k=top_k,
+        input_is_expanded=True,
+        enable_pdl=enable_pdl,
+    )
+    return output
 
 
 def moe_unpermute(

--- a/tests/moe/test_cute_dsl_moe_peer_scatter.py
+++ b/tests/moe/test_cute_dsl_moe_peer_scatter.py
@@ -1,0 +1,508 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""
+Tests for the peer-scatter (cross-GPU fused combine) path of the Blackwell
+CuTe-DSL MoE GEMM2 finalize kernel.
+
+The kernel change replaces the epilogue's destination address: instead of
+storing each ``(token, k_slot)`` row into the local ``out`` buffer, it stores
+into the combine buffer of the rank that owns the token, selected from a
+peer-pointer table. Every route has exactly one writer across the world, so
+the store stays the plain non-accumulating bulk copy and no zero-init is
+needed.
+
+The multi-rank behaviour is exercised on a single GPU by handing the kernel a
+peer table of ordinary local allocations: the kernel only ever loads a base
+address out of that table and stores to it, so several "ranks" can be
+simulated with several buffers on one device. That covers the rank selection,
+the (rank, row) metadata packing, and the address arithmetic without needing a
+distributed job.
+"""
+
+import pytest
+import torch
+
+from flashinfer.cute_dsl import is_cute_dsl_available
+from flashinfer.cute_dsl.utils import is_cute_dsl_arch_supported
+from flashinfer.fused_moe.cute_dsl.blackwell.blockscaled_contiguous_grouped_gemm_finalize_fusion import (
+    PEER_DST_RANK_LIMIT,
+    PEER_DST_ROW_BITS,
+    PEER_DST_ROW_LIMIT,
+    PEER_DST_ROW_MASK,
+    Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel,
+)
+from flashinfer.fused_moe.cute_dsl.fused_moe import cute_dsl_fused_moe
+from flashinfer.fused_moe.cute_dsl.moe_utils import (
+    build_peer_scatter_destination_map,
+    peer_scatter_local_reduce,
+)
+
+from .utils import check_accuracy, create_moe_tensors
+
+
+def _is_sm100_family() -> bool:
+    return torch.cuda.is_available() and torch.cuda.get_device_capability(0) in (
+        (10, 0),
+        (10, 3),
+        (10, 7),
+    )
+
+
+cute_dsl_available = pytest.mark.skipif(
+    not is_cute_dsl_available(), reason="CuteDSL not available"
+)
+sm100_required = pytest.mark.skipif(
+    not _is_sm100_family(),
+    reason="Peer scatter targets the Blackwell CuTe-DSL MoE GEMM2 kernel",
+)
+requires_dsl_arch = pytest.mark.skipif(
+    torch.cuda.is_available()
+    and not is_cute_dsl_arch_supported(
+        *torch.cuda.get_device_capability(0), native_only=True
+    ),
+    reason="installed CuTe DSL does not support this GPU architecture",
+)
+cuda_required = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires a CUDA device"
+)
+# moe_unpermute's JIT module is generated only for SM90 and SM100
+# (gen_moe_utils_module passes supported_major_versions=[9, 10]), so the local
+# reduce cannot even be built on older cards.
+moe_utils_arch_required = pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or torch.cuda.get_device_capability(0)[0] not in (9, 10),
+    reason="moe_unpermute is compiled only for SM90 and SM100",
+)
+
+
+# ---------------------------------------------------------------------------
+# Metadata packing. Host-only: no GPU needed.
+# ---------------------------------------------------------------------------
+
+
+def test_packing_constants_are_consistent():
+    assert PEER_DST_ROW_LIMIT == 1 << PEER_DST_ROW_BITS
+    assert PEER_DST_ROW_MASK == PEER_DST_ROW_LIMIT - 1
+    assert PEER_DST_RANK_LIMIT == 1 << (31 - PEER_DST_ROW_BITS)
+
+
+def test_packing_is_lossless_and_fits_int32():
+    """The packed (rank, row) pair must round-trip and stay a positive int32.
+
+    The epilogue reuses the single int32 ``sMetaTokenIdx`` slot for both
+    fields, so a signed overflow here would silently corrupt destinations.
+    """
+    worst = (PEER_DST_RANK_LIMIT - 1) * PEER_DST_ROW_LIMIT + (PEER_DST_ROW_LIMIT - 1)
+    assert worst == 2**31 - 1
+
+    for rank, row in (
+        (0, 0),
+        (0, PEER_DST_ROW_LIMIT - 1),
+        (PEER_DST_RANK_LIMIT - 1, 0),
+        (PEER_DST_RANK_LIMIT - 1, PEER_DST_ROW_LIMIT - 1),
+        (3, 12345),
+    ):
+        packed = rank * PEER_DST_ROW_LIMIT + row
+        assert packed >= 0
+        assert packed // PEER_DST_ROW_LIMIT == rank
+        assert packed & PEER_DST_ROW_MASK == row
+
+
+def test_kernel_rejects_peer_scatter_with_fused_finalize():
+    with pytest.raises(ValueError, match="use_fused_finalize=False"):
+        Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel(
+            sf_vec_size=16,
+            mma_tiler_mn=(128, 128),
+            cluster_shape_mn=(1, 1),
+            use_fused_finalize=True,
+            use_peer_scatter=True,
+        )
+
+
+def test_default_path_passes_no_peer_kwargs():
+    """The non-peer path must trace and launch with exactly its old arguments.
+
+    Peer scatter must not perturb the default kernel: if any peer keyword
+    leaked into ``cute.compile`` when the feature is off, every existing
+    caller would trace a different wrapper signature.
+    """
+    from flashinfer.fused_moe.cute_dsl.blockscaled_contiguous_grouped_gemm_finalize_fusion import (
+        _peer_wrapper_kwargs,
+    )
+
+    assert _peer_wrapper_kwargs(False, "p", "r", "l", world_size=4, peer_rows=8) == {}
+    # Compile site: pointers plus the two compile-time scalars.
+    assert _peer_wrapper_kwargs(True, "p", "r", "l", world_size=4, peer_rows=8) == {
+        "peer_addresses_ptr": "p",
+        "token_dst_rank_ptr": "r",
+        "token_dst_local_idx_ptr": "l",
+        "world_size": 4,
+        "peer_rows": 8,
+    }
+    # Launch site: pointers only, the scalars are baked in.
+    assert _peer_wrapper_kwargs(True, "p", "r", "l") == {
+        "peer_addresses_ptr": "p",
+        "token_dst_rank_ptr": "r",
+        "token_dst_local_idx_ptr": "l",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Destination map. Host-only.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sizes,expect_rank,expect_local",
+    [
+        ([4], [0, 0, 0, 0], [0, 1, 2, 3]),
+        ([2, 3], [0, 0, 1, 1, 1], [0, 1, 0, 1, 2]),
+        ([3, 0, 2], [0, 0, 0, 2, 2], [0, 1, 2, 0, 1]),
+        ([0, 0], [], []),
+    ],
+)
+def test_build_peer_scatter_destination_map(sizes, expect_rank, expect_local):
+    """The map is a pure function of ``sizes``: all-gather is rank-contiguous."""
+    rank, local = build_peer_scatter_destination_map(sizes, "cpu")
+    assert rank.dtype == torch.int32
+    assert local.dtype == torch.int32
+    assert rank.shape == (sum(sizes),)
+    assert rank.tolist() == expect_rank
+    assert local.tolist() == expect_local
+
+
+def test_build_peer_scatter_destination_map_rejects_bad_sizes():
+    with pytest.raises(ValueError, match="non-negative"):
+        build_peer_scatter_destination_map([1, -1], "cpu")
+    with pytest.raises(ValueError, match="at least one rank"):
+        build_peer_scatter_destination_map([], "cpu")
+
+
+@cuda_required
+def test_build_peer_scatter_destination_map_on_device():
+    rank, local = build_peer_scatter_destination_map([2, 2], "cuda")
+    assert rank.device.type == "cuda"
+    assert local.device.type == "cuda"
+    assert rank.tolist() == [0, 0, 1, 1]
+    assert local.tolist() == [0, 1, 0, 1]
+
+
+# ---------------------------------------------------------------------------
+# Local reduce. Needs CUDA but not Blackwell: moe_unpermute is a plain kernel.
+# ---------------------------------------------------------------------------
+
+
+@moe_utils_arch_required
+@pytest.mark.parametrize("num_local_tokens", [1, 7, 64])
+@pytest.mark.parametrize("top_k", [2, 4])
+def test_peer_scatter_local_reduce_matches_reference(num_local_tokens, top_k):
+    """The local half of p2p+local_reduce is a plain weighted sum over top_k."""
+    torch.manual_seed(0)
+    hidden_size = 128
+    combine_buffer = torch.randn(
+        (num_local_tokens * top_k, hidden_size), dtype=torch.bfloat16, device="cuda"
+    )
+    topk_scales = torch.rand(
+        (num_local_tokens, top_k), dtype=torch.float32, device="cuda"
+    )
+
+    result = peer_scatter_local_reduce(
+        combine_buffer, topk_scales, num_local_tokens, top_k
+    )
+
+    reference = (
+        combine_buffer.float().view(num_local_tokens, top_k, hidden_size)
+        * topk_scales.unsqueeze(-1)
+    ).sum(dim=1)
+
+    assert result.shape == (num_local_tokens, hidden_size)
+    torch.testing.assert_close(
+        result.float(), reference.to(result.dtype).float(), rtol=2e-2, atol=2e-2
+    )
+
+
+@cuda_required
+def test_peer_scatter_local_reduce_validates_shapes():
+    combine_buffer = torch.zeros((8, 16), dtype=torch.bfloat16, device="cuda")
+    scales = torch.ones((4, 2), dtype=torch.float32, device="cuda")
+    with pytest.raises(ValueError, match="at least"):
+        peer_scatter_local_reduce(combine_buffer, scales, num_local_tokens=8, top_k=2)
+    with pytest.raises(ValueError, match="topk_scales must have shape"):
+        peer_scatter_local_reduce(
+            combine_buffer,
+            torch.ones((3, 2), dtype=torch.float32, device="cuda"),
+            num_local_tokens=4,
+            top_k=2,
+        )
+
+
+# ---------------------------------------------------------------------------
+# End to end through the Blackwell kernel.
+# ---------------------------------------------------------------------------
+
+
+def _moe_case(num_tokens: int, top_k: int, num_experts: int):
+    hidden_size, intermediate_size = 256, 512
+    tensors = create_moe_tensors(
+        num_tokens=num_tokens,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=num_experts,
+        num_local_experts=num_experts,
+        top_k=top_k,
+    )
+    api_inputs = {
+        "x": tensors["x"],
+        "x_sf": tensors["x_sf"],
+        "fc2_input_scale": tensors["fc2_input_scale"],
+        "per_token_scale": tensors["x_per_token_scale"],
+    }
+    common = dict(
+        token_selected_experts=tensors["token_selected_experts"],
+        token_final_scales=tensors["token_final_scales"],
+        w1_weight=tensors["w1_weight"],
+        w1_weight_sf=tensors["w1_weight_sf"],
+        w1_alpha=tensors["w1_alpha"],
+        w2_weight=tensors["w2_weight"],
+        w2_weight_sf=tensors["w2_weight_sf"],
+        w2_alpha=tensors["w2_alpha"],
+        num_experts=num_experts,
+        top_k=top_k,
+        num_local_experts=num_experts,
+        use_fused_finalize=False,
+        quant_mode="w4a4",
+        **api_inputs,
+    )
+    return tensors, common, hidden_size
+
+
+@cute_dsl_available
+@sm100_required
+@requires_dsl_arch
+@pytest.mark.parametrize("num_tokens", [128, 256])
+@pytest.mark.parametrize("top_k", [2, 8])
+def test_peer_scatter_single_rank_matches_local(num_tokens, top_k):
+    """A world of one must reproduce the ordinary deterministic path exactly.
+
+    With ``world_size == 1`` the destination row the meta warp computes,
+    ``dst_local_idx * top_k + topk_idx``, is the same ``token_idx * top_k +
+    topk_idx`` the deterministic path already writes, and the peer table's only
+    entry is this rank's own buffer. So the peer path must agree with the
+    unmodified path to the bit.
+    """
+    num_experts = 256
+    tensors, common, hidden_size = _moe_case(num_tokens, top_k, num_experts)
+
+    reference = cute_dsl_fused_moe(**common)
+
+    combine_buffer = torch.zeros(
+        (num_tokens * top_k, hidden_size), dtype=torch.bfloat16, device="cuda"
+    )
+    peer_addresses = torch.tensor(
+        [combine_buffer.data_ptr()], dtype=torch.int64, device="cuda"
+    )
+    token_dst_rank, token_dst_local_idx = build_peer_scatter_destination_map(
+        [num_tokens], "cuda"
+    )
+
+    returned = cute_dsl_fused_moe(
+        **common,
+        peer_addresses=peer_addresses,
+        token_dst_rank=token_dst_rank,
+        token_dst_local_idx=token_dst_local_idx,
+        combine_buffer=combine_buffer,
+    )
+    # GEMM2 hands back the raw per-slot buffer; the reduction is the caller's
+    # job, after the completion barrier.
+    assert returned.data_ptr() == combine_buffer.data_ptr()
+
+    reduced = peer_scatter_local_reduce(
+        combine_buffer, tensors["token_final_scales"], num_tokens, top_k
+    )
+    assert reduced.shape == (num_tokens, hidden_size)
+    assert not torch.isnan(reduced).any()
+    torch.testing.assert_close(reduced, reference, rtol=0, atol=0)
+
+
+@cute_dsl_available
+@sm100_required
+@requires_dsl_arch
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_peer_scatter_simulated_multi_rank_matches_local(world_size):
+    """Simulate several owning ranks with several buffers on one GPU.
+
+    The kernel only loads a base address out of the peer table and stores to
+    it, so distinct local allocations stand in for distinct peers. This is what
+    actually exercises rank selection and the packed-metadata unpack; the
+    single-rank test above cannot, because rank 0 packs to zero.
+    """
+    num_tokens, top_k, num_experts = 256, 4, 256
+    assert num_tokens % world_size == 0
+    tokens_per_rank = num_tokens // world_size
+
+    tensors, common, hidden_size = _moe_case(num_tokens, top_k, num_experts)
+    reference = cute_dsl_fused_moe(**common)
+
+    buffers = [
+        torch.zeros(
+            (tokens_per_rank * top_k, hidden_size),
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        for _ in range(world_size)
+    ]
+    peer_addresses = torch.tensor(
+        [buf.data_ptr() for buf in buffers], dtype=torch.int64, device="cuda"
+    )
+    token_dst_rank, token_dst_local_idx = build_peer_scatter_destination_map(
+        [tokens_per_rank] * world_size, "cuda"
+    )
+
+    cute_dsl_fused_moe(
+        **common,
+        peer_addresses=peer_addresses,
+        token_dst_rank=token_dst_rank,
+        token_dst_local_idx=token_dst_local_idx,
+        # `out` is this process' own buffer; the stores for every rank still go
+        # through the peer table, including rank 0's entry.
+        combine_buffer=buffers[0],
+    )
+
+    scales = tensors["token_final_scales"]
+    reduced = torch.cat(
+        [
+            peer_scatter_local_reduce(
+                buffers[r],
+                scales[r * tokens_per_rank : (r + 1) * tokens_per_rank],
+                tokens_per_rank,
+                top_k,
+            )
+            for r in range(world_size)
+        ],
+        dim=0,
+    )
+
+    assert reduced.shape == (num_tokens, hidden_size)
+    torch.testing.assert_close(reduced, reference, rtol=0, atol=0)
+
+
+@cute_dsl_available
+@sm100_required
+@requires_dsl_arch
+def test_peer_scatter_accuracy_against_moe_reference():
+    """Sanity-check the fused path against the numerical MoE reference."""
+    from .utils import compute_reference_moe_fp4
+
+    num_tokens, top_k, num_experts = 128, 2, 256
+    hidden_size, intermediate_size = 256, 512
+    tensors, common, _ = _moe_case(num_tokens, top_k, num_experts)
+
+    combine_buffer = torch.zeros(
+        (num_tokens * top_k, hidden_size), dtype=torch.bfloat16, device="cuda"
+    )
+    peer_addresses = torch.tensor(
+        [combine_buffer.data_ptr()], dtype=torch.int64, device="cuda"
+    )
+    token_dst_rank, token_dst_local_idx = build_peer_scatter_destination_map(
+        [num_tokens], "cuda"
+    )
+    cute_dsl_fused_moe(
+        **common,
+        peer_addresses=peer_addresses,
+        token_dst_rank=token_dst_rank,
+        token_dst_local_idx=token_dst_local_idx,
+        combine_buffer=combine_buffer,
+    )
+    result = peer_scatter_local_reduce(
+        combine_buffer, tensors["token_final_scales"], num_tokens, top_k
+    )
+
+    ref_output = compute_reference_moe_fp4(
+        token_selected_experts=tensors["token_selected_experts"],
+        token_final_scales=tensors["token_final_scales"],
+        num_tokens=num_tokens,
+        num_experts=num_experts,
+        top_k=top_k,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        hidden_states=tensors["x_ref"].float(),
+        gemm1_weights=tensors["w1_weight_bf16"].float(),
+        gemm2_weights=tensors["w2_weight_bf16"].float(),
+        gemm1_alpha=tensors["w1_alpha"],
+        gemm2_alpha=tensors["w2_alpha"],
+        fc2_input_scale=tensors["fc2_input_scale"],
+        use_per_token_activation=tensors["x_per_token_scale"] is not None,
+    )
+    passed, percent_within, atol = check_accuracy(result, ref_output)
+    assert passed, (
+        f"Only {percent_within * 100:.2f}% within tolerance (atol={atol:.4f})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Input validation on the dispatcher.
+# ---------------------------------------------------------------------------
+
+
+@cute_dsl_available
+@sm100_required
+@requires_dsl_arch
+def test_peer_scatter_rejects_fused_finalize_end_to_end():
+    num_tokens, top_k, num_experts = 128, 2, 256
+    tensors, common, hidden_size = _moe_case(num_tokens, top_k, num_experts)
+    common["use_fused_finalize"] = True
+
+    combine_buffer = torch.zeros(
+        (num_tokens * top_k, hidden_size), dtype=torch.bfloat16, device="cuda"
+    )
+    token_dst_rank, token_dst_local_idx = build_peer_scatter_destination_map(
+        [num_tokens], "cuda"
+    )
+    with pytest.raises(ValueError, match="use_fused_finalize=False"):
+        cute_dsl_fused_moe(
+            **common,
+            peer_addresses=torch.tensor(
+                [combine_buffer.data_ptr()], dtype=torch.int64, device="cuda"
+            ),
+            token_dst_rank=token_dst_rank,
+            token_dst_local_idx=token_dst_local_idx,
+            combine_buffer=combine_buffer,
+        )
+
+
+@cute_dsl_available
+@sm100_required
+@requires_dsl_arch
+def test_peer_scatter_requires_combine_buffer():
+    num_tokens, top_k, num_experts = 128, 2, 256
+    _, common, hidden_size = _moe_case(num_tokens, top_k, num_experts)
+    token_dst_rank, token_dst_local_idx = build_peer_scatter_destination_map(
+        [num_tokens], "cuda"
+    )
+    scratch = torch.zeros(
+        (num_tokens * top_k, hidden_size), dtype=torch.bfloat16, device="cuda"
+    )
+    with pytest.raises(ValueError, match="combine_buffer"):
+        cute_dsl_fused_moe(
+            **common,
+            peer_addresses=torch.tensor(
+                [scratch.data_ptr()], dtype=torch.int64, device="cuda"
+            ),
+            token_dst_rank=token_dst_rank,
+            token_dst_local_idx=token_dst_local_idx,
+            combine_buffer=None,
+        )

--- a/tests/moe/test_cute_dsl_moe_peer_scatter_multigpu.py
+++ b/tests/moe/test_cute_dsl_moe_peer_scatter_multigpu.py
@@ -1,0 +1,280 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""
+Real multi-GPU test for the peer-scatter combine fused into the Blackwell
+CuTe-DSL MoE GEMM2 finalize epilogue.
+
+Launch with four ranks on one node::
+
+    python -m torch.distributed.run --nproc_per_node=4 -m pytest -q \
+        tests/moe/test_cute_dsl_moe_peer_scatter_multigpu.py
+
+(`python -m torch.distributed.run`, not the bare `torchrun`: in a container
+where flashinfer lives in a venv, the `torchrun` on PATH belongs to the base
+interpreter and its workers would not see the venv.)
+
+Setup mirrors what the vLLM wiring plan does. Every rank holds the same
+all-gathered token batch (that is what `AgRsAll2AllManager.dispatch()`'s
+`all_gatherv` produces), but owns a distinct slice of the experts, so each
+`(token, k_slot)` route is computed by exactly one rank in the world. GEMM2
+then writes that route straight into the combine buffer of the rank that owns
+the token, over NVLink, through `SymmetricBuffer.peer_addresses`.
+
+Two things are checked, and they are the two claims the design rests on:
+
+1. Every destination slot has exactly one writer, so the buffer needs no
+   zero-initialisation. The buffer is pre-filled with NaN and must contain
+   none afterwards.
+2. Reducing the peer-written buffer locally gives the same answer as the
+   baseline this is meant to replace: run the identical GEMM2 without peer
+   writes and all-reduce the per-rank partial results, which is what
+   `AgRsAll2AllManager.combine()`'s `reduce_scatterv` does.
+
+The weights are deliberately identical on every rank while the global expert
+ranges differ. That makes the "global model" inconsistent, which does not
+matter here: both arms of the comparison use the same per-rank weights, so the
+test isolates the combine mechanism, which is what is under test.
+"""
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from flashinfer.fused_moe.cute_dsl.fused_moe import cute_dsl_fused_moe
+from flashinfer.fused_moe.cute_dsl.moe_utils import (
+    allocate_peer_combine_buffer,
+    build_peer_scatter_destination_map,
+    peer_scatter_local_reduce,
+)
+from flashinfer.utils import is_sm100a_supported
+
+from .utils import create_moe_tensors
+
+WORLD_SIZE = 4
+NUM_TOKENS = 256
+TOP_K = 4
+NUM_EXPERTS = 256
+HIDDEN_SIZE = 256
+INTERMEDIATE_SIZE = 512
+SEED = 42
+
+
+@pytest.fixture(scope="module")
+def distributed_group():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    if world_size != WORLD_SIZE:
+        pytest.skip(f"Run this test with {WORLD_SIZE} distributed ranks")
+
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if not is_sm100a_supported(device):
+        pytest.skip("Peer scatter targets the Blackwell CuTe-DSL MoE GEMM2 kernel")
+    owns_group = not dist.is_initialized()
+    if owns_group:
+        dist.init_process_group("nccl", device_id=device)
+    try:
+        yield dist.group.WORLD
+    finally:
+        if owns_group:
+            dist.destroy_process_group()
+
+
+def _expert_parallel_case(rank: int, device: torch.device):
+    """Build this rank's slice of an expert-parallel MoE step.
+
+    Same seed on every rank, so the token batch and the routing are identical
+    everywhere, exactly as they are after an all-gather. Only
+    `local_expert_offset` differs, which is what makes each route land on one
+    rank.
+    """
+    num_local_experts = NUM_EXPERTS // WORLD_SIZE
+    tensors = create_moe_tensors(
+        num_tokens=NUM_TOKENS,
+        hidden_size=HIDDEN_SIZE,
+        intermediate_size=INTERMEDIATE_SIZE,
+        num_experts=NUM_EXPERTS,
+        num_local_experts=num_local_experts,
+        top_k=TOP_K,
+        device=str(device),
+        seed=SEED,
+    )
+    call = dict(
+        token_selected_experts=tensors["token_selected_experts"],
+        token_final_scales=tensors["token_final_scales"],
+        w1_weight=tensors["w1_weight"],
+        w1_weight_sf=tensors["w1_weight_sf"],
+        w1_alpha=tensors["w1_alpha"],
+        w2_weight=tensors["w2_weight"],
+        w2_weight_sf=tensors["w2_weight_sf"],
+        w2_alpha=tensors["w2_alpha"],
+        num_experts=NUM_EXPERTS,
+        top_k=TOP_K,
+        num_local_experts=num_local_experts,
+        local_expert_offset=rank * num_local_experts,
+        use_fused_finalize=False,
+        quant_mode="w4a4",
+        x=tensors["x"],
+        x_sf=tensors["x_sf"],
+        fc2_input_scale=tensors["fc2_input_scale"],
+        per_token_scale=tensors["x_per_token_scale"],
+    )
+    return tensors, call
+
+
+@pytest.mark.parametrize("release_fence", [False, True])
+def test_peer_scatter_four_ranks_matches_reduce_scatter_baseline(
+    distributed_group, release_fence
+):
+    group = distributed_group
+    rank = dist.get_rank(group)
+    device = torch.device("cuda", torch.cuda.current_device())
+    tokens_per_rank = NUM_TOKENS // WORLD_SIZE
+
+    tensors, call = _expert_parallel_case(rank, device)
+
+    # --- Baseline arm: unmodified GEMM2, then a cross-rank sum -------------
+    # Each rank reduces only its own routes (moe_sort masks the rest with -1),
+    # so summing across ranks reconstructs the full output. That is what
+    # AgRsAll2AllManager.combine()'s reduce_scatterv does today.
+    local_partial = cute_dsl_fused_moe(**call)
+    assert local_partial.shape == (NUM_TOKENS, HIDDEN_SIZE)
+    baseline = local_partial.float().clone()
+    dist.all_reduce(baseline, op=dist.ReduceOp.SUM, group=group)
+    my_baseline = baseline[rank * tokens_per_rank : (rank + 1) * tokens_per_rank]
+
+    # --- Peer arm: GEMM2 writes into the owning rank's combine buffer ------
+    combine = allocate_peer_combine_buffer(
+        (tokens_per_rank * TOP_K, HIDDEN_SIZE), torch.bfloat16, device, group
+    )
+    assert combine.peer_addresses is not None
+    assert combine.peer_addresses.shape == (WORLD_SIZE,)
+    if rank == 0:
+        print(f"[peer table via {combine.source}]", flush=True)
+
+    # Poison every slot. The design claims each (token, k_slot) has exactly one
+    # writer in the whole world, so no slot may survive as NaN and the buffer
+    # needs no zero-init. Anything unwritten shows up here.
+    combine.tensor.fill_(float("nan"))
+
+    token_dst_rank, token_dst_local_idx = build_peer_scatter_destination_map(
+        [tokens_per_rank] * WORLD_SIZE, device
+    )
+    dist.barrier(group)
+
+    returned = cute_dsl_fused_moe(
+        **call,
+        peer_addresses=combine.peer_addresses,
+        token_dst_rank=token_dst_rank,
+        token_dst_local_idx=token_dst_local_idx,
+        combine_buffer=combine.tensor,
+        # With the fence, GEMM2 drains its bulk copies and issues a
+        # system-scope release before exiting, so the writes are guaranteed
+        # visible rather than relying on kernel completion alone.
+        peer_release_fence=release_fence,
+    )
+    assert returned.data_ptr() == combine.tensor.data_ptr()
+
+    # Completion signal: every rank's peer writes must have landed before any
+    # rank reads its own buffer.
+    torch.cuda.synchronize(device)
+    dist.barrier(group)
+
+    unwritten = int(torch.isnan(combine.tensor).any(dim=1).sum().item())
+    assert unwritten == 0, (
+        f"rank {rank}: {unwritten} of {tokens_per_rank * TOP_K} combine slots "
+        "were never written; the one-writer-per-slot invariant does not hold"
+    )
+
+    # Establish that this really was a cross-GPU write and not every rank
+    # filling its own buffer. The writer of slot (t, k) is the rank owning the
+    # expert routed to, which the routing tensor names outright.
+    my_experts = tensors["token_selected_experts"][
+        rank * tokens_per_rank : (rank + 1) * tokens_per_rank
+    ]
+    writers = torch.bincount(
+        (my_experts.long() // (NUM_EXPERTS // WORLD_SIZE)).flatten(),
+        minlength=WORLD_SIZE,
+    )
+    assert int(writers.sum().item()) == tokens_per_rank * TOP_K
+    remote = int(writers.sum().item() - writers[rank].item())
+    assert (writers > 0).all(), (
+        f"rank {rank}: not every peer wrote into this buffer ({writers.tolist()}), "
+        "so this run did not exercise cross-GPU scatter"
+    )
+    print(
+        f"[rank {rank}] writers per rank={writers.tolist()} remote_slots={remote}",
+        flush=True,
+    )
+
+    my_scales = tensors["token_final_scales"][
+        rank * tokens_per_rank : (rank + 1) * tokens_per_rank
+    ]
+    fused = peer_scatter_local_reduce(combine.tensor, my_scales, tokens_per_rank, TOP_K)
+    assert fused.shape == (tokens_per_rank, HIDDEN_SIZE)
+
+    # The two arms differ only in summation order: the baseline sums bf16
+    # partials across ranks through NCCL, the peer arm accumulates the top_k
+    # slots in fp32 inside moe_unpermute and rounds once. So this is close, not
+    # bitwise.
+    diff = (fused.float() - my_baseline).abs()
+    scale = my_baseline.abs().max().clamp_min(1e-6)
+    max_abs = float(diff.max().item())
+    max_rel = float((diff.max() / scale).item())
+    print(
+        f"[rank {rank}] slots={tokens_per_rank * TOP_K} unwritten=0 "
+        f"max_abs={max_abs:.3e} max_rel={max_rel:.3e}",
+        flush=True,
+    )
+    torch.testing.assert_close(fused.float(), my_baseline, rtol=2e-2, atol=2e-2)
+
+    dist.barrier(group)
+
+
+def test_peer_scatter_four_ranks_rejects_short_combine_buffer(distributed_group):
+    """The opt-in bounds check must catch a combine buffer that is too small."""
+    group = distributed_group
+    rank = dist.get_rank(group)
+    device = torch.device("cuda", torch.cuda.current_device())
+    tokens_per_rank = NUM_TOKENS // WORLD_SIZE
+
+    _, call = _expert_parallel_case(rank, device)
+    # One row short of what token_dst_local_idx will ask for.
+    combine = allocate_peer_combine_buffer(
+        (tokens_per_rank * TOP_K - 1, HIDDEN_SIZE), torch.bfloat16, device, group
+    )
+    token_dst_rank, token_dst_local_idx = build_peer_scatter_destination_map(
+        [tokens_per_rank] * WORLD_SIZE, device
+    )
+
+    os.environ["FLASHINFER_VALIDATE_INPUTS"] = "1"
+    try:
+        with pytest.raises(ValueError, match="combine-buffer row"):
+            cute_dsl_fused_moe(
+                **call,
+                peer_addresses=combine.peer_addresses,
+                token_dst_rank=token_dst_rank,
+                token_dst_local_idx=token_dst_local_idx,
+                combine_buffer=combine.tensor,
+            )
+    finally:
+        os.environ.pop("FLASHINFER_VALIDATE_INPUTS", None)
+    dist.barrier(group)


### PR DESCRIPTION
## 📌 Description

**Fuse the cross-GPU MoE combine into the Blackwell GEMM2 finalize epilogue.**


This PR is a proposition, feedback is highly appreciated.

### Context

In an expert-parallel MoE layer, GEMM2 finishes and then a *separate* collective
combines the partial results across ranks. In vLLM's modular kernel that is
`finalize()` calling `get_ep_group().combine(...)`, a `reduce_scatterv`. Because
it is a distinct kernel launch, the combine can never overlap with GEMM2's own
compute - it is strictly serialized after it.

CuteDSL Mega MoE already fuses the whole MoE layer into one kernel, this PR introduce a more fined grained fusion, only to allow more communication/compute overlap by executing the cross-GPU combine at tile granularity while GEMM2 is computing instead of a collective afterwards.

### What changed

Every `(token, k_slot)` route gets its own destination slot in a
`combine_buffer` on the rank that owns the token. GEMM2's epilogue writes there
directly with a plain, non-accumulating peer store, once
the writes land, the owning rank does a cheap local weighted reduction.

This is the cross-GPU generalization of a mode the kernel already had: in
deterministic mode (`use_fused_finalize=False`) it already writes each
`(token, slot)` to a unique row with a plain `blk_copy`, deferring the routing
weights to `moe_unpermute`.

### How

**Only the destination address changes.** The store instruction, the offset
arithmetic and the SMEM staging are untouched.

- `blk_copy_peer` in `blackwell/utils.py` emits the *same*
  `cp.async.bulk.global.shared::cta.bulk_group` PTX as `blk_copy`, but takes an
  already-computed 64-bit address so it can name memory belonging to a peer GPU.
- The epilogue selects a base pointer from a `[world_size]` peer table
  (`SymmetricBuffer.peer_addresses`) and computes the row as
  `dst_local_idx * top_k + k_slot`, replacing the single fixed `out` base.
- The destination rank and row are **packed into the one int32 slot the meta
  warp already stages**, rather than adding a third SMEM array. A third array
  would grow `meta_smem_bytes` in `_compute_stages` and could cost the default
  path a pipeline stage for a feature it never uses. The host validates both
  fields fit.
- Everything is behind `cutlass.const_expr(self.use_peer_scatter)`, so the
  default path traces exactly the code it did before. The dispatcher also omits
  the peer keyword arguments entirely when the feature is off, so `cute.compile`
  sees an unchanged signature.
- `peer_release_fence` (opt-in) adds **one** cumulative
  `cp.async.bulk.wait_group(0)` drain plus `fence.acq_rel.sys` per CTA at kernel
  exit, so the kernel cannot finish until its peer writes have landed. The drain
  is the load-bearing half: bulk-copy completion is tracked by the async-group
  counter, not by the memory model, so a fence alone would order nothing. It is
  cumulative, so once at CTA exit suffices - per tile it would stall the
  epilogue on a round trip and destroy the overlap.

New host helpers in `moe_utils.py`: `build_peer_scatter_destination_map` (the
map is a pure function of the all-gather `sizes` vector, since an all-gather is
rank-contiguous - nothing is derived in the kernel),
`peer_scatter_local_reduce`, and `allocate_peer_combine_buffer`.

### Performance

Every number below comes from driving **vLLM's real
`FusedMoEKernel`** - `prepare()` → experts → `finalize()` - with expert
parallelism, the `allgather_reducescatter` all2all backend and NVFP4 experts.

The vLLM-side integration used to drive it is a separate branch:
**https://github.com/x41lakazam/vllm/commit/de86b6fee8e58ae4ce30df7d152dc3b2ee42a0d6**

The benchmark includes the baseline and two variants of the GEMM2+combine 
which differ by how the local GPU knows when all the other ranks have finished writing into it. 
All three are measured in the same process.

| arm | GEMM2 finalize | combine | ordering |
|---|---|---|---|
| `baseline` | fused atomic scatter-add | `reduce_scatterv` | collective |
| `peer_stream` | deterministic, written into the owner's buffer | none; stream-ordered wait + local reduce | **implicit** |
| `peer_fence` | same, plus a drain and system-scope release fence in GEMM2 | none; stream-ordered wait + local reduce | **explicit** |

**Two peer variants are proposed, and they differ only in ordering guarantee.**
`peer_fence` drains the outstanding bulk copies and issues
`cp.async.bulk.wait_group` and `fence.acq_rel.sys` per CTA, so the kernel cannot exit until its peer writes
have landed. `peer_stream` omits both and relies on kernel completion alone.
Both were numerically correct in every run here, but I couldn't find official doc 
stating that the kernel waits for async communications to be terminated before exiting, therefore I'll let the 
two variants here and wait for feedback 
Note: The practice is widespread - CUTLASS's own
`PipelineTmaStore::producer_tail()` is `cp.async.bulk.wait_group.read 0`, so
every TMA-store epilogue exits with writes outstanding - but widespread is not
the same as specified.


**Hardware:** 4x NVIDIA GB300 (sm103) in one node, exclusive, SM clock steady at
2070 MHz for every run. torch 2.13.0+cu130.

**The layer is captured in a CUDA graph**, which is what production vLLM does.

**22,352 recorded rows across the sweeps** (16 and 22 configurations, 4–5 arms,
4 ranks, 15–16 repetitions each), every row itself the median of 200 timed layer
executions. Wins and losses below held in **15 of 15 repetitions** unless noted.

### Speedup vs tokens per rank (hidden 2048, top_k 4, ep 4)

```
peer_fence relative to the reduce-scatter baseline (peer_stream is ~1.5% faster throughout)

                                                   | parity
   64                                          ####|  0.957x
   96                                           ###|  0.968x
  128                                            ##|  0.981x
  160                                            ##|  0.983x
  192                                              |#  1.012x
  256                                              |#####  1.052x
  320                                              |##########  1.096x
  512                                              |##########  1.101x
 1024                                              |################  1.156x
 4096                                              |##############  1.144x
 8192                                              |#################  1.173x
16384                                              |###################  1.187x
```

The crossover is between **192 and 256 tokens per rank**. Below it the peer
path's fixed cost dominates; above it `reduce_scatterv` becomes a real cost on
the critical path that GEMM2's compute hides. Two independent sweeps measured
the overlapping points within 1.4% of each other.

### Speedup vs top_k (1024 tokens/rank, hidden 2048)

```
peer_fence relative to baseline

                                               | parity
1                                              |###############################  1.309x
2                                              |########################  1.239x
4                                              |################  1.160x
8                                              |#  1.008x
```

Monotonic, and the mechanism is direct: the peer path ships `top_k` unreduced
rows per token where the baseline ships one reduced row. **top_k 8 is the
boundary of usefulness**, and more hidden does not rescue it (1.016x at hidden
4096, 0.999x at 7168).

### Speedup vs hidden size (1024 tokens/rank, top_k 4)

```
peer_fence relative to baseline

                                                  | parity
2048                                              |################  1.156x
4096                                              |###################  1.188x
7168                                              |################  1.160x
```

Roughly neutral - both paths scale with hidden.

### Speedup vs EP rank count

| tokens/rank | ep 2 | ep 4 |
|---|---|---|
| 128 | 0.988 (noise) | 0.981 (noise) |
| 256 | 1.000 (noise) | **1.052** |
| 1024 | **1.104** | **1.156** |
| 4096 | **1.053** | **1.144** |

The win grows with rank count at every batch size, which is the expected
mechanism: `reduce_scatterv` gets more expensive with more ranks while a peer
write stays one hop. **4 ranks is therefore the pessimistic end** of what a
larger EP group would show.

### Speedup vs num_experts and intermediate ratio (1024 tokens/rank)

```
num_experts

                                                 | parity
 16                                              |################  1.155x
 32                                              |################  1.156x
 64                                              |###############  1.147x
128                                              |##############  1.141x

intermediate size (hidden 2048)

                                                  | parity
 512                                              |#################  1.166x
1024                                              |################  1.156x
2048                                              |##############  1.140x
```

Neither is a significant axis. The mild decline with intermediate size is
expected: more GEMM work dilutes a roughly fixed combine saving.

### Absolute times, selected points (ms per MoE layer, slowest rank)

| tokens/rank | hidden | top_k | ep | baseline | `peer_stream` | `peer_fence` |
|---|---|---|---|---|---|---|
| 64 | 2048 | 4 | 4 | 0.076 | 0.078 | 0.080 |
| 128 | 2048 | 4 | 4 | 0.086 | 0.086 | 0.088 |
| 256 | 2048 | 4 | 4 | 0.097 | 0.091 | 0.094 |
| 512 | 2048 | 4 | 4 | 0.114 | 0.102 | 0.103 |
| 1024 | 2048 | 1 | 4 | 0.142 | 0.107 | 0.109 |
| 1024 | 2048 | 4 | 4 | 0.157 | 0.131 | 0.135 |
| 1024 | 4096 | 4 | 4 | 0.237 | 0.197 | 0.200 |
| 1024 | 7168 | 4 | 4 | 0.385 | 0.331 | 0.332 |
| 4096 | 2048 | 4 | 4 | 0.316 | 0.275 | 0.275 |
| 8192 | 2048 | 4 | 4 | 0.520 | 0.440 | 0.443 |
| 16384 | 2048 | 4 | 4 | 0.967 | 0.812 | 0.813 |


### The cost of the fence

Head to head, `peer_stream` is faster - the drain and fence are not free - but
the margin is small and shrinks as the layer grows, because they are a fixed
per-CTA cost:

| config | baseline | `peer_stream` | `peer_fence` |
|---|---|---|---|
| 512 tok | 1.000x | **1.118x** | 1.101x |
| 1024 tok, top_k 1 | 1.000x | **1.336x** | 1.309x |
| 1024 tok, top_k 4 | 1.000x | **1.185x** | 1.160x |
| 1024 tok, hidden 4096 | 1.000x | **1.190x** | 1.188x |
| 1024 tok, hidden 7168 | 1.000x | **1.161x** | 1.160x |
| 4096 tok | 1.000x | **1.156x** | 1.147x |

Paired directly over 241 comparisons: **`peer_fence` costs 1.48% median**
(range 0.2% to 4.2%, smallest on the largest layers). In eager mode it is free
(1.0003x) - the cost only appears once graph capture removes the launch
overhead that was hiding it.


### Correctness

Numerics against the reduce-scatter baseline, on 4 ranks, verified **both eager
and under graph capture** (capture changes allocation and stream behaviour, so
it was re-established rather than inherited):

| | max_abs | mean_abs | NaN |
|---|---|---|---|
| peer_fence | 1.953e-03 | 5.294e-05 | none |
| peer_stream | 1.953e-03 | 5.294e-05 | none |

That is bf16 summation-order noise. The peer path reduces each token's top_k
contributions in a fixed order on the owning rank, while the baseline accumulates
them with float atomics in whatever order the CTAs happen to retire, so the two
cannot agree bitwise.

The 4-rank test also poisons the combine buffer with NaN beforehand and asserts
none survive, which is a direct check of the one-writer-per-slot invariant, and
it verifies from the routing tensor that writes really arrived from every peer
(on rank 0, 184 of 256 slots were written remotely) rather than assuming it.

## 🔍 Related Issues

<!-- none yet -->

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit`.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing.

Added:

- `tests/moe/test_cute_dsl_moe_peer_scatter.py` - 26 tests. Metadata packing is
  lossless and stays inside positive int32; the destination map; the local
  reduce; and end-to-end peer scatter on a single GPU, simulating 2 and 4 peers
  with separate local allocations, which exercises rank selection and the packed
  metadata. Bitwise identical (`rtol=0, atol=0`) to the unmodified deterministic
  path.
- `tests/moe/test_cute_dsl_moe_peer_scatter_multigpu.py` - real 4-GPU expert-
  parallel test over NVLink symmetric memory, parametrized over
  `peer_release_fence`.

Regression, run on the final commit including the fence: the existing CuTe-DSL
MoE suite (`test_cute_dsl_fused_moe.py`, `test_cute_dsl_moe_can_implement.py`,
`test_cute_dsl_bf16_grouped_gemm_finalize.py`) plus the new peer tests is
**600 passed / 28 skipped / 0 failed**.

The default path is untouched by construction: both `use_peer_scatter` and
`peer_release_fence` default to `False`, every peer site in the kernel is behind
`cutlass.const_expr`, and the dispatcher only enables the feature when
`peer_addresses is not None`.

## Reviewer Notes

- **The default path should be untouched.** The peer code is all
  `cutlass.const_expr`-gated, the packing avoids new SMEM so stage counts cannot
  shift, and the dispatcher omits the peer keywords entirely when the feature is
  off. `test_default_path_passes_no_peer_kwargs` guards that last point.
- **Where to look first:** the epilogue destination in
  `blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py`, the
  packing constants above the class, and the drain/fence at CTA exit. The fence
  site carries a comment on why all epilogue threads fence rather than the
  `bar.sync`-then-one-thread idiom used by the TRT-LLM dispatch kernel.
- **`token_final_scales` is deliberately still required** even though peer mode
  ignores its value: it is structurally load-bearing for `final_scale_dtype` and
  `topK`, and `final_scale_dtype` feeds the SMEM budget.
- **Rubin (SM107) raises `NotImplementedError`** - its wrapper has no peer
  parameters. SM90 is out of scope.
